### PR TITLE
feat(sessions): creatorId + GET /api/analysis/my

### DIFF
--- a/src/05-features/analysis-results/api/analysis.controller.ts
+++ b/src/05-features/analysis-results/api/analysis.controller.ts
@@ -1,4 +1,5 @@
 import { Response, NextFunction } from 'express';
+import { Types } from 'mongoose';
 import { AnalysisResult } from '@06-entities/analysis-results';
 import { Session } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
@@ -23,7 +24,9 @@ export const getAnalysisResult = async (
       throw new AppError('해당 그룹을 찾을 수 없습니다.', 404);
     }
     const isParticipant = sessions.some(
-      (s) => s.userId && s.userId._id?.toString() === req.user!.id
+      (s) =>
+        (s.userId && s.userId._id?.toString() === req.user!.id) ||
+        s.creatorId?.toString() === req.user!.id
     );
     if (!isParticipant) {
       throw new AppError('해당 그룹에 대한 접근 권한이 없습니다.', 403);
@@ -54,6 +57,63 @@ export const getAnalysisResult = async (
         user2Name: user2?.name || null,
       },
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** 내 분석 결과 목록 조회 수행함 */
+export const getMyAnalysisResults = async (
+  req: AuthedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    if (!req.user?.id) {
+      throw new AppError('인증이 필요합니다.', 401);
+    }
+
+    const userId = new Types.ObjectId(req.user.id);
+
+    // creatorId 또는 userId 기준으로 완료된 세션 조회함
+    const sessions = await Session.find({
+      $or: [{ userId }, { creatorId: userId }],
+      status: 'COMPLETED',
+    }).select('groupId');
+
+    // 중복 groupId 제거함
+    const groupIds = [...new Set(sessions.map((s) => s.groupId))];
+
+    if (groupIds.length === 0) {
+      return res.status(200).json({ status: 'success', data: [] });
+    }
+
+    /** lean() 조회용 분석 결과 타입 정의함 */
+    interface LeanAnalysisResult {
+      groupId: string;
+      matchingScore: number;
+      user1Id: { name: string } | null;
+      user2Id: { name: string } | null;
+      createdAt: Date;
+    }
+
+    // .lean()으로 조회하여 toJSON의 createdAt 삭제 회피함
+    const results = await AnalysisResult.find({
+      groupId: { $in: groupIds },
+    })
+      .populate('user1Id user2Id', 'name')
+      .sort({ createdAt: -1 })
+      .lean<LeanAnalysisResult[]>();
+
+    const data = results.map((r) => ({
+      groupId: r.groupId,
+      matchingScore: r.matchingScore,
+      user1Name: r.user1Id?.name || null,
+      user2Name: r.user2Id?.name || null,
+      createdAt: r.createdAt,
+    }));
+
+    res.status(200).json({ status: 'success', data });
   } catch (error) {
     next(error);
   }

--- a/src/05-features/analysis-results/api/analysis.routes.ts
+++ b/src/05-features/analysis-results/api/analysis.routes.ts
@@ -1,8 +1,25 @@
 import { Router } from 'express';
-import { getAnalysisResult } from './analysis.controller';
+import { getAnalysisResult, getMyAnalysisResults } from './analysis.controller';
 import { authenticate } from '@07-shared/middlewares';
 
 const router = Router();
+
+/**
+ * @openapi
+ * /api/analysis/my:
+ *   get:
+ *     summary: 내 분석 결과 목록 조회
+ *     description: 로그인 사용자가 참여(Subject 또는 Operator)한 완료 세션의 분석 결과 목록을 반환함
+ *     tags: [Analysis]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: 결과 목록 반환 성공
+ *       401:
+ *         description: 인증 실패
+ */
+router.get('/my', authenticate, getMyAnalysisResults);
 
 /**
  * @openapi

--- a/src/05-features/sessions/api/session.controller.ts
+++ b/src/05-features/sessions/api/session.controller.ts
@@ -16,7 +16,7 @@ import { AuthedRequest } from '@07-shared/types';
  * [Controller] 새로운 그룹 세션 또는 그룹 내 추가 세션 생성 수행함
  */
 export const createSession = async (
-  req: Request,
+  req: AuthedRequest,
   res: Response,
   next: NextFunction
 ) => {
@@ -24,7 +24,7 @@ export const createSession = async (
     const { groupId } = req.body; // 기존 그룹에 추가할 경우 groupId를 본문에서 받음
 
     // 비즈니스 프로세스 호출하여 세션 생성 수행함
-    const newSession = await createGroupSessionProcess(groupId);
+    const newSession = await createGroupSessionProcess(groupId, req.user?.id);
 
     res.status(201).json({
       status: 'success',
@@ -71,7 +71,9 @@ export const checkGroupStatus = async (
     const hasBindings = sessions.some((s) => s.userId);
     if (hasBindings) {
       const isParticipant = sessions.some(
-        (s) => s.userId && s.userId._id?.toString() === req.user!.id
+        (s) =>
+          (s.userId && s.userId._id?.toString() === req.user!.id) ||
+          s.creatorId?.toString() === req.user!.id
       );
       if (!isParticipant) {
         throw new AppError('해당 그룹에 대한 접근 권한이 없습니다.', 403);

--- a/src/05-features/sessions/services/pairing.service.ts
+++ b/src/05-features/sessions/services/pairing.service.ts
@@ -9,7 +9,10 @@ import crypto from 'crypto';
  * $inc 원자적 연산으로 동시 요청 시에도 고유한 subjectIndex 보장함
  * @param groupId 기존 그룹에 추가할 경우 제공하며, 없을 경우 신규 생성함
  */
-export const createGroupSessionProcess = async (groupId?: string) => {
+export const createGroupSessionProcess = async (
+  groupId?: string,
+  creatorId?: string
+) => {
   // 1. 그룹 식별자 결정함 (제공되지 않으면 신규 생성 수행함)
   const effectiveGroupId =
     groupId || crypto.randomBytes(4).toString('hex').toUpperCase();
@@ -39,6 +42,7 @@ export const createGroupSessionProcess = async (groupId?: string) => {
     pairingToken,
     status: 'CREATED',
     expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5분 유효함
+    ...(creatorId ? { creatorId: new Types.ObjectId(creatorId) } : {}),
   });
 
   return await newSession.save();

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -8,6 +8,7 @@ export interface Session {
   subjectIndex: number | null; // 추가: 해당 그룹 내 피실험자 할당 번호(1 또는 2)임
   pairingToken: string; // 고유 페어링 토큰임
   userId: Types.ObjectId | null; // 페어링 성공 시 바인딩되는 사용자 ID임
+  creatorId: Types.ObjectId | null; // 세션 생성자(운영자) ID임
   status:
     | 'CREATED'
     | 'PAIRED'
@@ -50,6 +51,11 @@ const sessionSchema = new Schema<Session, SessionModel, SessionMethods>(
       index: true,
     },
     userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      default: null,
+    },
+    creatorId: {
       type: Schema.Types.ObjectId,
       ref: 'User',
       default: null,
@@ -131,6 +137,10 @@ sessionSchema.index(
   { groupId: 1, subjectIndex: 1 },
   { unique: true, sparse: true, name: 'groupId_subjectIndex_unique' }
 );
+
+/** 조회 성능 개선을 위한 복합 인덱스 선언함 */
+sessionSchema.index({ userId: 1, status: 1 });
+sessionSchema.index({ creatorId: 1, status: 1 });
 
 /** 7. 모델 생성 및 수출 */
 export const Session = model<Session, SessionModel>('Session', sessionSchema);


### PR DESCRIPTION
## Summary
- Session 스키마에 creatorId 추가 (Operator 소유권 검사)
- GET /api/analysis/my — 내 실험 결과 목록 API

## Test plan
- [ ] creatorId가 세션 생성 시 정상 저장 확인
- [ ] GET /api/analysis/my 호출 → 본인 결과만 반환 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve their personal analysis results, including matching scores and timestamps.
  * Session creators have been granted access to view analysis results from sessions they created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->