### PR TITLE
feat(sessions): QR 기반 기기 페어링 및 연구 참여 동의 프로세스 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ npm run lint:fix
 | **POST** | `/auth/signup` | 회원가입 |
 | **POST** | `/auth/login` | 로그인 |
 | **GET** | `/user/me` | 내 정보 조회 |
+| **POST** | `/sessions` | 페어링 세션 생성 (Phase 1) |
+| **POST** | `/sessions/:pairingToken/pair` | 모바일 기기 페어링 연결 (Phase 1.5-A) |
+| **POST** | `/sessions/:sessionId/consents` | 동의서 제출 및 스냅샷 생성 (Phase 1.5-B) |
 ---
 
 ## 5. 📁 프로젝트 구조
@@ -73,6 +76,7 @@ mind-signal-backend/
 │   ├── 05-features/        # 특정 기능 구현 (예: 인증, 사용자 관리)
 │   │   ├── analyze-eeg/    # EEG 분석 기능
 │   │   ├── auth/           # 인증 유스케이스(로그인/가입/토큰 발급·갱신/로그아웃 등) + 라우트 단위 로직
+│   │   ├── sessions/       # PC-모바일 간 기기 페어링 연동 및 측정 전 동의 제출 프로세스 관리
 │   │   └── users/          # 사용자 관리 기능
 │   │
 │   ├── 06-entities/        # 도메인 엔티티 (데이터 모델, 스키마, CRUD 로직)
@@ -81,7 +85,7 @@ mind-signal-backend/
 │   │   ├── eeg-records/         # 측정된 뇌파 원천 데이터 및 로그 정보
 │   │   ├── matching-pools/      # 분석 점수 기반의 사용자 간 매칭 데이터
 │   │   ├── neuro-chats/         # AI 상담원 '뉴로'와의 상호작용 대화 로그
-│   │   ├── sessions/            # 기기 페어링 및 데이터 측정 세션 상태 관리
+│   │   ├── sessions/            # 기기 페어링 토큰 발급 및 세션 생명주기(Status Machine) 관리
 │   │   ├── surveys/             # 사용자 성향 분석용 설문 문항 및 응답 데이터
 │   │   └── users/               # 사용자 계정 정보 및 뇌파 유형/멤버십 프로필
 │   │
@@ -113,8 +117,8 @@ mind-signal-backend/
 
 이 프로젝트의 FSD (Feature-Sliced Design) 폴더 구조는 다음과 같은 원칙에 따라 README.md에 표현됩니다:
 
-- **`01-app/` 및 `07-shared/`**: 애플리케이션의 엔트리/전역 규약(예: app wiring, 전역 미들웨어, 공통 에러/설정 등)을 담는 계층입니다. 온보딩에 중요한 진입점이 있는 경우, README에 내부 구조를 상대적으로 상세히 표기합니다.
-- **`02-processes/` ~ `06-entities/`**: 비즈니스 도메인/기능 단위로 확장되는 계층입니다. README에는 최상위 폴더(도메인)만 노출하고, 내부 구현은 원칙적으로 각 도메인의 `index.ts` (Public API)를 통해 접근하도록 합니다. 이를 통해 계층 간 결합도를 낮추고 내부 변경의 영향을 최소화합니다.
+- **`01-app/` 및 `07-shared/`**: 애플리케이션의 엔트리/전역 규약(예: app wiring, 전역 미들웨어, 공통 에러/설정 등)을 담는 계층입니다. **이 계층 내에서는 `01-app/`의 모든 내부 파일과 `07-shared/config/config.ts` 파일의 존재를 상세히 표기합니다.** 온보딩에 중요한 진입점이 있는 경우, README에 내부 구조를 상대적으로 상세히 표기합니다.
+- **`02-processes/` ~ `06-entities/`**: 비즈니스 도메인/기능 단위로 확장되는 계층입니다. README에는 최상위 폴더(도메인)만 노출하고, **그 하위 계층(예: `05-features/auth/` 또는 `06-entities/users/`)은 1단계 하위 폴더까지만 표시합니다.** 내부 파일 및 더 깊은 하위 폴더 구조는 원칙적으로 각 도메인의 `index.ts` (Public API)를 통해 접근하도록 합니다. 이를 통해 계층 간 결합도를 낮추고 내부 변경의 영향을 최소화합니다.
 - **세분화 기준**: 한 폴더에 파일이 증가해 가독성이 떨어지면(예: 6~8개 이상) `api/`, `model/`, `lib/` 등 하위 폴더로 점진적으로 분리하는 것을 원칙으로 합니다.
 
 ---

--- a/src/01-app/app.router.ts
+++ b/src/01-app/app.router.ts
@@ -1,9 +1,12 @@
 import { Router } from 'express';
 import { userApi } from '@05-features/users';
 import { authApi } from '@05-features/auth';
+import { sessionApi } from '@05-features/sessions';
+
 const router = Router();
 
 router.use('/user', userApi);
 router.use('/auth', authApi);
+router.use('/sessions', sessionApi);
 
 export default router;

--- a/src/05-features/sessions/api/session.controller.ts
+++ b/src/05-features/sessions/api/session.controller.ts
@@ -1,19 +1,98 @@
 import { Request, Response, NextFunction } from 'express';
-import { pairDeviceProcess } from '@02-processes/sessions/pairing.process';
+import { pairDeviceProcess } from '@05-features/sessions/services/pairing.service';
+import { submitConsentProcess } from '@05-features/sessions/services/submit-consent.service';
+import { AppError } from '@07-shared/errors';
+import { pairDeviceSchema } from '@05-features/sessions/dto/session.dto'; //DTO 임포트
+import { submitConsentSchema } from '@05-features/sessions/dto/session.dto';
+import { Session } from '@06-entities/sessions';
+import crypto from 'crypto';
 
-
-export const pairDevice = async (req: Request, res: Response, next: NextFunction) => {
+export const createSession = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
   try {
-    const { pairingToken } = req.params;
-    const userId = req.user.id; // 인증 미들웨어(Shared)에서 받은 유저 ID
+    // 6자리 혹은 특정 길이의 무작위 토큰 생성
+    const pairingToken = crypto.randomBytes(3).toString('hex').toUpperCase();
 
+    const newSession = new Session({
+      pairingToken,
+      status: 'CREATED',
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5분 유효
+    });
+
+    await newSession.save();
+
+    res.status(201).json({
+      success: true,
+      data: {
+        pairingToken: newSession.pairingToken,
+        sessionId: newSession._id,
+        expiresAt: newSession.expiresAt,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const pairDevice = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    console.log('Current User Check:', req.user);
+    //DTO를 사용한 입력값 검증 (Zod 활용)
+    // req.params가 스키마에 정의된 형식을 따르는지 확인한다.
+    const validatedRequest = pairDeviceSchema.parse({ params: req.params });
+    const { pairingToken } = validatedRequest.params;
+
+    // 3. 유저 존재 여부 체크 (Type Guard)
+    if (!req.user || !req.user.id) {
+      throw new AppError('인증이 필요한 서비스입니다.', 401);
+    }
+
+    const userId = req.user.id;
+
+    // 4. 비즈니스 프로세스 호출
     const session = await pairDeviceProcess(pairingToken, userId);
 
     res.status(200).json({
       success: true,
-      data: session
+      data: session,
     });
   } catch (error) {
-    next(error); // 전역 에러 핸들러로 전달
+    // Zod 검증 에러 등은 전역 에러 핸들러에서 400 에러로 처리하도록 넘긴다.
+    next(error);
+  }
+};
+
+export const submitConsent = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const validated = submitConsentSchema.parse({
+      body: req.body,
+      params: req.params,
+    });
+    const { sessionId } = validated.params;
+    const { versionId, isResearchAgreed } = validated.body;
+
+    if (!req.user) throw new AppError('인증이 필요합니다.', 401);
+
+    const consent = await submitConsentProcess({
+      sessionId,
+      userId: req.user.id,
+      versionId,
+      isResearchAgreed,
+    });
+
+    res.status(201).json({ success: true, data: consent });
+  } catch (error) {
+    next(error);
   }
 };

--- a/src/05-features/sessions/api/session.routes.ts
+++ b/src/05-features/sessions/api/session.routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import * as sessionsController from './session.controller';
+import { authenticate } from '@07-shared/middlewares/authenticate.middleware'; // 인증 미들웨어
+
+const router = Router();
+
+/**
+ * Phase 1.5: 모바일 QR 스캔 & 페어링
+ * POST /sessions/:pairingToken/pair
+ * * 1. authenticate: 요청자가 로그인한 사용자인지 확인하고 req.user를 바인딩함
+ * 2. pairDevice: DTO 검증 후 비즈니스 프로세스(pairingProcess) 실행
+ */
+// 반드시 컨트롤러 앞에서 인증을 통해서 req.user를 확보해야 함
+router.post('/', authenticate, sessionsController.createSession);
+router.post('/:pairingToken/pair', authenticate, sessionsController.pairDevice);
+router.post('/:sessionId/consents', authenticate, sessionsController.submitConsent);
+
+export default router;

--- a/src/05-features/sessions/dto/session.dto.ts
+++ b/src/05-features/sessions/dto/session.dto.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+// 페어링 요청 검증 DTO
+export const pairDeviceSchema = z.object({
+  params: z.object({
+    pairingToken: z.string().min(1, '페어링 토큰은 필수입니다.'),
+  }),
+});
+
+export type PairDeviceDto = z.infer<typeof pairDeviceSchema>;
+
+// 동의서 제출 검증 DTO
+export const submitConsentSchema = z.object({
+  body: z.object({
+    versionId: z.string().min(1, '약관 버전 ID는 필수입니다.'),
+    isResearchAgreed: z.boolean(),
+  }),
+  params: z.object({
+    sessionId: z.string().min(1, '세션 ID는 필수입니다.'),
+  }),
+});
+
+export type SubmitConsentDto = z.infer<typeof submitConsentSchema>;

--- a/src/05-features/sessions/index.ts
+++ b/src/05-features/sessions/index.ts
@@ -1,0 +1,5 @@
+export { default as sessionApi } from './api/session.routes';
+export { pairDeviceSchema, submitConsentSchema } from './dto/session.dto';
+export * from './services/submit-consent.service';
+export * from './services/pairing.service';
+export * from './dto/session.dto';

--- a/src/05-features/sessions/services/pairing.service.ts
+++ b/src/05-features/sessions/services/pairing.service.ts
@@ -1,5 +1,6 @@
 import { Session } from '@06-entities/sessions';
 import { Types } from 'mongoose';
+import { AppError } from '@07-shared/errors';
 
 /**
  * Phase 1.5: 모바일 기기 페어링 프로세스
@@ -26,11 +27,11 @@ export const pairDeviceProcess = async (
   if (session.isExpired()) {
     session.status = 'EXPIRED';
     await session.save();
-    throw new Error('TOKEN_EXPIRED');
+    throw new AppError('페어링 토큰이 만료되었습니다. 다시 시도해주세요.', 401);
   }
 
   if (!session.canTransitionTo('PAIRED')) {
-    throw new Error(`CANNOT_PAIR_FROM_STATUS_${session.status}`);
+    throw new AppError(`현재 세션 상태(${session.status})에서는 페어링할 수 없습니다.`, 400);
   }
 
   // 3. 페어링 정보 업데이트 (Note A-3)

--- a/src/05-features/sessions/services/submit-consent.service.ts
+++ b/src/05-features/sessions/services/submit-consent.service.ts
@@ -1,0 +1,39 @@
+import { Session } from '@06-entities/sessions';
+import { Consent } from '@06-entities/consents';
+import { AppError } from '@07-shared/errors';
+
+/**
+ * Phase 1.5: 동의서 제출 및 스냅샷 생성
+ * 1. 세션 상태 확인 (PAIRED 상태여야 함)
+ * 2. Consent 레코드 생성 (Note B 규칙: 이후 모든 데이터는 이 consentId를 참조)
+ */
+export const submitConsentProcess = async (params: {
+  sessionId: string;
+  userId: string;
+  versionId: string;
+  isResearchAgreed: boolean;
+}) => {
+  const { sessionId, userId, versionId, isResearchAgreed } = params;
+
+  // 1. 세션 존재 및 상태 확인
+  const session = await Session.findById(sessionId);
+  if (!session) throw new AppError('세션을 찾을 수 없습니다.', 404);
+  if (session.status !== 'PAIRED') {
+    throw new AppError(
+      '페어링되지 않은 세션에서는 동의를 진행할 수 없습니다.',
+      400
+    );
+  }
+
+  // 2. Consent 레코드 생성 (스냅샷)
+  const newConsent = new Consent({
+    userId,
+    versionId,
+    isResearchAgreed,
+  });
+
+  await newConsent.save();
+
+  // (선택) 동의 완료 후 세션 상태를 다음 단계(예: READY 또는 MEASURING 준비)로 관리할 수 있음
+  return newConsent;
+};

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -103,7 +103,7 @@ sessionSchema.methods.canTransitionTo = function (
     PAIRED: ['MEASURING', 'CANCELLED'],
     MEASURING: ['COMPLETED', 'CANCELLED'],
     COMPLETED: [], // 최종 상태
-    EXPIRED: [],   // 최종 상태
+    EXPIRED: [], // 최종 상태
     CANCELLED: [], // 최종 상태
   };
 

--- a/src/07-shared/middlewares/authenticate.middleware.ts
+++ b/src/07-shared/middlewares/authenticate.middleware.ts
@@ -21,7 +21,7 @@ export const authenticate = (
       config.jwtSecret.secret as string
     ) as JwtPayload;
 
-    req.userId = payload.id;
+    (req as any).user = { id: payload.id };
     next();
   } catch {
     next(new AppError('유효하지 않은 토큰입니다.', 401));

--- a/src/07-shared/types/express.d.ts
+++ b/src/07-shared/types/express.d.ts
@@ -1,0 +1,8 @@
+declare namespace Express {
+  export interface Request {
+    user?: {
+      id: string; // 또는 실제 user 객체의 타입에 맞게 정의
+      // 필요한 다른 user 속성들을 여기에 추가
+    };
+  }
+}


### PR DESCRIPTION
개요 (Overview)
PC 웹과 모바일 기기를 연결하는 Phase 1(발급) 및 Phase 1.5(연결 및 동의) 핵심 워크플로우를 구현하고 검증을 완료했습니다. FSD 아키텍처 원칙에 따라 비즈니스 로직을 서비스 레이어로 분리하여 유지보수성을 높였습니다.

주요 변경 사항 (Key Changes)
1. Phase 1: 세션 및 페어링 토큰 발급
POST /sessions: QR 코드 렌더링을 위한 6자리 무작위 pairingToken 생성 및 세션 초기화 기능을 추가했습니다.

2. Phase 1.5-A: 모바일 기기 페어링
POST /sessions/:pairingToken/pair: 토큰 유효성 및 만료 시간을 검증하고, 현재 로그인한 사용자와 세션을 원자적으로 연결합니다.

세션 상태를 CREATED에서 PAIRED로 전이시키며 사용자 ID를 바인딩합니다.

3. Phase 1.5-B: 연구 참여 동의서 제출
POST /sessions/:sessionId/consents: 페어링된 세션을 확인하고 개인정보 활용 및 연구 참여 동의 스냅샷(Consent 엔티티)을 생성합니다.

🛠️ 기술적 개선 사항 (Technical Points)
FSD 아키텍처 준수: 컨트롤러에서 직접 비즈니스 로직을 처리하지 않고, 05-features/sessions/services로 로직을 이관하여 계층 간 의존성을 정립했습니다.

강력한 데이터 검증: Zod DTO(session.dto.ts)를 사용하여 요청 데이터(params, body)의 런타임 타입을 엄격하게 검증합니다.

에러 핸들링: 토큰 만료 및 상태 전이 불가능 시 AppError를 통해 명확한 에러 메시지와 상태 코드(401, 400)를 반환하도록 개선했습니다.

테스트 결과 (Testing Results)
Postman 검증 완료: 세션 생성 -> 페어링 -> 동의서 제출로 이어지는 전 과정을 성공적으로 테스트했습니다.

빌드 체크: npm run build를 통해 타입스크립트 컴파일 및 별칭(tsc-alias) 설정에 문제가 없음을 확인했습니다.