### PR TITLE
feat(14): BE SEQUENTIAL mode — schema + sequential-analysis.service + orchestration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ import prettierConfig from "eslint-config-prettier";
 
 export default [
   {
+    ignores: ["dist/**", "node_modules/**", "coverage/**"],
+  },
+  {
     files: ["**/*.ts"],
     languageOptions: {
       parser: tsParser,

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,12 @@ module.exports = {
     testEnvironment: 'node',
     moduleNameMapper: {
       '^@/(.*)$': '<rootDir>/src/$1', // 테스트에서도 절대 경로(@/) 인식
+      '^@01-app/(.*)$': '<rootDir>/src/01-app/$1',
+      '^@02-processes/(.*)$': '<rootDir>/src/02-processes/$1',
+      '^@03-pages/(.*)$': '<rootDir>/src/03-pages/$1',
+      '^@04-widgets/(.*)$': '<rootDir>/src/04-widgets/$1',
+      '^@05-features/(.*)$': '<rootDir>/src/05-features/$1',
+      '^@06-entities/(.*)$': '<rootDir>/src/06-entities/$1',
+      '^@07-shared/(.*)$': '<rootDir>/src/07-shared/$1', // FSD 레이어 절대 경로 인식
     },
   };

--- a/src/01-app/app.router.ts
+++ b/src/01-app/app.router.ts
@@ -7,6 +7,7 @@ import { measurementApi } from '@02-processes/measurements';
 import engineRouter from '@02-processes/engine/api/engine.routes';
 import { chatApi } from '@05-features/neuro-chats';
 import analysisRouter from '@05-features/analysis-results/api/analysis.routes';
+import sequentialRouter from '@02-processes/post-measurement/api/sequential.routes';
 
 const router = Router();
 
@@ -18,5 +19,7 @@ router.use('/measurements', measurementApi);
 router.use('/engine', engineRouter);
 router.use('/chat', chatApi);
 router.use('/analysis', analysisRouter);
+// SEQUENTIAL 모드 분석 엔드포인트 등록함 (최종 URL: /api/analyze/sequential)
+router.use('/analyze', sequentialRouter);
 
 export default router;

--- a/src/02-processes/engine/api/engine.controller.test.ts
+++ b/src/02-processes/engine/api/engine.controller.test.ts
@@ -1,0 +1,119 @@
+/**
+ * engine.controller.ts — SEQUENTIAL 분기 정적 검증
+ *
+ * 검증 항목:
+ *   - triggerPostMeasurementByTier에 SEQUENTIAL 분기가 추가됨
+ *   - SEQUENTIAL 모드 시 기존 tier 분류 로직이 실행되지 않고 조기 반환함
+ *   - DUAL/BTI 모드 시 기존 tier 분류 로직(VALID/PARTIAL/ABORTED)이 그대로 유지됨
+ *   - app.router.ts에 sequentialRouter 등록이 존재함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('engine.controller.ts: SEQUENTIAL dispatch 분기가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.controller.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('triggerPostMeasurementByTier 함수가 존재함', () => {
+    expect(source).toContain('triggerPostMeasurementByTier');
+  });
+
+  it("SEQUENTIAL 모드 분기가 존재함 (experimentMode === 'SEQUENTIAL')", () => {
+    expect(source).toContain('SEQUENTIAL');
+  });
+
+  it('SEQUENTIAL 분기에서 emitLiveEvent를 호출함', () => {
+    expect(source).toContain('emitLiveEvent');
+  });
+
+  it('SEQUENTIAL 분기에서 early return이 존재함', () => {
+    // SEQUENTIAL 분기 내 return이 있어야 기존 tier 로직 건너뜀
+    expect(source).toMatch(/SEQUENTIAL[\s\S]*?return/);
+  });
+
+  it('기존 VALID tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'VALID'");
+  });
+
+  it('기존 PARTIAL tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'PARTIAL'");
+  });
+
+  it('기존 ABORTED tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'ABORTED'");
+  });
+
+  it('experimentMode를 대표 세션에서 조회함', () => {
+    expect(source).toContain('experimentMode');
+  });
+});
+
+describe('sequential.routes.ts: POST /sequential 라우트 정적 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../post-measurement/api/sequential.routes.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('authenticate 미들웨어를 사용함', () => {
+    expect(source).toContain('authenticate');
+  });
+
+  it('validate 미들웨어를 사용함', () => {
+    expect(source).toContain('validate');
+  });
+
+  it('groupId 필드 검증이 있음', () => {
+    expect(source).toContain('groupId');
+  });
+
+  it('algorithm 필드가 optional로 처리됨', () => {
+    expect(source).toContain('optional');
+  });
+
+  it('creatorId 소유권 검증 로직이 존재함', () => {
+    expect(source).toContain('creatorId');
+  });
+
+  it('403 에러 응답이 존재함', () => {
+    expect(source).toContain('403');
+  });
+
+  it('runSequentialAnalysisPipeline을 호출함', () => {
+    expect(source).toContain('runSequentialAnalysisPipeline');
+  });
+
+  it('200 응답으로 { success: true, result }를 반환함', () => {
+    expect(source).toContain('success: true');
+  });
+});
+
+describe('app.router.ts: sequentialRouter 등록 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../../01-app/app.router.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('sequentialRouter를 import함', () => {
+    expect(source).toContain('sequentialRouter');
+  });
+
+  it("/analyze 경로에 sequentialRouter가 등록됨", () => {
+    expect(source).toContain("'/analyze'");
+    expect(source).toContain('sequentialRouter');
+  });
+});

--- a/src/02-processes/engine/api/engine.controller.test.ts
+++ b/src/02-processes/engine/api/engine.controller.test.ts
@@ -101,10 +101,7 @@ describe('app.router.ts: sequentialRouter 등록 검증', () => {
   let source: string;
 
   beforeAll(() => {
-    const filePath = path.resolve(
-      __dirname,
-      '../../../01-app/app.router.ts'
-    );
+    const filePath = path.resolve(__dirname, '../../../01-app/app.router.ts');
     source = fs.readFileSync(filePath, 'utf-8');
   });
 
@@ -112,7 +109,7 @@ describe('app.router.ts: sequentialRouter 등록 검증', () => {
     expect(source).toContain('sequentialRouter');
   });
 
-  it("/analyze 경로에 sequentialRouter가 등록됨", () => {
+  it('/analyze 경로에 sequentialRouter가 등록됨', () => {
     expect(source).toContain("'/analyze'");
     expect(source).toContain('sequentialRouter');
   });

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -10,12 +10,30 @@ const MIN_ANALYSIS_SECONDS = 180;
 
 /**
  * 3-tier 분류 후 적절한 분석 파이프라인 트리거함
+ * - SEQUENTIAL: 자동 트리거 안 함. operator "Analyze" 버튼(POST /api/analyze/sequential) 대기함
  * - VALID: measuredDurationSeconds >= MIN_ANALYSIS_SECONDS
  * - PARTIAL: 한쪽만 VALID
  * - ABORTED: 둘 다 INVALID
  */
 async function triggerPostMeasurementByTier(groupId: string) {
   const { Session: SessionModel } = await import('@06-entities/sessions');
+
+  // SEQUENTIAL 모드 조기 분기: 자동 분석 트리거 안 함 (I2 + N1)
+  const representativeSession = await SessionModel.findOne({ groupId }).sort({
+    subjectIndex: 1,
+  });
+  const experimentMode = representativeSession?.experimentMode ?? 'DUAL';
+
+  if (experimentMode === 'SEQUENTIAL') {
+    // operator "Analyze" 버튼 대기 — 소켓으로 측정 완료만 알림
+    SocketService.emitLiveEvent('analysis-status', {
+      groupId,
+      tier: 'SEQUENTIAL',
+      message: 'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
+    });
+    return;
+  }
+
   const completedSessions = await SessionModel.find({
     groupId,
     status: 'COMPLETED',

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -29,7 +29,8 @@ async function triggerPostMeasurementByTier(groupId: string) {
     SocketService.emitLiveEvent('analysis-status', {
       groupId,
       tier: 'SEQUENTIAL',
-      message: 'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
+      message:
+        'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
     });
     return;
   }

--- a/src/02-processes/engine/api/engine.routes.test.ts
+++ b/src/02-processes/engine/api/engine.routes.test.ts
@@ -1,0 +1,109 @@
+/**
+ * engine.routes.ts — analyzePipelineSchema mode/similarity_features 확장 검증
+ *
+ * 검증 항목:
+ *   - analyzePipelineSchema에 mode 필드(enum)가 추가됨
+ *   - mode: 'SEQUENTIAL', 'DUAL', 'BTI' 모두 허용됨
+ *   - mode: 'INVALID' 시 파싱 실패함
+ *   - algorithm 필드가 추가됨
+ *   - 기존 groupId, subjectIndices 검증이 유지됨
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('engine.routes.ts: analyzePipelineSchema 확장 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.routes.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it("analyzePipelineSchema에 mode 필드가 추가됨 (z.enum(['DUAL','SEQUENTIAL','BTI']))", () => {
+    expect(source).toContain('mode');
+    expect(source).toContain("z.enum(['DUAL', 'SEQUENTIAL', 'BTI'])");
+  });
+
+  it("mode 필드의 default가 'DUAL'로 설정됨", () => {
+    expect(source).toMatch(/mode[\s\S]*?default\('DUAL'\)/);
+  });
+
+  it('algorithm 필드가 analyzePipelineSchema에 추가됨', () => {
+    expect(source).toContain('algorithm');
+  });
+
+  it("algorithm 필드의 default가 'default'로 설정됨", () => {
+    expect(source).toMatch(/algorithm[\s\S]*?default\('default'\)/);
+  });
+
+  it('기존 groupId 검증이 유지됨', () => {
+    expect(source).toContain('groupId');
+  });
+});
+
+describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
+  let analyzePipelineSchema: import('zod').ZodTypeAny | undefined;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.routes.ts');
+    const hasFile = fs.existsSync(filePath);
+    if (!hasFile) return;
+
+    // 소스에서 z.object 형식으로 정의된 스키마를 직접 파싱하기 위해 zod 활용함
+    // engine.routes.ts는 Router를 export하므로 직접 import 불가
+    // zod를 통해 독립적으로 스키마 생성하여 검증함
+    const { z } = require('zod');
+    analyzePipelineSchema = z.object({
+      groupId: z.string().min(1),
+      subjectIndices: z.array(z.number().int().positive()).optional(),
+      mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
+      algorithm: z.string().optional().default('default'),
+    });
+  });
+
+  it("mode: 'SEQUENTIAL'이 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'SEQUENTIAL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'DUAL'이 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'DUAL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'BTI'가 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'BTI',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'INVALID' 시 스키마 검증 실패함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'INVALID',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('mode 미지정 시 default DUAL이 적용됨', () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({ groupId: 'grp_test' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).mode).toBe('DUAL');
+    }
+  });
+});

--- a/src/02-processes/engine/api/engine.routes.test.ts
+++ b/src/02-processes/engine/api/engine.routes.test.ts
@@ -56,7 +56,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     const { z } = require('zod');
     analyzePipelineSchema = z.object({
       groupId: z.string().min(1),
-      subjectIndices: z.array(z.number().int().positive()).optional(),
+      subjectIndices: z.array(z.number().int().positive()),
       mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
       algorithm: z.string().optional().default('default'),
     });
@@ -66,6 +66,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'SEQUENTIAL',
     });
     expect(result.success).toBe(true);
@@ -75,6 +76,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'DUAL',
     });
     expect(result.success).toBe(true);
@@ -84,6 +86,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'BTI',
     });
     expect(result.success).toBe(true);
@@ -93,6 +96,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'INVALID',
     });
     expect(result.success).toBe(false);
@@ -100,7 +104,10 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
 
   it('mode 미지정 시 default DUAL이 적용됨', () => {
     if (!analyzePipelineSchema) return;
-    const result = analyzePipelineSchema.safeParse({ groupId: 'grp_test' });
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      subjectIndices: [1, 2],
+    });
     expect(result.success).toBe(true);
     if (result.success) {
       expect((result.data as any).mode).toBe('DUAL');

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -77,7 +77,7 @@ router.post('/register', validate(registerSchema), engineController.register);
 // 전체 파이프라인 분석 프록시
 const analyzePipelineSchema = z.object({
   groupId: z.string().min(1),
-  subjectIndices: z.array(z.number().int().positive()).optional(),
+  subjectIndices: z.array(z.number().int().positive()),
   mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
   algorithm: z.string().optional().default('default'),
   params: z

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -77,7 +77,9 @@ router.post('/register', validate(registerSchema), engineController.register);
 // 전체 파이프라인 분석 프록시
 const analyzePipelineSchema = z.object({
   groupId: z.string().min(1),
-  subjectIndices: z.array(z.number().int().positive()),
+  subjectIndices: z.array(z.number().int().positive()).optional(),
+  mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
+  algorithm: z.string().optional().default('default'),
   params: z
     .object({
       stimulusDurationSec: z.number().int().positive().optional(),

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -108,6 +108,38 @@ export const engineProxyService = {
     return toCamelCaseKeys(data) as Record<string, unknown>;
   },
 
+  /** SEQUENTIAL 모드 파이프라인 분석 요청을 파이썬 엔진으로 프록시함 */
+  async analyzeSequentialPipeline(
+    groupId: string,
+    algorithm: string = 'default'
+  ): Promise<Record<string, unknown>> {
+    const engineUrl = engineRegistryService.getEngineUrl();
+
+    const response = await fetch(`${engineUrl}/api/analyze/pipeline`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Engine-Secret': config.dataEngine.secretKey,
+      },
+      body: JSON.stringify({
+        ['group_id']: groupId,
+        ['mode']: 'SEQUENTIAL',
+        ['algorithm']: algorithm,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new AppError(
+        `파이썬 엔진 SEQUENTIAL 파이프라인 분석 실패: ${response.status} ${errorText}`,
+        response.status
+      );
+    }
+
+    const data = await response.json();
+    return toCamelCaseKeys(data) as Record<string, unknown>;
+  },
+
   /** 등록된 파이썬 엔진으로 EEG 스트리밍 시작 요청을 프록시함 */
   async streamStart(
     groupId: string,

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -123,6 +123,7 @@ export const engineProxyService = {
       },
       body: JSON.stringify({
         ['group_id']: groupId,
+        ['subject_indices']: [1, 2], // DE Pydantic PipelineRequest 필수 필드 — SEQUENTIAL 브랜치는 값을 무시하지만 검증을 통과해야 함
         ['mode']: 'SEQUENTIAL',
         ['algorithm']: algorithm,
       }),

--- a/src/02-processes/post-measurement/api/sequential.routes.ts
+++ b/src/02-processes/post-measurement/api/sequential.routes.ts
@@ -1,0 +1,60 @@
+import { Router, Response, NextFunction } from 'express';
+import { authenticate } from '@07-shared/middlewares/authenticate.middleware';
+import { validate } from '@07-shared/middlewares/validate.middleware';
+import { AppError } from '@07-shared/errors';
+import { runSequentialAnalysisPipeline } from '../services/sequential-analysis.service';
+import { Session } from '@06-entities/sessions';
+import { z } from 'zod';
+import type { AuthedRequest } from '@07-shared/types/type';
+
+const router = Router();
+
+/** POST /sequential 요청 body 검증 스키마 */
+const sequentialAnalyzeSchema = z.object({
+  groupId: z.string().min(1),
+  algorithm: z.string().optional(),
+});
+
+/**
+ * POST /api/analyze/sequential
+ * operator "Analyze" 버튼 → SEQUENTIAL 모드 분석 파이프라인 트리거함
+ * 인증 필수 + 세션 소유권 검증함
+ */
+router.post(
+  '/sequential',
+  authenticate,
+  validate(sequentialAnalyzeSchema),
+  async (req: AuthedRequest, res: Response, next: NextFunction) => {
+    try {
+      const { groupId, algorithm } = req.body;
+      const requesterId = req.user?.id;
+
+      // 소유권 검증: groupId의 세션 생성자만 분석 가능함
+      const session = await Session.findOne({ groupId }).sort({
+        subjectIndex: 1,
+      });
+
+      if (!session) {
+        throw new AppError(`groupId=${groupId} 세션을 찾을 수 없습니다.`, 404);
+      }
+
+      if (
+        session.creatorId === null ||
+        session.creatorId.toString() !== requesterId
+      ) {
+        throw new AppError('이 세션에 대한 분석 권한이 없습니다.', 403);
+      }
+
+      const result = await runSequentialAnalysisPipeline(
+        groupId,
+        algorithm ?? 'default'
+      );
+
+      res.status(200).json({ success: true, result });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * sequential-analysis.service — 통합 수준 검증 (unit-level, MongoDB 없이)
  *
@@ -23,10 +24,7 @@ describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () =
       'utf-8'
     );
     proxySource = fs.readFileSync(
-      path.resolve(
-        __dirname,
-        '../../engine/services/engine-proxy.service.ts'
-      ),
+      path.resolve(__dirname, '../../engine/services/engine-proxy.service.ts'),
       'utf-8'
     );
   });
@@ -90,7 +88,9 @@ describe('AnalysisResult 스키마: SEQUENTIAL + similarity_features 필드 roun
 
 describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () => {
   it('유효한 cosine_pearson_faa 결과가 Zod 파싱을 통과함', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const mockDEResponse = {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.73,
@@ -113,12 +113,20 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
   });
 
   it('Mixed type 중첩 객체가 보존됨 (Zod parse 후 동일 구조)', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const nested = {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.5,
       overall_cosine: 0.6,
-      band_ratio_diff: { alpha: 0.1, beta: 0.2, delta: 0.0, theta: 0.3, gamma: 0.1 },
+      band_ratio_diff: {
+        alpha: 0.1,
+        beta: 0.2,
+        delta: 0.0,
+        theta: 0.3,
+        gamma: 0.1,
+      },
       faa_absolute_diff: null,
     };
     const result = cosinePearsonFAASchema.safeParse(nested);
@@ -130,7 +138,9 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
   });
 
   it('DE 500 응답 시나리오: similarity_score 미포함 응답은 Zod 검증 실패함', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const errorResponse = {
       error: 'Internal server error',
       detail: 'CSV not found',
@@ -142,19 +152,25 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
 
 describe('similaritySchemaRegistry: 레지스트리 조회 검증', () => {
   it("'cosine_pearson_faa' 키로 스키마 조회 성공함", () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('cosine_pearson_faa');
     expect(schema).toBeDefined();
   });
 
   it("'default' 키로 스키마 조회 성공함", () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('default');
     expect(schema).toBeDefined();
   });
 
   it('미등록 알고리즘은 undefined 반환함', () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('unknown_algorithm_xyz');
     expect(schema).toBeUndefined();
   });

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * sequential-analysis.service — 통합 수준 검증 (unit-level, MongoDB 없이)
+ *
+ * 실제 mongoose/DB 연결 없이 소스 코드와 모듈 구조를 검증함.
+ * mongodb-memory-server 미설치 환경을 고려하여 정적 소스 검증 + Zod 런타임 검증만 수행함.
+ *
+ * 검증 항목:
+ *   - SEQUENTIAL 파이프라인 service + proxy 연계 구조 확인
+ *   - similarity_features round-trip 에서 Zod 스키마 파싱 확인
+ *   - DB 레이어 분리: 에러 전파 구조 확인
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () => {
+  let serviceSource: string;
+  let proxySource: string;
+
+  beforeAll(() => {
+    serviceSource = fs.readFileSync(
+      path.resolve(__dirname, 'sequential-analysis.service.ts'),
+      'utf-8'
+    );
+    proxySource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../engine/services/engine-proxy.service.ts'
+      ),
+      'utf-8'
+    );
+  });
+
+  it('service가 proxy의 analyzeSequentialPipeline을 호출함', () => {
+    expect(serviceSource).toContain('analyzeSequentialPipeline');
+    expect(proxySource).toContain('analyzeSequentialPipeline');
+  });
+
+  it('proxy가 SEQUENTIAL mode와 algorithm을 DE에 전달함', () => {
+    expect(proxySource).toContain("'SEQUENTIAL'");
+    expect(proxySource).toContain("['algorithm']");
+    expect(proxySource).toContain('/api/analyze/pipeline');
+  });
+
+  it('service가 DE 응답에서 similarity_features를 추출함', () => {
+    // camelCase 변환 후 similarityFeatures 키로 접근함 (toCamelCaseKeys)
+    expect(serviceSource).toContain('similarityFeatures');
+  });
+
+  it('service가 AnalysisResult.create에 올바른 필드를 전달함', () => {
+    expect(serviceSource).toContain('analysis_mode');
+    expect(serviceSource).toContain('similarity_features');
+    expect(serviceSource).toContain('synchronyScore: null');
+    expect(serviceSource).toContain('yScore: null');
+  });
+
+  it('service가 엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
+    expect(serviceSource).toContain('findByIdAndDelete');
+    expect(serviceSource).toContain('throw err');
+  });
+});
+
+describe('AnalysisResult 스키마: SEQUENTIAL + similarity_features 필드 round-trip 검증 (정적)', () => {
+  let schemaSource: string;
+
+  beforeAll(() => {
+    schemaSource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../../06-entities/analysis-results/model/analysis-result.schema.ts'
+      ),
+      'utf-8'
+    );
+  });
+
+  it('analysis_mode 필드가 스키마에 존재함', () => {
+    expect(schemaSource).toContain('analysis_mode');
+  });
+
+  it('similarity_features 필드가 Schema.Types.Mixed로 존재함', () => {
+    expect(schemaSource).toContain('similarity_features');
+    expect(schemaSource).toContain('Schema.Types.Mixed');
+  });
+
+  it('AnalysisResult 인터페이스에 두 신규 필드가 optional로 선언됨', () => {
+    expect(schemaSource).toContain('analysis_mode?:');
+    expect(schemaSource).toContain('similarity_features?:');
+  });
+});
+
+describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () => {
+  it('유효한 cosine_pearson_faa 결과가 Zod 파싱을 통과함', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const mockDEResponse = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.73,
+      overall_cosine: 0.85,
+      band_ratio_diff: {
+        delta: 0.1,
+        theta: 0.2,
+        alpha: 0.05,
+        beta: 0.15,
+        gamma: 0.08,
+      },
+      faa_absolute_diff: 0.2,
+    };
+    const result = cosinePearsonFAASchema.safeParse(mockDEResponse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.similarity_score).toBe(0.73);
+      expect(result.data.algorithm).toBe('cosine_pearson_faa');
+    }
+  });
+
+  it('Mixed type 중첩 객체가 보존됨 (Zod parse 후 동일 구조)', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const nested = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.5,
+      overall_cosine: 0.6,
+      band_ratio_diff: { alpha: 0.1, beta: 0.2, delta: 0.0, theta: 0.3, gamma: 0.1 },
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(nested);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.band_ratio_diff).toEqual(nested.band_ratio_diff);
+      expect(result.data.faa_absolute_diff).toBeNull();
+    }
+  });
+
+  it('DE 500 응답 시나리오: similarity_score 미포함 응답은 Zod 검증 실패함', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const errorResponse = {
+      error: 'Internal server error',
+      detail: 'CSV not found',
+    };
+    const result = cosinePearsonFAASchema.safeParse(errorResponse);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('similaritySchemaRegistry: 레지스트리 조회 검증', () => {
+  it("'cosine_pearson_faa' 키로 스키마 조회 성공함", () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('cosine_pearson_faa');
+    expect(schema).toBeDefined();
+  });
+
+  it("'default' 키로 스키마 조회 성공함", () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('default');
+    expect(schema).toBeDefined();
+  });
+
+  it('미등록 알고리즘은 undefined 반환함', () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('unknown_algorithm_xyz');
+    expect(schema).toBeUndefined();
+  });
+});

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -40,6 +40,24 @@ describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () =
     expect(proxySource).toContain('/api/analyze/pipeline');
   });
 
+  it('proxy가 subject_indices를 DE Pydantic PipelineRequest 검증 통과용으로 포함함', () => {
+    // DE PipelineRequest.subject_indices 는 default 없는 필수 필드임
+    // 누락 시 FastAPI가 422 Unprocessable Entity 반환 — SEQUENTIAL 브랜치 실행 전 차단됨
+    expect(proxySource).toContain("'subject_indices'");
+    expect(proxySource).toMatch(
+      /\['subject_indices'\]\s*:\s*\[\s*1\s*,\s*2\s*\]/
+    );
+  });
+
+  it('proxy SEQUENTIAL 블록에 subject_indices 키가 존재함 (부재 감지 테스트)', () => {
+    // analyzeSequentialPipeline 함수 본문에서 subject_indices 키 존재 여부 확인
+    const sequentialBlock = proxySource.slice(
+      proxySource.indexOf('analyzeSequentialPipeline'),
+      proxySource.indexOf('analyzeSequentialPipeline') + 1000
+    );
+    expect(sequentialBlock).toContain('subject_indices');
+  });
+
   it('service가 DE 응답에서 similarity_features를 추출함', () => {
     // camelCase 변환 후 similarityFeatures 키로 접근함 (toCamelCaseKeys)
     expect(serviceSource).toContain('similarityFeatures');

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
@@ -1,0 +1,89 @@
+/**
+ * sequential-analysis.service.ts — SEQUENTIAL 분석 파이프라인 서비스 검증
+ *
+ * 검증 항목:
+ *   - 서비스가 engineProxyService.analyzeSequentialPipeline을 import 및 호출함
+ *   - 두 subject COMPLETED 검증 로직이 존재함
+ *   - AnalysisResult 생성 시 analysis_mode='SEQUENTIAL' 설정됨
+ *   - 엔진 실패 시 에러를 전파함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sequential-analysis.service.ts: 소스 정적 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'sequential-analysis.service.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('engineProxyService를 import함', () => {
+    expect(source).toContain('engineProxyService');
+  });
+
+  it('analyzeSequentialPipeline을 호출함', () => {
+    expect(source).toContain('analyzeSequentialPipeline');
+  });
+
+  it("analysis_mode: 'SEQUENTIAL'을 AnalysisResult.create에 전달함", () => {
+    expect(source).toContain("analysis_mode: 'SEQUENTIAL'");
+  });
+
+  it('두 subject COMPLETED 상태 검증 로직이 존재함', () => {
+    expect(source).toContain("'COMPLETED'");
+  });
+
+  it('session1, session2 둘 다 조회함', () => {
+    expect(source).toContain('session1');
+    expect(source).toContain('session2');
+  });
+
+  it('엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
+    expect(source).toContain('findByIdAndDelete');
+    expect(source).toContain('throw err');
+  });
+
+  it('groupId와 algorithm 파라미터를 받음', () => {
+    expect(source).toContain('groupId: string');
+    expect(source).toContain('algorithm');
+  });
+
+  it("algorithm 기본값이 'default'임", () => {
+    expect(source).toContain("algorithm: string = 'default'");
+  });
+
+  it('Promise<AnalysisResultDoc>를 반환함', () => {
+    expect(source).toContain('AnalysisResultDoc');
+  });
+
+  it('SEQUENTIAL 모드에서 synchronyScore와 yScore를 null로 설정함 (ADR-14-004)', () => {
+    expect(source).toContain('synchronyScore: null');
+    expect(source).toContain('yScore: null');
+  });
+});
+
+describe('engine-proxy.service.ts: analyzeSequentialPipeline 메서드 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../engine/services/engine-proxy.service.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('analyzeSequentialPipeline 메서드가 정의됨', () => {
+    expect(source).toContain('analyzeSequentialPipeline');
+  });
+
+  it("mode: 'SEQUENTIAL'을 요청 body에 포함함", () => {
+    expect(source).toContain("'SEQUENTIAL'");
+  });
+
+  it('algorithm 파라미터를 요청 body에 전달함', () => {
+    expect(source).toContain("['algorithm']");
+  });
+});

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -1,0 +1,132 @@
+import { Session } from '@06-entities/sessions';
+import { AnalysisResult } from '@06-entities/analysis-results';
+import { EegRecord } from '@06-entities/eeg-records';
+import { Consent } from '@06-entities/consents';
+import { engineProxyService } from '@02-processes/engine/services/engine-proxy.service';
+import { AppError } from '@07-shared/errors';
+import type { AnalysisResultDoc } from '@06-entities/analysis-results';
+
+/**
+ * SEQUENTIAL 모드 분석 파이프라인 수행함
+ * operator "Analyze" 버튼 클릭 시 호출됨
+ * 두 subject 모두 COMPLETED 상태여야 실행 가능함
+ */
+export const runSequentialAnalysisPipeline = async (
+  groupId: string,
+  algorithm: string = 'default'
+): Promise<AnalysisResultDoc> => {
+  // 멱등성 가드: 이미 SEQUENTIAL 결과가 있으면 스킵함
+  const existing = await AnalysisResult.findOne({
+    groupId,
+    analysis_mode: 'SEQUENTIAL',
+  });
+  if (existing) {
+    console.log(
+      `[sequentialAnalysis] groupId=${groupId} 이미 처리됨, 기존 결과 반환`
+    );
+    return existing;
+  }
+
+  // 두 subject 세션 조회 + COMPLETED 상태 검증함
+  const sessions = await Session.find({ groupId }).populate('userId');
+  const session1 = sessions.find((s) => s.subjectIndex === 1);
+  const session2 = sessions.find((s) => s.subjectIndex === 2);
+
+  if (!session1 || !session2) {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 1 또는 2 세션 미발견`,
+      404
+    );
+  }
+
+  if (session1.status !== 'COMPLETED') {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 1 세션이 COMPLETED 상태가 아님 (현재: ${session1.status})`,
+      422
+    );
+  }
+
+  if (session2.status !== 'COMPLETED') {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 2 세션이 COMPLETED 상태가 아님 (현재: ${session2.status})`,
+      422
+    );
+  }
+
+  if (!session1.userId || !session2.userId) {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} 세션에 userId가 바인딩되지 않음`,
+      422
+    );
+  }
+
+  const user1Id = (session1.userId as any)._id;
+  const user2Id = (session2.userId as any)._id;
+
+  // EegRecord 2건 생성함
+  const consent1 = await Consent.findOne({ userId: user1Id });
+  const consent2 = await Consent.findOne({ userId: user2Id });
+
+  const record1Doc: any = {
+    userId: user1Id,
+    sessionId: session1._id,
+    rawDataPath: `data/${groupId}/subject_1.csv`,
+    eegSummary: {},
+  };
+  if (consent1?._id) record1Doc.consentId = consent1._id;
+
+  const record2Doc: any = {
+    userId: user2Id,
+    sessionId: session2._id,
+    rawDataPath: `data/${groupId}/subject_2.csv`,
+    eegSummary: {},
+  };
+  if (consent2?._id) record2Doc.consentId = consent2._id;
+
+  const record1 = await EegRecord.create(record1Doc);
+  const record2 = await EegRecord.create(record2Doc);
+
+  // DE /analyze/pipeline (mode=SEQUENTIAL) 호출함
+  let pipelineResult: Record<string, unknown> = {};
+  let similarityFeatures: Record<string, unknown> | undefined;
+
+  try {
+    pipelineResult = await engineProxyService.analyzeSequentialPipeline(
+      groupId,
+      algorithm
+    );
+    similarityFeatures = (pipelineResult.similarityFeatures ??
+      pipelineResult.similarity_features) as Record<string, unknown> | undefined;
+  } catch (err) {
+    // EegRecord 롤백 후 에러 전파함
+    await EegRecord.findByIdAndDelete(record1._id);
+    await EegRecord.findByIdAndDelete(record2._id);
+    throw err;
+  }
+
+  // AnalysisResult 생성함 (analysis_mode: SEQUENTIAL)
+  const analysisResult = await AnalysisResult.create({
+    groupId,
+    user1Id,
+    user2Id,
+    record1Id: record1._id,
+    record2Id: record2._id,
+    surveySummary: '',
+    matchingScore: similarityFeatures?.similarity_score
+      ? Math.round((similarityFeatures.similarity_score as number) * 100)
+      : 0,
+    synchronyScore: null, // SEQUENTIAL 모드에서 PLV/coherence 미계산 (ADR-14-004)
+    yScore: null,
+    aiComment: '뇌파 반응 유사도 분석이 완료되었습니다.',
+    markdown: (pipelineResult.markdown as string) ?? '',
+    pipelineResult,
+    analysis_mode: 'SEQUENTIAL',
+    similarity_features: similarityFeatures ?? null,
+  });
+
+  console.log(
+    `[sequentialAnalysis] groupId=${groupId} SEQUENTIAL 분석 완료, algorithm=${algorithm}`
+  );
+
+  return analysisResult;
+};

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Session } from '@06-entities/sessions';
 import { AnalysisResult } from '@06-entities/analysis-results';
 import { EegRecord } from '@06-entities/eeg-records';
@@ -96,7 +97,9 @@ export const runSequentialAnalysisPipeline = async (
       algorithm
     );
     similarityFeatures = (pipelineResult.similarityFeatures ??
-      pipelineResult.similarity_features) as Record<string, unknown> | undefined;
+      pipelineResult.similarity_features) as
+      | Record<string, unknown>
+      | undefined;
   } catch (err) {
     // EegRecord 롤백 후 에러 전파함
     await EegRecord.findByIdAndDelete(record1._id);
@@ -121,7 +124,7 @@ export const runSequentialAnalysisPipeline = async (
     markdown: (pipelineResult.markdown as string) ?? '',
     pipelineResult,
     analysis_mode: 'SEQUENTIAL',
-    similarity_features: similarityFeatures ?? null,
+    similarity_features: similarityFeatures ?? undefined,
   });
 
   console.log(

--- a/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * analysis-result.schema.ts — analysis_mode + similarity_features 필드 검증
  *
@@ -55,7 +56,9 @@ describe('analysis-result.schema.ts: analysis_mode 필드가 올바르게 추가
     // analysis_mode는 인터페이스에서 optional(?)이거나 Mongoose default로 채워짐
     // 인터페이스 필드에 '?'(optional) 또는 default 선언 확인함
     const hasOptionalInInterface = source.match(/analysis_mode\s*\?:/);
-    const hasDefaultInSchema = source.match(/analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/);
+    const hasDefaultInSchema = source.match(
+      /analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/
+    );
     expect(hasOptionalInInterface || hasDefaultInSchema).toBeTruthy();
   });
 });
@@ -70,7 +73,9 @@ describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
     );
     const hasFile = fs.existsSync(schemaPath);
     if (hasFile) {
-      ({ cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
+      ({
+        cosinePearsonFAASchema,
+      } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
     }
   });
 
@@ -80,7 +85,13 @@ describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.73,
       overall_cosine: 0.85,
-      band_ratio_diff: { delta: 0.1, theta: 0.2, alpha: 0.05, beta: 0.15, gamma: 0.08 },
+      band_ratio_diff: {
+        delta: 0.1,
+        theta: 0.2,
+        alpha: 0.05,
+        beta: 0.15,
+        gamma: 0.08,
+      },
       faa_absolute_diff: 0.2,
     };
     const result = cosinePearsonFAASchema.safeParse(validPayload);

--- a/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
@@ -1,0 +1,127 @@
+/**
+ * analysis-result.schema.ts — analysis_mode + similarity_features 필드 검증
+ *
+ * 검증 항목:
+ *   - analysis_mode 필드가 스키마에 정의됨
+ *   - similarity_features 필드가 Mixed 타입으로 정의됨
+ *   - 기존 생성 경로(bti-analysis, post-measurement)에서 analysis_mode 미지정 시
+ *     Mongoose default 'DUAL'이 적용됨 (정적 소스 검증)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('analysis-result.schema.ts: analysis_mode 필드가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'analysis-result.schema.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('AnalysisResult 인터페이스에 analysis_mode 필드가 존재함', () => {
+    expect(source).toContain('analysis_mode');
+  });
+
+  it("인터페이스 analysis_mode에 'DUAL' | 'SEQUENTIAL' | 'BTI' 유니온이 포함됨", () => {
+    expect(source).toContain('DUAL');
+    expect(source).toContain('SEQUENTIAL');
+    expect(source).toContain('BTI');
+  });
+
+  it('Mongoose 스키마에 analysis_mode 필드 정의가 존재함', () => {
+    expect(source).toContain('analysis_mode:');
+  });
+
+  it("스키마 analysis_mode enum에 'DUAL', 'SEQUENTIAL', 'BTI'가 포함됨", () => {
+    expect(source).toContain("'DUAL'");
+    expect(source).toContain("'SEQUENTIAL'");
+    expect(source).toContain("'BTI'");
+  });
+
+  it("스키마 analysis_mode default가 'DUAL'로 설정됨", () => {
+    expect(source).toMatch(/default:\s*['"]DUAL['"]/);
+  });
+
+  it('인터페이스에 similarity_features 필드가 존재함', () => {
+    expect(source).toContain('similarity_features');
+  });
+
+  it('스키마에 similarity_features가 Schema.Types.Mixed로 정의됨', () => {
+    expect(source).toContain('Schema.Types.Mixed');
+  });
+
+  it('기존 AnalysisResult.create 호출 시 analysis_mode 미지정이 허용됨 (optional 또는 default)', () => {
+    // analysis_mode는 인터페이스에서 optional(?)이거나 Mongoose default로 채워짐
+    // 인터페이스 필드에 '?'(optional) 또는 default 선언 확인함
+    const hasOptionalInInterface = source.match(/analysis_mode\s*\?:/);
+    const hasDefaultInSchema = source.match(/analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/);
+    expect(hasOptionalInInterface || hasDefaultInSchema).toBeTruthy();
+  });
+});
+
+describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
+  let cosinePearsonFAASchema: ReturnType<typeof import('zod').z.object>;
+
+  beforeAll(() => {
+    const schemaPath = path.resolve(
+      __dirname,
+      '../../../07-shared/schemas/similarity/cosine_pearson_faa.schema.ts'
+    );
+    const hasFile = fs.existsSync(schemaPath);
+    if (hasFile) {
+      ({ cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
+    }
+  });
+
+  it('유효한 payload를 올바르게 파싱함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const validPayload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.73,
+      overall_cosine: 0.85,
+      band_ratio_diff: { delta: 0.1, theta: 0.2, alpha: 0.05, beta: 0.15, gamma: 0.08 },
+      faa_absolute_diff: 0.2,
+    };
+    const result = cosinePearsonFAASchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('similarity_score가 범위 초과(1.5)면 파싱 실패함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const invalidPayload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 1.5,
+      overall_cosine: 0.85,
+      band_ratio_diff: {},
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(invalidPayload);
+    expect(result.success).toBe(false);
+  });
+
+  it('algorithm 필드 누락 시 파싱 실패함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const invalidPayload = {
+      similarity_score: 0.5,
+      overall_cosine: 0.7,
+      band_ratio_diff: {},
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(invalidPayload);
+    expect(result.success).toBe(false);
+  });
+
+  it('faa_absolute_diff가 null이어도 파싱 성공함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const payload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.5,
+      overall_cosine: 0.6,
+      band_ratio_diff: { alpha: 0.1 },
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/06-entities/analysis-results/model/analysis-result.schema.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 
 /** 1. 문서 필드 타입 정의 */

--- a/src/06-entities/analysis-results/model/analysis-result.schema.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.ts
@@ -14,6 +14,8 @@ export interface AnalysisResult {
   aiComment: string; // AI 분석 코멘트
   markdown: string; // 엔진 분석 markdown 원문
   pipelineResult: Record<string, unknown>; // analyzePipeline 전체 응답 저장
+  analysis_mode?: 'DUAL' | 'SEQUENTIAL' | 'BTI'; // 실험 모드 (ADR-14-002)
+  similarity_features?: Record<string, unknown>; // 유사도 지표 (ADR-14-009 Mixed type)
 }
 
 export interface AnalysisResultMethods {}
@@ -60,6 +62,17 @@ const analysisResultSchema = new Schema<
     aiComment: { type: String, required: true },
     markdown: { type: String, default: '' },
     pipelineResult: { type: Schema.Types.Mixed, default: {} },
+    analysis_mode: {
+      type: String,
+      enum: ['DUAL', 'SEQUENTIAL', 'BTI'],
+      default: 'DUAL',
+    },
+    similarity_features: {
+      type: Schema.Types.Mixed,
+      required: false,
+      // 예시: { algorithm: "cosine_pearson_faa", similarity_score: 0.73, ... }
+      // ADR-14-009: 새 알고리즘 추가 시 shape 변경 자유, 마이그레이션 불필요
+    },
   },
   {
     timestamps: true,

--- a/src/06-entities/sessions/model/session.schema.test.ts
+++ b/src/06-entities/sessions/model/session.schema.test.ts
@@ -1,0 +1,60 @@
+/**
+ * session.schema.ts — experimentMode 필드 추가 검증
+ *
+ * 검증 항목:
+ *   - Session 인터페이스에 experimentMode 필드가 추가됨
+ *   - Mongoose 스키마에 experimentMode 필드 정의 존재함
+ *   - enum 값으로 DUAL, SEQUENTIAL, BTI가 정의됨
+ *   - default 값이 'DUAL'로 설정됨
+ *   - required: true가 설정됨
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('session.schema.ts: experimentMode 필드가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'session.schema.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('Session 인터페이스에 experimentMode 필드가 존재함', () => {
+    expect(source).toContain('experimentMode');
+  });
+
+  it('Session 인터페이스에 DUAL | SEQUENTIAL | BTI 유니온 타입이 포함됨', () => {
+    expect(source).toContain('SEQUENTIAL');
+    expect(source).toContain('DUAL');
+    expect(source).toContain('BTI');
+  });
+
+  it('Mongoose 스키마에 experimentMode 필드 정의가 존재함', () => {
+    // 스키마 객체 내에 experimentMode 키 존재함
+    expect(source).toContain('experimentMode:');
+  });
+
+  it("스키마 enum에 'SEQUENTIAL'이 포함됨", () => {
+    expect(source).toContain("'SEQUENTIAL'");
+  });
+
+  it("스키마 enum에 'DUAL'이 포함됨", () => {
+    // 'DUAL' 리터럴이 schema enum 배열에 존재함
+    expect(source).toContain("'DUAL'");
+  });
+
+  it("스키마 enum에 'BTI'이 포함됨", () => {
+    expect(source).toContain("'BTI'");
+  });
+
+  it("스키마 default가 'DUAL'로 설정됨", () => {
+    // experimentMode 필드 default 값 확인함
+    // "default: 'DUAL'" 또는 `default: "DUAL"` 형식으로 존재해야 함
+    expect(source).toMatch(/default:\s*['"]DUAL['"]/);
+  });
+
+  it('스키마 required가 true로 설정됨', () => {
+    expect(source).toContain('required: true');
+  });
+});

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -1,4 +1,5 @@
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
+import { ExperimentMode } from '@07-shared/constants/experiment';
 
 /** * 1. 문서 필드 타입 정의
  * ERD의 필드와 Note A 규칙을 반영함
@@ -21,6 +22,7 @@ export interface Session {
   measuredAt: Date | null; // 측정 시작 시점
   stopReason: 'Natural' | 'ManualEarly' | 'HeadsetLost' | 'ProcessError' | null;
   measuredDurationSeconds: number | null;
+  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI)
 }
 
 /** 2. 인스턴스 메서드 타입 정의 */
@@ -94,6 +96,12 @@ const sessionSchema = new Schema<Session, SessionModel, SessionMethods>(
     measuredDurationSeconds: {
       type: Number,
       default: null,
+    },
+    experimentMode: {
+      type: String,
+      enum: ['DUAL', 'SEQUENTIAL', 'BTI'],
+      required: true,
+      default: 'DUAL',
     },
   },
   {

--- a/src/07-shared/constants/experiment.test.ts
+++ b/src/07-shared/constants/experiment.test.ts
@@ -1,0 +1,73 @@
+/**
+ * experiment.ts — EXPERIMENT_MODES 상수 및 ExperimentMode 타입 검증
+ *
+ * 검증 항목:
+ *   - SEQUENTIAL 모드가 상수에 정의됨
+ *   - DUAL, BTI 모드가 기존과 동일하게 유지됨
+ *   - ExperimentMode 타입이 'SEQUENTIAL' 리터럴을 수용함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('experiment.ts: EXPERIMENT_MODES 상수가 올바르게 정의됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'experiment.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('EXPERIMENT_MODES에 DUAL 모드가 정의됨', () => {
+    expect(source).toContain("DUAL: 'DUAL'");
+  });
+
+  it('EXPERIMENT_MODES에 BTI 모드가 정의됨', () => {
+    expect(source).toContain("BTI: 'BTI'");
+  });
+
+  it('EXPERIMENT_MODES에 SEQUENTIAL 모드가 정의됨', () => {
+    expect(source).toContain("SEQUENTIAL: 'SEQUENTIAL'");
+  });
+
+  it('ExperimentMode 타입이 keyof typeof 방식으로 자동 파생됨', () => {
+    // (typeof X)[keyof typeof X] 또는 typeof X[keyof typeof X] 두 형식 모두 허용함
+    const hasParenForm = source.includes(
+      '(typeof EXPERIMENT_MODES)[keyof typeof EXPERIMENT_MODES]'
+    );
+    const hasNonParenForm = source.includes(
+      'typeof EXPERIMENT_MODES[keyof typeof EXPERIMENT_MODES]'
+    );
+    expect(hasParenForm || hasNonParenForm).toBe(true);
+  });
+
+  it('EXPERIMENT_MODES 객체가 as const로 선언됨', () => {
+    expect(source).toContain('as const');
+  });
+});
+
+describe('experiment.ts: EXPERIMENT_MODES 런타임 값 검증', () => {
+  let EXPERIMENT_MODES: Record<string, string>;
+
+  beforeAll(() => {
+    // 파일이 생성된 후에만 require 실행함
+    const filePath = path.resolve(__dirname, 'experiment.ts');
+    const exists = fs.existsSync(filePath);
+    if (exists) {
+      // ts-jest 환경에서 직접 require 가능함
+      EXPERIMENT_MODES = require('./experiment').EXPERIMENT_MODES;
+    }
+  });
+
+  it('EXPERIMENT_MODES.SEQUENTIAL 값이 문자열 SEQUENTIAL임', () => {
+    expect(EXPERIMENT_MODES['SEQUENTIAL']).toBe('SEQUENTIAL');
+  });
+
+  it('EXPERIMENT_MODES.DUAL 값이 문자열 DUAL임', () => {
+    expect(EXPERIMENT_MODES['DUAL']).toBe('DUAL');
+  });
+
+  it('EXPERIMENT_MODES.BTI 값이 문자열 BTI임', () => {
+    expect(EXPERIMENT_MODES['BTI']).toBe('BTI');
+  });
+});

--- a/src/07-shared/constants/experiment.ts
+++ b/src/07-shared/constants/experiment.ts
@@ -1,0 +1,16 @@
+/**
+ * experiment.ts — 실험 모드 상수 정의
+ *
+ * DUAL: 2PC 동시 측정 모드 (기본값)
+ * BTI: BTI 전용 측정 모드
+ * SEQUENTIAL: 1PC 시분할 측정 모드 (Phase 14 P2)
+ */
+
+export const EXPERIMENT_MODES = {
+  DUAL: 'DUAL',
+  BTI: 'BTI',
+  SEQUENTIAL: 'SEQUENTIAL', // 시분할 측정 (1PC 환경, Phase 14 P2)
+} as const;
+
+export type ExperimentMode =
+  (typeof EXPERIMENT_MODES)[keyof typeof EXPERIMENT_MODES];

--- a/src/07-shared/schemas/similarity/_base.ts
+++ b/src/07-shared/schemas/similarity/_base.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * Similarity 스키마 공통 필드 정의
+ * 모든 알고리즘 스키마의 base
+ */
+export const similarityBaseSchema = z.object({
+  algorithm: z.string(),
+  similarity_score: z.number().min(0).max(1),
+});
+
+export type SimilarityBase = z.infer<typeof similarityBaseSchema>;

--- a/src/07-shared/schemas/similarity/_base.ts
+++ b/src/07-shared/schemas/similarity/_base.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { z } from 'zod';
 
 /**
@@ -6,7 +7,7 @@ import { z } from 'zod';
  */
 export const similarityBaseSchema = z.object({
   algorithm: z.string(),
-  similarity_score: z.number().min(0).max(1),
+  similarity_score: z.number().min(0).max(1), // DE API snake_case 키 그대로 유지함
 });
 
 export type SimilarityBase = z.infer<typeof similarityBaseSchema>;

--- a/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
+++ b/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { z } from 'zod';
 import { similarityBaseSchema } from './_base';
 

--- a/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
+++ b/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { similarityBaseSchema } from './_base';
+
+/**
+ * cosine_pearson_faa 알고리즘 유사도 결과 스키마
+ * DE의 CosinePearsonFAAStrategy.compute() 출력 형식과 일치함
+ */
+export const cosinePearsonFAASchema = similarityBaseSchema.extend({
+  overall_cosine: z.number(),
+  band_ratio_diff: z.record(z.string(), z.number()),
+  faa_absolute_diff: z.number().nullable(),
+});
+
+export type CosinePearsonFAAResult = z.infer<typeof cosinePearsonFAASchema>;

--- a/src/07-shared/schemas/similarity/index.ts
+++ b/src/07-shared/schemas/similarity/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Similarity 스키마 레지스트리
+ * 팀원이 새 알고리즘 추가 시: 새 스키마 파일 생성 후 이 map에 등록함
+ */
+import { z } from 'zod';
+import { cosinePearsonFAASchema } from './cosine_pearson_faa.schema';
+
+export { similarityBaseSchema } from './_base';
+export { cosinePearsonFAASchema } from './cosine_pearson_faa.schema';
+export type { SimilarityBase } from './_base';
+export type { CosinePearsonFAAResult } from './cosine_pearson_faa.schema';
+
+/** algorithm 이름 → Zod 스키마 매핑 (새 알고리즘 등록 위치) */
+export const similaritySchemaRegistry: Record<string, z.ZodTypeAny> = {
+  cosine_pearson_faa: cosinePearsonFAASchema,
+  default: cosinePearsonFAASchema,
+};
+
+/**
+ * algorithm 이름으로 스키마를 조회함
+ * 등록되지 않은 이름이면 undefined 반환
+ */
+export function getSimilaritySchema(
+  algorithm: string
+): z.ZodTypeAny | undefined {
+  return similaritySchemaRegistry[algorithm];
+}

--- a/src/07-shared/schemas/similarity/index.ts
+++ b/src/07-shared/schemas/similarity/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Similarity 스키마 레지스트리
  * 팀원이 새 알고리즘 추가 시: 새 스키마 파일 생성 후 이 map에 등록함


### PR DESCRIPTION
## Summary
- Phase 14 (P2 시분할 측정) — BE SEQUENTIAL experimentMode + analysis schema + orchestration
- Wave 1: `EXPERIMENT_MODES.SEQUENTIAL` 상수 + `session.schema.ts`에 `experimentMode` 필드 신규 추가
- Wave 3: `AnalysisResult` schema 확장 (`analysis_mode` enum, `similarity_features` Mongoose Mixed) + `src/07-shared/schemas/similarity/` Zod 패키지
- `sequential-analysis.service.ts` 신규 + `POST /api/analyze/sequential` 엔드포인트 (authenticate + creatorId ownership + Zod validate)
- `engine.controller.ts::triggerPostMeasurementByTier` SEQUENTIAL early-return branch (자동 dispatch 차단, operator "Analyze" 버튼 대기)
- verify Round 1~2 fix: I-1 CRITICAL (proxy `subject_indices` 누락 → DE 422) + eslint `dist/**` ignore

## Verification
- [x] build 0 errors
- [x] lint 0 warnings
- [x] test 102 passed (10 test suites)
- [x] DUAL/BTI regression: 기존 tier 분류 로직 unchanged

## Commits (10)
- 83b8372 feat(shared): add SEQUENTIAL experiment mode constant and schema field
- 8db1215 feat(schema): extend AnalysisResult with analysis_mode and similarity_features
- 47bf4ad feat(post-measurement): add sequential-analysis.service for SEQUENTIAL mode pipeline
- 1f44970 feat(engine): add SEQUENTIAL dispatch branch and POST /analyze/sequential endpoint
- 32dde60 feat(engine): extend /engine/analyze/pipeline schema with mode and similarity_features
- 36a4380 test(post-measurement): add SEQUENTIAL analysis integration tests
- 6fc26c8 style: apply prettier formatting and fix camelcase lint warnings across Wave 3 files
- a3a69da fix(engine): keep subjectIndices required in analyzePipelineSchema
- ccf0bf5 fix(engine): include subject_indices in SEQUENTIAL proxy body to satisfy DE validation
- 61c9e6c chore(lint): ignore dist and coverage output from ESLint scan

## Related
- Plan: \`.plans/14-dual-ble-resolution/PLAN.md\`
- Checklist: \`.plans/14-dual-ble-resolution/CHECKLIST.md\`