### PR TITLE
dev → main: Phase 13 BE stopReason + stopAll + 3-tier

### DIFF
--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -2,6 +2,71 @@ import { Request, Response, NextFunction } from 'express';
 import { engineRegistryService } from '../services/engine-registry.service';
 import { engineProxyService } from '../services/engine-proxy.service';
 import { stopMeasurementService } from '@02-processes/measurements/services/measurement.service';
+import { AppError } from '@07-shared/errors';
+import { SocketService } from '@07-shared/lib/socket';
+
+/** 최소 분석 가능 시간 (초) — 교수 확인 후 확정 예정 (임시 180초) */
+const MIN_ANALYSIS_SECONDS = 180;
+
+/**
+ * 3-tier 분류 후 적절한 분석 파이프라인 트리거함
+ * - VALID: measuredDurationSeconds >= MIN_ANALYSIS_SECONDS
+ * - PARTIAL: 한쪽만 VALID
+ * - ABORTED: 둘 다 INVALID
+ */
+async function triggerPostMeasurementByTier(groupId: string) {
+  const { Session: SessionModel } = await import('@06-entities/sessions');
+  const completedSessions = await SessionModel.find({
+    groupId,
+    status: 'COMPLETED',
+  });
+
+  const validSessions = completedSessions.filter(
+    (s) =>
+      s.measuredDurationSeconds !== null &&
+      s.measuredDurationSeconds >= MIN_ANALYSIS_SECONDS
+  );
+
+  const tier =
+    validSessions.length >= 2
+      ? 'VALID'
+      : validSessions.length === 1
+        ? 'PARTIAL'
+        : 'ABORTED';
+
+  console.log(
+    `[postMeasurement] groupId=${groupId} tier=${tier} (valid=${validSessions.length}/${completedSessions.length})`
+  );
+
+  if (tier === 'ABORTED') {
+    // 양쪽 모두 데이터 부족 — 분석 불가, Socket.io로 ABORTED 알림함
+    SocketService.emitLiveEvent('analysis-status', {
+      groupId,
+      tier: 'ABORTED',
+      message: '양쪽 모두 측정 데이터가 부족합니다. 재측정이 필요합니다.',
+    });
+    return;
+  }
+
+  const mod = await import('@02-processes/post-measurement');
+
+  if (tier === 'VALID') {
+    // DUAL 분석 실행함
+    mod
+      .runPostMeasurementPipeline(groupId)
+      .catch((err) => console.error('포스트-측정 파이프라인 에러:', err));
+  } else {
+    // PARTIAL — BTI 폴백 분석 실행함
+    SocketService.emitLiveEvent('analysis-status', {
+      groupId,
+      tier: 'PARTIAL',
+      message: '한 명의 데이터로 BTI 개인 분석을 진행합니다.',
+    });
+    mod
+      .runBTIAnalysisPipeline(groupId)
+      .catch((err) => console.error('BTI 폴백 파이프라인 에러:', err));
+  }
+}
 
 export const engineController = {
   /** 파이썬 엔진 URL 등록 처리함 */
@@ -55,7 +120,7 @@ export const engineController = {
   /** EEG 스트리밍 종료 요청을 파이썬 엔진으로 프록시 + 세션 COMPLETED 전이함 */
   streamStop: async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { groupId, subjectIndex } = req.body;
+      const { groupId, subjectIndex, stopReason } = req.body;
 
       // 1. 엔진에 스트리밍 종료 요청함
       const engineResult = await engineProxyService.streamStop(
@@ -63,31 +128,78 @@ export const engineController = {
         subjectIndex
       );
 
-      // 2. 세션 COMPLETED 전이 + Redis 구독 해제함
+      // 2. 세션 COMPLETED 전이 + Redis 구독 해제 + stopReason 기록함
       const { allCompleted } = await stopMeasurementService(
         groupId,
-        subjectIndex
+        subjectIndex,
+        stopReason ?? 'Natural'
       );
 
-      // 3. 모든 subject 완료 시 포스트-측정 오케스트레이션 트리거함
+      // 3. 모든 subject 완료 시 3-tier 분류 후 파이프라인 트리거함
       if (allCompleted) {
-        // COMPLETED 세션 수로 DUAL/BTI 판별함 (CANCELLED/EXPIRED 제외)
-        const { Session: SessionModel } = await import('@06-entities/sessions');
-        const completedCount = await SessionModel.countDocuments({
-          groupId,
-          status: 'COMPLETED',
-        });
-
-        import('@02-processes/post-measurement')
-          .then((mod) =>
-            completedCount >= 2
-              ? mod.runPostMeasurementPipeline(groupId)
-              : mod.runBTIAnalysisPipeline(groupId)
-          )
-          .catch((err) => console.error('포스트-측정 파이프라인 에러:', err));
+        triggerPostMeasurementByTier(groupId).catch((err) =>
+          console.error('3-tier 파이프라인 트리거 에러:', err)
+        );
       }
 
       res.status(200).json({ ...engineResult, allCompleted });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  /** 그룹 내 모든 MEASURING 세션 일괄 종료 수행함 */
+  stopAll: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { groupId, stopReason } = req.body;
+
+      // MEASURING 상태의 세션만 조회함
+      const { Session: SessionModel } = await import('@06-entities/sessions');
+      const measuringSessions = await SessionModel.find({
+        groupId,
+        status: 'MEASURING',
+      });
+
+      if (measuringSessions.length === 0) {
+        throw new AppError('현재 측정 중인 세션이 없습니다.', 404);
+      }
+
+      // 각 subject를 순차적으로 종료함
+      for (const session of measuringSessions) {
+        if (session.subjectIndex === null) continue;
+
+        try {
+          await engineProxyService.streamStop(groupId, session.subjectIndex);
+        } catch (err) {
+          console.error(
+            `[stopAll] 엔진 종료 실패 subject=${session.subjectIndex}:`,
+            err
+          );
+        }
+
+        await stopMeasurementService(
+          groupId,
+          session.subjectIndex,
+          stopReason ?? 'ManualEarly'
+        );
+      }
+
+      // 루프 후 순서 무관하게 전체 완료 여부 독립 확인함
+      const allSessions = await SessionModel.find({ groupId });
+      const allCompleted = allSessions.every((s) => s.status === 'COMPLETED');
+
+      // 모든 subject 완료 시 3-tier 분류 후 파이프라인 트리거함
+      if (allCompleted) {
+        triggerPostMeasurementByTier(groupId).catch((err) =>
+          console.error('3-tier 파이프라인 트리거 에러:', err)
+        );
+      }
+
+      res.status(200).json({
+        status: 'success',
+        stoppedCount: measuringSessions.length,
+        allCompleted,
+      });
     } catch (error) {
       next(error);
     }

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -313,6 +313,10 @@ router.post(
 const streamStopSchema = z.object({
   groupId: z.string().min(1),
   subjectIndex: z.number().int().nonnegative(),
+  stopReason: z
+    .enum(['Natural', 'ManualEarly', 'HeadsetLost', 'ProcessError'])
+    .optional()
+    .default('Natural'),
 });
 
 /**
@@ -341,6 +345,12 @@ const streamStopSchema = z.object({
  *                 type: integer
  *                 minimum: 0
  *                 example: 1
+ *               stopReason:
+ *                 type: string
+ *                 enum: [Natural, ManualEarly, HeadsetLost, ProcessError]
+ *                 default: Natural
+ *                 description: 종료 사유
+ *                 example: "Natural"
  *     responses:
  *       200:
  *         description: 스트리밍 종료 성공
@@ -361,6 +371,66 @@ router.post(
   authenticate,
   validate(streamStopSchema),
   engineController.streamStop
+);
+
+const stopAllSchema = z.object({
+  groupId: z.string().min(1),
+  stopReason: z
+    .enum(['Natural', 'ManualEarly', 'HeadsetLost', 'ProcessError'])
+    .optional()
+    .default('ManualEarly'),
+});
+
+/**
+ * @openapi
+ * /api/engine/stream/stop-all:
+ *   post:
+ *     summary: 그룹 내 모든 EEG 스트리밍 일괄 종료
+ *     description: |
+ *       groupId에 속한 MEASURING 상태의 모든 subject를 순차적으로 종료함.
+ *       조기 종료 버튼 클릭 시 프론트엔드에서 호출함.
+ *     tags: [Engine]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [groupId]
+ *             properties:
+ *               groupId:
+ *                 type: string
+ *                 minLength: 1
+ *                 example: "grp_abc123"
+ *               stopReason:
+ *                 type: string
+ *                 enum: [Natural, ManualEarly, HeadsetLost, ProcessError]
+ *                 default: ManualEarly
+ *                 description: 종료 사유
+ *                 example: "ManualEarly"
+ *     responses:
+ *       200:
+ *         description: 일괄 종료 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "success" }
+ *                 stoppedCount: { type: integer, example: 2 }
+ *                 allCompleted: { type: boolean, example: true }
+ *       404:
+ *         description: MEASURING 상태의 세션 없음
+ *       503:
+ *         description: 파이썬 엔진 미등록
+ */
+router.post(
+  '/stream/stop-all',
+  authenticate,
+  validate(stopAllSchema),
+  engineController.stopAll
 );
 
 export default router;

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -95,7 +95,12 @@ export const startMeasurementService = async (sessionId: string) => {
  */
 export const stopMeasurementService = async (
   groupId: string,
-  subjectIndex: number
+  subjectIndex: number,
+  stopReason:
+    | 'Natural'
+    | 'ManualEarly'
+    | 'HeadsetLost'
+    | 'ProcessError' = 'Natural'
 ) => {
   const session = await Session.findOne({ groupId, subjectIndex });
   if (!session) {
@@ -109,8 +114,14 @@ export const stopMeasurementService = async (
     );
   }
 
-  // 세션 상태 COMPLETED 전이함
+  // 세션 상태 COMPLETED 전이 + stopReason + measuredDuration 기록함
   session.status = 'COMPLETED';
+  session.stopReason = stopReason;
+  if (session.measuredAt) {
+    session.measuredDurationSeconds = Math.round(
+      (Date.now() - session.measuredAt.getTime()) / 1000
+    );
+  }
   await session.save();
 
   // Redis 구독자 정리함
@@ -133,6 +144,7 @@ export const stopMeasurementService = async (
     groupId,
     subjectIndex,
     status: 'COMPLETED',
+    stopReason,
   });
 
   // 두 subject 모두 COMPLETED인지 확인함

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -19,6 +19,8 @@ export interface Session {
   pairedAt: Date | null; // 페어링 완료 시점
   expiresAt: Date; // 토큰 만료 시점
   measuredAt: Date | null; // 측정 시작 시점
+  stopReason: 'Natural' | 'ManualEarly' | 'HeadsetLost' | 'ProcessError' | null;
+  measuredDurationSeconds: number | null;
 }
 
 /** 2. 인스턴스 메서드 타입 정의 */
@@ -82,6 +84,15 @@ const sessionSchema = new Schema<Session, SessionModel, SessionMethods>(
     },
     measuredAt: {
       type: Date,
+      default: null,
+    },
+    stopReason: {
+      type: String,
+      enum: ['Natural', 'ManualEarly', 'HeadsetLost', 'ProcessError', null],
+      default: null,
+    },
+    measuredDurationSeconds: {
+      type: Number,
       default: null,
     },
   },


### PR DESCRIPTION
## Summary
- Phase 13 BE 코드 dev → main 동기화
- stopAll 엔드포인트 + stopReason + 3-tier 분류 (VALID/PARTIAL/ABORTED)
- FE에서 사용하는 `POST /engine/stream/stop-all` 엔드포인트 활성화

## Context
feature/34-stop-reason이 dev에 squash 머지됨 (PR #38). main에 반영하여 Heroku 배포와 동기화.