### PR TITLE
feat(14): BE SEQUENTIAL analysis pipeline + Phase 14 finishing (dev → main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,104 @@
-# mind-signal-backend (뇌파 시그널 프로젝트)
+# mind-signal-backend
 
-## 1. 📝 프로젝트 개요 (Project Overview)
+## 1. 프로젝트 개요 (Project Overview)
 
+**Mind Signal Backend**는 EEG(뇌파) 기반 2인 심리 동기화 측정 · 분석 서비스의 **백엔드 서버**입니다.
+Operator의 세션 생성 → Subject QR 페어링 → 실시간 EEG 스트리밍 → 사후 분석 파이프라인을 오케스트레이션합니다. Python Data Engine을 세션별로 spawn하고, Redis Pub/Sub으로 수집된 데이터를 Socket.io로 프론트엔드에 브릿지합니다.
+졸업 프로젝트로 실제 협업 경험과 실시간 데이터 파이프라인 운영을 핵심 목표로 합니다.
+
+### 핵심 파이프라인
+
+```
+Emotiv 헤드셋 → Emotiv App → Python Data Engine (spawn)
+              → Redis Pub/Sub → Backend SUBSCRIBE
+              → Socket.io → Frontend 실시간 차트
+```
 
 ---
-## 2. 🛠️ Tech Stack
- 구분 | 기술 |
+
+## 2. Tech Stack
+
+| 구분 | 기술 |
 | :--- | :--- |
-| **Back-end** | `Node.js`, `Express`, `MongoDB`, `TypeScript`, `JWT`, `Jest`, `ESLint` |
-| **External API** | `Google Gemini (LLM)`|
-| **DevOps** | `Heroku`|
+| **Runtime** | `Node.js 20+`, `TypeScript strict` |
+| **Framework** | `Express 4.x`, `Socket.io` |
+| **Architecture** | `Feature-Sliced Design` (커스텀 번호 체계) |
+| **DB / Infra** | `MongoDB Atlas` (Mongoose), `Redis` (Docker Compose) |
+| **Auth** | `JWT` (HS256), `Google OAuth`, `Kakao OAuth` |
+| **Validation** | `Zod` DTO |
+| **Test** | `Jest`, `Supertest` |
+| **Quality** | `ESLint`, `Prettier`, `tsc-alias` |
+| **External Services** | Python Data Engine (`FastAPI` via HTTP proxy), `Google Gemini` |
+| **DevOps** | `Heroku` |
+
 ---
-## 3. 🚀 프로젝트 클론 및 각종 명령어
+
+## 3. 프로젝트 클론 및 각종 명령어
 
 ### 저장소 복제
+
 ```bash
 git clone https://github.com/KWONSEOK02/mind-signal-backend.git
 ```
 
 ### 의존성 설치
+
 ```bash
 npm install
 ```
 
 ### 환경 변수 설정
-.env.example 복사해서 .env.local (로컬) / .env.test (테스트)파일을 생성합니다.
+
+`.env.example`을 복사해서 `.env.local` (로컬) / `.env.test` (테스트) 파일을 생성합니다.
+
+```bash
+cp .env.example .env.local
+```
+
+### 로컬 인프라 (Redis) 기동 / 정리
+
+```bash
+npm run infra:up      # Docker Compose로 Redis 컨테이너 기동
+npm run infra:down    # 컨테이너 정리
+npm run test:redis    # Redis 연결 헬스체크
+```
 
 ### 개발 서버 실행
+
 ```bash
-npm run dev 
-``` 
-### 테스트 서버 실행
+npm run dev
+```
+
+### 테스트
+
 ```bash
 npm run test
-``` 
-### prettier 실행 (코드 포맷 정리)
-```bash
-npm run format
-``` 
+```
 
-### 린트 검사
+### 포맷 자동 수정 / 검증
+
+```bash
+npm run format                        # Prettier --write
+npx prettier --check "src/**/*.ts"    # CI와 동일 검증
+```
+
+### 린트
+
 ```bash
 npm run lint
 npm run lint:fix
- ``` 
+```
 
-### 도커 실행 및 redis 태스트 실행
+### 빌드
+
 ```bash
-npm run infra:up
-npm run infra:down
-npm run test:redis
-npm run data:run
-
+npm run build
 ```
 
 ---
 
 ## 4. API 엔드포인트
+
 | Method | Endpoint | 설명 |
 | :--- | :--- | :--- |
 | **POST** | `/auth/signup` | 회원가입 |
@@ -73,7 +115,8 @@ npm run data:run
 
 ---
 
-## 5. 📁 프로젝트 구조
+## 5. 프로젝트 구조
+
 ```
 mind-signal-backend/
 ├── node_modules/           # Node.js 모듈
@@ -132,7 +175,7 @@ mind-signal-backend/
 └── tsconfig.json           # TypeScript 컴파일러 설정 파일
 ```
 
-### 💡 폴더 구조 표현 원칙
+### 폴더 구조 표현 원칙
 
 이 프로젝트의 FSD (Feature-Sliced Design) 폴더 구조는 다음과 같은 원칙에 따라 README.md에 표현됩니다:
 
@@ -167,78 +210,143 @@ Sessions: **QR 코드를 보여주기 위한 세션 생성/조회 기능만** 05
 
 ---
 
-## 7. 🤝 협업 가이드라인 (Contribution Guidelines)
+## 7. 협업 가이드라인 (Contribution Guidelines)
 
 ### Git Workflow
-- `master` (Production): 최종 배포 브랜치
-- `develop` (Staging): 개발 완료 코드를 병합하는 메인 브랜치
-- `feat/*`, `fix/*`, `docs/*`: 기능별, 목적별 브랜치
 
-### 작업 흐름
-1. `develop` 브랜치에서 `feat/my-new-feature` 브랜치를 생성하여 작업을 시작합니다.
-2. 기능 완료 후 **Pull Request(PR)** 를 생성합니다.
-3. 1명 이상의 팀원에게 **Approve(리뷰 승인)** 를 받습니다.
-4. Merge 전, `develop` 최신 변경 사항을 `pull` 하여 충돌을 최소화합니다.
+- `main` (Production): 최종 배포 브랜치 — 직접 push 금지. `dev`에서만 PR 올림
+- `dev` (Staging): 개발 통합 브랜치 — 모든 `feat/*` 기능 브랜치의 PR 대상
+- `feat/#{이슈번호}-{작업명}`: 이슈 기반 기능 브랜치
+- `fix/#{이슈번호}-{작업명}`: 이슈 기반 버그 수정 브랜치
+- `docs/#{이슈번호}-{작업명}`: 문서 작업 브랜치
+- `refactor/#{이슈번호}-{작업명}`, `chore/#{이슈번호}-{작업명}`: 그 외 목적별 브랜치
+
+### 작업 흐름 (모든 변경은 이슈 기반)
+
+모든 코드 변경은 반드시 **GitHub Issue를 먼저 생성**한 뒤 진행합니다. **`main` 직접 commit은 금지**이며, `dev` 직접 commit도 원칙적으로 금지합니다. 오타·로컬 세팅·사소한 문서 수정도 예외 없이 이슈 → 브랜치 → PR 절차를 따릅니다.
+
+1. **Issue 생성**: GitHub Issues → New Issue → 템플릿 선택 후 작업 내용 등록 (제목: `feat: 작업 내용`)
+2. **브랜치 생성**: 이슈 페이지 Development → Create a branch → **base를 `dev`로 설정** → `타입/#{이슈번호}-{작업명}` 형식
+3. **개발**: 기능 구현. 커밋 전 로컬 검증(§8) 통과 필수
+4. **PR**: **base를 `dev`로 설정**하여 PR 생성 (main 아님). Reviewers / Assignees / Labels 지정
+5. **코드리뷰**: 팀원 1명 이상의 Approve + CodeRabbit 리뷰 확인
+6. **머지**: 승인 완료 후 `feat/*` → `dev` 머지
+7. **Issue Close**: 머지 직후 해당 이슈 close
+8. **릴리스**: `dev`가 안정화되면 `dev` → `main` PR을 별도 생성, CI + CodeRabbit 리뷰 통과 후 머지
 
 ### 프로젝트 규칙
-- **PR은 작은 단위로.** 하나의 PR은 하나의 기능에만 집중합니다.
-- 세부 작업은 체크리스트로 관리합니다.
-- 작업 충돌을 방지하기 위해 회의 중 역할을 명확히 나눕니다.
+
+- **PR은 작은 단위로.** 하나의 PR은 하나의 이슈 · 하나의 기능에만 집중합니다.
+- 세부 작업은 이슈 체크리스트로 관리합니다.
+- 머지 직전 `dev` 최신 변경 사항을 `pull` 하여 충돌을 최소화합니다.
 
 ### 개발 가이드라인
+
 - 코딩 스타일: **ESLint + Prettier** 기준
-- 변수 네이밍 규칙: **camelCase / PascalCase**   
-- 폴더 네이밍 규칙: **kebab-case** (-)사용, **복수형**(s)사용, 도메인/개념 단위 명사로만 구성, 역할(role)은 폴더가 아니라 내부 파일에서 표현
-- 파일 네이밍 규칙: **단수형 사용**, **kebab-case + dot(.)** role suffix, 역할이 있을 때만 dot으로 구분, 의미 단위가 하나면 dot 없이 사용 가능
-- 주석 스타일: **JSDoc (Google Style)**
-- TypeScript strict mode 사용
-
-### 커밋 및 브랜치 컨벤션
-- 커밋 메시지 및 브랜치는 **Conventional Commits 규칙 준수**
-
-
-📄 상세 컨벤션 문서 (Notion)  
+- 변수 / 함수 네이밍: **camelCase**
+- 폴더 네이밍: **kebab-case**, 복수형 (도메인/개념 단위 명사로만 구성)
+- 파일 네이밍: **단수형**, **kebab-case + dot(.)** role suffix (예: `auth.service.ts`, `sessions.route.ts`)
+- TypeScript strict mode, `any` 금지 — `unknown` 또는 명시 타입
+- 주석 스타일: JSDoc (Google Style), 종결 어미는 명사형 (`~함`, `~처리`, `~반환`)
 
 ---
 
-## 📝 커밋 컨벤션
-**Conventional Commits** 규칙 준수
+## 8. CI 파이프라인 & AI 코드 리뷰
 
-- `feat:` 새 기능
-- `fix:` 버그 수정
-- `docs:` 문서 변경
-- `style:` 코드 포매팅, 공백/정렬, 주석 정리 등 로직 변경이 없는 스타일 수정
-- `refactor:` 코드 리팩토링
-- `perf:` 성능 개선
-- `test:` 테스트 관련
-- `chore:` 빌드·배포·패키지 설정, 설정 파일 수정, 잡무성 정리 작업
-- `ci:` CI 설정
-- `revert:` 이전 커밋 되돌리기
+PR이 올라오면 아래 순서로 자동 검증됩니다. **모든 단계를 통과해야 머지 가능합니다.**
 
-**메시지 형식**
 ```
-feat(sessions): pairing token 기반 세션 생성 API 추가
-style(auth): 불필요한 주석 제거 및 포맷 정리
-refactor(shared): 공통 설정 로딩 구조 개선
-docs(readme): 커밋 컨벤션 규칙 수정
+  PR 생성
+     ↓
+┌─── CI 자동 검증 ──────────────────────────────┐
+│ 1. lint              → ESLint 정적 분석       │
+│ 2. prettier --check  → 포맷 검증 (CI 전용)    │  ← FAIL 시
+│ 3. test              → Jest 유닛 테스트       │     머지 차단
+│ 4. build             → tsc + tsc-alias        │
+└────────────────────────────────────────────────┘
+     ↓ CI 통과한 코드만
+┌─── CodeRabbit AI 리뷰 ────────────────────────┐
+│ • FSD 레이어 위반 / any 타입                  │
+│ • 비즈니스 로직 / 트랜잭션 경계 / 보안        │
+│ • Zod 검증 누락 / 에러 핸들링                 │
+└────────────────────────────────────────────────┘
 ```
+
+### CI가 자동으로 잡아주는 것
+
+| 도구 | 검증 항목 |
+|------|----------|
+| **ESLint** | 코드 품질, 사용하지 않는 변수, import 순서 |
+| **Prettier** | 포맷, 들여쓰기, 줄바꿈 (CI는 `npx prettier --check "src/**/*.ts"`) |
+| **Jest** | 유닛 테스트 (MongoDB · Redis 미연결, 소스 파일 기반 테스트) |
+| **TypeScript build** | `tsc` + `tsc-alias` — 타입 에러 · 경로 별칭 변환 실패 |
+
+### PR 전 로컬에서 확인하는 법
+
+```bash
+npm run lint:fix                         # 린트 자동 수정
+npx prettier --check "src/**/*.ts"       # 포맷 검증 (CI 동일 명령)
+npm run test                             # Jest
+npm run build                            # tsc + tsc-alias
+```
+
+순서: `lint:fix → prettier --check → test → build` — 한 단계라도 실패하면 멈추고 수정 후 재실행.
+
+Integration 테스트가 필요하면 `npm run infra:up`으로 로컬 Redis를 먼저 기동하고, CI 대상 테스트는 mock으로 격리합니다.
+
 ---
 
-## 🌱 Git 브랜치 네이밍 컨벤션 (요약)
+## 9. 커밋 메시지 컨벤션
 
-- **feature/** → 새로운 기능 / 알고리즘 / 환경 추가  
-  예) `feature/eeg-record-upload`, `feature/admin-access-control`
+**Conventional Commits** 규칙을 따릅니다. Gitmoji 이모지는 사용하지 않습니다.
 
-- **fix/** → 버그 수정  
-  예) `fix/session-expire-time-bug`, `fix/jwt-expiration-handling`
+### 형식
 
-- **hotfix/** → 긴급 수정  
-  예) `hotfix/env-secret-missing`
+```
+{type}({scope}): {description}
+```
 
-- **refactor/** → 코드 구조 개선  
-  예) `refactor/auth-middleware-split`, `refactor/shared-error-structure`
+예시:
 
-- **docs/** → 문서 작업  
-  예) `docs/folder-naming-convention`, `docs/update-readme-structure`
+```
+feat(sessions): add pairing token-based session creation API
+fix(auth): handle JWT expiry in refresh flow
+refactor(measurement): extract engine proxy service
+chore(deps): bump socket.io to 4.8.0
+```
+
+### 타입 목록
+
+| 타입 | 용도 |
+|------|------|
+| feat | 새 기능 |
+| fix | 버그 수정 |
+| refactor | 리팩토링 (기능 변경 없는 구조 개선) |
+| style | 포맷·세미콜론·공백 (로직 변경 없음) |
+| docs | 문서 변경 |
+| chore | 빌드·설정·패키지 |
+| test | 테스트 추가·수정 |
+| perf | 성능 개선 |
+| ci | CI 설정 |
+| revert | 이전 커밋 되돌리기 |
+
+- 태스크 1개 = 커밋 1개
+- `main` 브랜치 직접 commit 금지 — 반드시 `feat/#{이슈번호}-{작업명}` 브랜치에서 작업 후 `dev`로 PR
 
 ---
+
+## 10. 브랜치 네이밍 컨벤션
+
+```
+{타입}/#{이슈번호}-{작업명}
+```
+
+예시:
+
+- `feat/#14-sequential-analysis-service`
+- `fix/#27-jwt-refresh-token-handling`
+- `docs/#31-readme-ci-section`
+- `refactor/#22-engine-proxy-extract`
+- `chore/#18-upgrade-express-5`
+
+이슈에서 "Create a branch"로 자동 생성할 때 base branch는 항상 `dev`로 설정합니다.

--- a/docs/md/changelog-timeline-guide.md
+++ b/docs/md/changelog-timeline-guide.md
@@ -1,0 +1,237 @@
+# CHANGELOG / TIMELINE 작성 가이드 — Mind Signal
+
+> 이 문서는 Mind Signal 프로젝트의 CHANGELOG와 PROJECT TIMELINE 작성 규칙을 정의한다.
+> PM이 merge 후 갱신하고, 팀원은 읽기 전용으로 Notion에서 확인한다.
+
+---
+
+## 0. Notion 페이지 ID (단일 진실원)
+
+`notion-update-page` / `notion-fetch` 호출 시 사용하는 page_id. 이 문서가 유일한 기록처다.
+
+| 문서 | Notion Page ID | URL |
+|------|---------------|-----|
+| **CHANGELOG** | `346f32b0-e268-8149-b0bb-f5f22912cc39` | https://www.notion.so/346f32b0e2688149b0bbf5f22912cc39 |
+| **PROJECT TIMELINE** | `346f32b0-e268-810a-83cd-de374c52acfe` | https://www.notion.so/346f32b0e268810a83cdde374c52acfe |
+| (부모) 아키텍처 진화 | `307f32b0-e268-805c-b8ec-fd742e6894d2` | https://www.notion.so/307f32b0e268805cb8ecfd742e6894d2 |
+
+부모 페이지에는 Phase 0(2026-01 ~ 2026-03-22) Gantt / Phase 1~3 아키텍처 다이어그램 / ADR 8건이 보존되어 있다. Phase 01 이후의 변경 이력과 진행 상태는 위 CHANGELOG / PROJECT TIMELINE 하위 페이지에서만 관리한다.
+
+---
+
+## 1. 두 문서의 역할 구분
+
+| 문서 | 핵심 질문 | 업데이트 시점 |
+|------|-----------|--------------|
+| **CHANGELOG** | "언제 뭐가 바뀌었는지" (변경 이력) | 브랜치 merge 후 |
+| **PROJECT TIMELINE** | "지금 어디까지 왔고, 다음에 뭘 해야 하는지" (진행 상황) | 마일스톤 달성 시 또는 주 1회 |
+
+Swagger UI는 별도 — "현재 BE API 스펙이 뭔지" (엔드포인트, 파라미터)를 담당한다.
+
+---
+
+## 2. CHANGELOG — Keep a Changelog 기반
+
+### 2.1 기반 컨벤션
+
+[Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/) + [Semantic Versioning](https://semver.org/)을 따른다.
+
+### 2.2 전체 구조
+
+```markdown
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Planned
+- Phase 15 template-intent-retrofit — 준비 완료, Phase 14 머지 후 착수
+
+## [0.14.0] - 2026-04-18 — Phase 14 dual-ble-resolution
+### Added
+- SEQUENTIAL 측정 모드 — 1 PC에서 헤드셋 순차 연결
+- similarity 계산 Strategy Pattern + Plugin Registry
+
+### Changed
+- engine.controller / engine.routes / app.router 측정 모드 라우팅
+
+## [0.13.0] - 2026-04-18 — Phase 13 dual-headset-connection
+### Added
+- 조기 종료 버튼 + stop-all API (FE #34)
+```
+
+### 2.3 카테고리 (6종 고정)
+
+| 카테고리 | 의미 | 예시 |
+|----------|------|------|
+| **Added** | 새 기능 추가 | 새 API 엔드포인트, 새 모듈 |
+| **Changed** | 기존 기능 변경 | API 응답 형식 변경, 구조 리팩터링 |
+| **Deprecated** | 곧 제거될 기능 | v0.3.0에서 제거 예정인 레거시 엔드포인트 |
+| **Removed** | 제거된 기능 | 더 이상 사용하지 않는 API |
+| **Fixed** | 버그 수정 | NullPointerException 수정 |
+| **Security** | 보안 취약점 수정 | 인증 토큰 검증 로직 강화 |
+
+### 2.4 작성 규칙
+
+1. **날짜 형식**: `YYYY-MM-DD` (ISO 8601)
+2. **역순 정렬**: 최신 버전이 맨 위
+3. **`[Unreleased]` 섹션 항상 유지**: 다음 릴리스에 포함될 변경사항을 먼저 기록
+4. **버전 형식**: `MAJOR.MINOR.PATCH`
+   - MAJOR: 호환 안 되는 API 변경 (1.0.0 전까지는 0.x.x 사용)
+   - MINOR: 하위 호환되는 기능 추가
+   - PATCH: 하위 호환되는 버그 수정
+5. **한 항목 = 한 줄**: 동사로 시작, 무엇을/왜를 간결하게
+   - 올바름: `조기 종료 버튼 + stop-all API 추가 (FE #34)`
+   - 잘못됨: `여러 가지 수정함`
+6. **해당 없는 카테고리는 생략**: 빈 섹션을 남기지 않는다
+7. **관련 이슈/PR 번호 링크**: 가능하면 `(FE #34)` `(BE #31)` `(DE #11)` 형태로 참조
+
+### 2.5 Phase-버전 매핑 규칙
+
+Mind Signal은 "Phase 번호 → `v0.{PhaseNum}.0`" 규칙을 따른다. Phase 완료 시 해당 버전 릴리스.
+
+| Phase | 버전 | 예시 |
+|-------|------|------|
+| Phase 01 | v0.1.0 | chat-api-integration |
+| Phase 02 | v0.2.0 | phase5-integration |
+| ... | ... | ... |
+| Phase 14 | v0.14.0 | dual-ble-resolution |
+
+Phase 09는 실제 없음 → 버전 번호도 스킵. 여러 Phase를 한 번에 릴리스할 경우 각각 별도 버전 엔트리로 기록한다.
+
+### 2.6 merge 후 업데이트 플로우
+
+```
+1. feature 브랜치 merge → main/dev
+2. [Unreleased] 섹션에 변경사항 추가 (카테고리별)
+3. Phase 완료 시: [Unreleased] → [x.y.z] - YYYY-MM-DD 로 변환
+4. Notion CHANGELOG 페이지에 notion-update-page 로 동기화
+5. notion-fetch 로 검증
+6. 팀 공지 채널에 "✅ feat/xxx merge → [Notion 링크]" 공지
+```
+
+---
+
+## 3. PROJECT TIMELINE — 마일스톤 기반 진행 추적
+
+### 3.1 기반 컨벤션
+
+공식 표준은 없다. GitHub 오픈소스 ROADMAP.md 패턴과 개발 커뮤니티 관행을 종합한 자체 형식이다.
+
+### 3.2 전체 구조
+
+```markdown
+> Mind Signal 프로젝트 진행 상황 추적 문서.
+
+## 현재 상태
+
+| 항목 | 값 |
+|------|---|
+| **현재 Phase** | Phase 14 — dual-ble-resolution (execute 완료 / verify 대기) |
+| **마지막 업데이트** | 2026-04-18 |
+| **다음 마일스톤** | Phase 14 verify 통과 + 3 PR 머지 → Phase 15 착수 |
+
+---
+
+## Phase 13 — dual-headset-connection ✅
+
+> EMOTIV 2대 동시 연결 + 운영 안정성
+
+- [✅] `2026-04-18` FE #38 dev → main 머지 + MyResultsList UI — **v0.13.0 릴리스**
+
+---
+
+## Phase 14 — dual-ble-resolution 🔄
+
+> 1PC에서 BLE 직접 연결로 2대 순차 측정 구현
+
+### 완료
+- [✅] `2026-04-18` plan-review 3라운드 🟢 PASS
+- [✅] `2026-04-18` Wave 1~4 execute 완료 (23 commits)
+
+### 진행중
+- [ ] `~2026-04-19` verify 실행
+- [ ] `~2026-04-20` 3 PR 머지 → **v0.14.0 릴리스 확정**
+
+---
+
+## Phase 15 — template-intent-retrofit 📋
+
+> llm-setup-templates v1.0.0 의도를 FE+BE에 이식
+
+- [✅] `2026-04-18` DISCUSS.md + PLAN.md 저장, plan-review PASS
+- [ ] Phase 14 verify 통과 후 착수
+```
+
+### 3.3 작성 규칙
+
+1. **Phase 단위로 구분**: 각 Phase에 한 줄 목표 설명 (blockquote)
+2. **상태 이모지**:
+   - `✅` 완료된 Phase
+   - `🔄` 진행중인 Phase (execute 진입 후)
+   - `📋` 예정된 Phase (plan-review 통과했어도 execute 전이면 📋)
+3. **체크박스**: `[✅]` 완료, `[ ]` 미완료
+4. **날짜 표기**:
+   - 완료 항목: `2026-04-01` (확정 날짜)
+   - 진행중/예정: `~2026-04-10` (목표 날짜, `~` 접두사)
+   - 날짜 미정: 날짜 생략
+5. **현재 상태 테이블**: 문서 최상단에 현재 Phase, 마지막 업데이트, 다음 마일스톤을 표시
+6. **릴리스 연결**: Phase 완료 시 해당 CHANGELOG 버전을 명시 (예: `— v0.14.0 릴리스`)
+7. **3단 분류** (진행중 Phase만):
+   - **완료**: 이미 끝난 항목
+   - **진행중**: 현재 작업 중
+   - **예정**: 이번 Phase에서 할 예정이지만 아직 시작 안 함
+
+### 3.4 업데이트 플로우
+
+```
+1. 마일스톤 달성 시:
+   - 해당 항목 [✅]로 체크 + 확정 날짜 기입
+   - "현재 상태" 테이블의 다음 마일스톤 갱신
+2. Phase 완료 시:
+   - Phase 상태를 🔄 → ✅ 로 변경
+   - 다음 Phase를 📋 → 🔄 로 변경 (execute 시작 시점)
+3. Notion PROJECT TIMELINE 페이지에 notion-update-page 로 동기화
+```
+
+---
+
+## 4. Notion 운영 규칙
+
+### 4.1 페이지 구조
+
+```
+📁 Mind Signal — 프로젝트 타임라인 & 아키텍처 진화 (부모, 307f32b0...)
+├── 📋 CHANGELOG    ← PM만 편집, 팀원 읽기 전용 (346f32b0...2912cc39)
+└── 🗓️ PROJECT TIMELINE  ← PM만 편집, 팀원 읽기 전용 (346f32b0...4c52acfe)
+```
+
+부모 페이지는 **Phase 0 아카이브** — 2026-01 ~ 2026-03-22 Gantt / Phase 1~3 아키텍처 다이어그램 / ADR 8건이 동결 보존. 편집 금지.
+
+### 4.2 팀 공지 (디스코드/슬랙 등)
+
+merge가 완료되면 팀 채널에 아래 형식으로 공지:
+
+```
+✅ feat/14-sequential-backend merge → [Notion CHANGELOG](링크) | [TIMELINE](링크)
+```
+
+> 현재 Mind Signal 팀의 공식 공지 채널이 확정되지 않았다면, 팀 규칙 수립 후 이 섹션의 `링크`를 실제 채널 템플릿으로 교체한다.
+
+팀원은:
+1. Notion CHANGELOG로 "뭐가 바뀌었는지" 확인
+2. PROJECT TIMELINE으로 "다음에 뭘 해야 하는지" 확인
+3. Swagger UI로 "현재 API 스펙" 확인 후 다음 작업 시작
+
+---
+
+## 5. 참고 자료
+
+- [Keep a Changelog v1.1.0](https://keepachangelog.com/en/1.1.0/)
+- [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [Common Changelog](https://common-changelog.org/) — Keep a Changelog의 더 엄격한 변형
+- [git-cliff](https://github.com/orhun/git-cliff) — Git 히스토리에서 CHANGELOG 자동 생성 도구
+- 범용 가이드 (볼트): `Guide/CHANGELOG and Project Timeline Keep a Changelog Guide.md`
+- CheckMate 패턴 참조: `checkmate-web/docs/md/changelog-timeline-guide.md`

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ import prettierConfig from "eslint-config-prettier";
 
 export default [
   {
+    ignores: ["dist/**", "node_modules/**", "coverage/**"],
+  },
+  {
     files: ["**/*.ts"],
     languageOptions: {
       parser: tsParser,

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,12 @@ module.exports = {
     testEnvironment: 'node',
     moduleNameMapper: {
       '^@/(.*)$': '<rootDir>/src/$1', // 테스트에서도 절대 경로(@/) 인식
+      '^@01-app/(.*)$': '<rootDir>/src/01-app/$1',
+      '^@02-processes/(.*)$': '<rootDir>/src/02-processes/$1',
+      '^@03-pages/(.*)$': '<rootDir>/src/03-pages/$1',
+      '^@04-widgets/(.*)$': '<rootDir>/src/04-widgets/$1',
+      '^@05-features/(.*)$': '<rootDir>/src/05-features/$1',
+      '^@06-entities/(.*)$': '<rootDir>/src/06-entities/$1',
+      '^@07-shared/(.*)$': '<rootDir>/src/07-shared/$1', // FSD 레이어 절대 경로 인식
     },
   };

--- a/src/01-app/app.router.ts
+++ b/src/01-app/app.router.ts
@@ -7,6 +7,7 @@ import { measurementApi } from '@02-processes/measurements';
 import engineRouter from '@02-processes/engine/api/engine.routes';
 import { chatApi } from '@05-features/neuro-chats';
 import analysisRouter from '@05-features/analysis-results/api/analysis.routes';
+import sequentialRouter from '@02-processes/post-measurement/api/sequential.routes';
 
 const router = Router();
 
@@ -18,5 +19,7 @@ router.use('/measurements', measurementApi);
 router.use('/engine', engineRouter);
 router.use('/chat', chatApi);
 router.use('/analysis', analysisRouter);
+// SEQUENTIAL 모드 분석 엔드포인트 등록함 (최종 URL: /api/analyze/sequential)
+router.use('/analyze', sequentialRouter);
 
 export default router;

--- a/src/02-processes/engine/api/engine.controller.test.ts
+++ b/src/02-processes/engine/api/engine.controller.test.ts
@@ -76,8 +76,8 @@ describe('sequential.routes.ts: POST /sequential 라우트 정적 검증', () =>
     expect(source).toContain('groupId');
   });
 
-  it('algorithm 필드가 optional로 처리됨', () => {
-    expect(source).toContain('optional');
+  it("algorithm 필드가 Zod default('default')로 처리됨", () => {
+    expect(source).toContain("default('default')");
   });
 
   it('creatorId 소유권 검증 로직이 존재함', () => {

--- a/src/02-processes/engine/api/engine.controller.test.ts
+++ b/src/02-processes/engine/api/engine.controller.test.ts
@@ -1,0 +1,119 @@
+/**
+ * engine.controller.ts — SEQUENTIAL 분기 정적 검증
+ *
+ * 검증 항목:
+ *   - triggerPostMeasurementByTier에 SEQUENTIAL 분기가 추가됨
+ *   - SEQUENTIAL 모드 시 기존 tier 분류 로직이 실행되지 않고 조기 반환함
+ *   - DUAL/BTI 모드 시 기존 tier 분류 로직(VALID/PARTIAL/ABORTED)이 그대로 유지됨
+ *   - app.router.ts에 sequentialRouter 등록이 존재함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('engine.controller.ts: SEQUENTIAL dispatch 분기가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.controller.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('triggerPostMeasurementByTier 함수가 존재함', () => {
+    expect(source).toContain('triggerPostMeasurementByTier');
+  });
+
+  it("SEQUENTIAL 모드 분기가 존재함 (experimentMode === 'SEQUENTIAL')", () => {
+    expect(source).toContain('SEQUENTIAL');
+  });
+
+  it('SEQUENTIAL 분기에서 emitLiveEvent를 호출함', () => {
+    expect(source).toContain('emitLiveEvent');
+  });
+
+  it('SEQUENTIAL 분기에서 early return이 존재함', () => {
+    // SEQUENTIAL 분기 내 return이 있어야 기존 tier 로직 건너뜀
+    expect(source).toMatch(/SEQUENTIAL[\s\S]*?return/);
+  });
+
+  it('기존 VALID tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'VALID'");
+  });
+
+  it('기존 PARTIAL tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'PARTIAL'");
+  });
+
+  it('기존 ABORTED tier 분류 로직이 유지됨', () => {
+    expect(source).toContain("'ABORTED'");
+  });
+
+  it('experimentMode를 대표 세션에서 조회함', () => {
+    expect(source).toContain('experimentMode');
+  });
+});
+
+describe('sequential.routes.ts: POST /sequential 라우트 정적 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../post-measurement/api/sequential.routes.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('authenticate 미들웨어를 사용함', () => {
+    expect(source).toContain('authenticate');
+  });
+
+  it('validate 미들웨어를 사용함', () => {
+    expect(source).toContain('validate');
+  });
+
+  it('groupId 필드 검증이 있음', () => {
+    expect(source).toContain('groupId');
+  });
+
+  it('algorithm 필드가 optional로 처리됨', () => {
+    expect(source).toContain('optional');
+  });
+
+  it('creatorId 소유권 검증 로직이 존재함', () => {
+    expect(source).toContain('creatorId');
+  });
+
+  it('403 에러 응답이 존재함', () => {
+    expect(source).toContain('403');
+  });
+
+  it('runSequentialAnalysisPipeline을 호출함', () => {
+    expect(source).toContain('runSequentialAnalysisPipeline');
+  });
+
+  it('200 응답으로 { success: true, result }를 반환함', () => {
+    expect(source).toContain('success: true');
+  });
+});
+
+describe('app.router.ts: sequentialRouter 등록 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../../01-app/app.router.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('sequentialRouter를 import함', () => {
+    expect(source).toContain('sequentialRouter');
+  });
+
+  it("/analyze 경로에 sequentialRouter가 등록됨", () => {
+    expect(source).toContain("'/analyze'");
+    expect(source).toContain('sequentialRouter');
+  });
+});

--- a/src/02-processes/engine/api/engine.controller.test.ts
+++ b/src/02-processes/engine/api/engine.controller.test.ts
@@ -101,10 +101,7 @@ describe('app.router.ts: sequentialRouter 등록 검증', () => {
   let source: string;
 
   beforeAll(() => {
-    const filePath = path.resolve(
-      __dirname,
-      '../../../01-app/app.router.ts'
-    );
+    const filePath = path.resolve(__dirname, '../../../01-app/app.router.ts');
     source = fs.readFileSync(filePath, 'utf-8');
   });
 
@@ -112,7 +109,7 @@ describe('app.router.ts: sequentialRouter 등록 검증', () => {
     expect(source).toContain('sequentialRouter');
   });
 
-  it("/analyze 경로에 sequentialRouter가 등록됨", () => {
+  it('/analyze 경로에 sequentialRouter가 등록됨', () => {
     expect(source).toContain("'/analyze'");
     expect(source).toContain('sequentialRouter');
   });

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -10,12 +10,30 @@ const MIN_ANALYSIS_SECONDS = 180;
 
 /**
  * 3-tier 분류 후 적절한 분석 파이프라인 트리거함
+ * - SEQUENTIAL: 자동 트리거 안 함. operator "Analyze" 버튼(POST /api/analyze/sequential) 대기함
  * - VALID: measuredDurationSeconds >= MIN_ANALYSIS_SECONDS
  * - PARTIAL: 한쪽만 VALID
  * - ABORTED: 둘 다 INVALID
  */
 async function triggerPostMeasurementByTier(groupId: string) {
   const { Session: SessionModel } = await import('@06-entities/sessions');
+
+  // SEQUENTIAL 모드 조기 분기: 자동 분석 트리거 안 함 (I2 + N1)
+  const representativeSession = await SessionModel.findOne({ groupId }).sort({
+    subjectIndex: 1,
+  });
+  const experimentMode = representativeSession?.experimentMode ?? 'DUAL';
+
+  if (experimentMode === 'SEQUENTIAL') {
+    // operator "Analyze" 버튼 대기 — 소켓으로 측정 완료만 알림
+    SocketService.emitLiveEvent('analysis-status', {
+      groupId,
+      tier: 'SEQUENTIAL',
+      message: 'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
+    });
+    return;
+  }
+
   const completedSessions = await SessionModel.find({
     groupId,
     status: 'COMPLETED',

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -19,9 +19,11 @@ async function triggerPostMeasurementByTier(groupId: string) {
   const { Session: SessionModel } = await import('@06-entities/sessions');
 
   // SEQUENTIAL 모드 조기 분기: 자동 분석 트리거 안 함 (I2 + N1)
-  const representativeSession = await SessionModel.findOne({ groupId }).sort({
-    subjectIndex: 1,
-  });
+  // subjectIndex: { $ne: null } 필터로 null 세션이 대표 세션으로 선택되는 경우 방지함
+  const representativeSession = await SessionModel.findOne({
+    groupId,
+    subjectIndex: { $ne: null },
+  }).sort({ subjectIndex: 1 });
   const experimentMode = representativeSession?.experimentMode ?? 'DUAL';
 
   if (experimentMode === 'SEQUENTIAL') {

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -29,7 +29,8 @@ async function triggerPostMeasurementByTier(groupId: string) {
     SocketService.emitLiveEvent('analysis-status', {
       groupId,
       tier: 'SEQUENTIAL',
-      message: 'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
+      message:
+        'SEQUENTIAL 모드 측정 완료. "Analyze" 버튼으로 분석을 시작하세요.',
     });
     return;
   }

--- a/src/02-processes/engine/api/engine.routes.test.ts
+++ b/src/02-processes/engine/api/engine.routes.test.ts
@@ -1,0 +1,109 @@
+/**
+ * engine.routes.ts — analyzePipelineSchema mode/similarity_features 확장 검증
+ *
+ * 검증 항목:
+ *   - analyzePipelineSchema에 mode 필드(enum)가 추가됨
+ *   - mode: 'SEQUENTIAL', 'DUAL', 'BTI' 모두 허용됨
+ *   - mode: 'INVALID' 시 파싱 실패함
+ *   - algorithm 필드가 추가됨
+ *   - 기존 groupId, subjectIndices 검증이 유지됨
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('engine.routes.ts: analyzePipelineSchema 확장 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.routes.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it("analyzePipelineSchema에 mode 필드가 추가됨 (z.enum(['DUAL','SEQUENTIAL','BTI']))", () => {
+    expect(source).toContain('mode');
+    expect(source).toContain("z.enum(['DUAL', 'SEQUENTIAL', 'BTI'])");
+  });
+
+  it("mode 필드의 default가 'DUAL'로 설정됨", () => {
+    expect(source).toMatch(/mode[\s\S]*?default\('DUAL'\)/);
+  });
+
+  it('algorithm 필드가 analyzePipelineSchema에 추가됨', () => {
+    expect(source).toContain('algorithm');
+  });
+
+  it("algorithm 필드의 default가 'default'로 설정됨", () => {
+    expect(source).toMatch(/algorithm[\s\S]*?default\('default'\)/);
+  });
+
+  it('기존 groupId 검증이 유지됨', () => {
+    expect(source).toContain('groupId');
+  });
+});
+
+describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
+  let analyzePipelineSchema: import('zod').ZodTypeAny | undefined;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'engine.routes.ts');
+    const hasFile = fs.existsSync(filePath);
+    if (!hasFile) return;
+
+    // 소스에서 z.object 형식으로 정의된 스키마를 직접 파싱하기 위해 zod 활용함
+    // engine.routes.ts는 Router를 export하므로 직접 import 불가
+    // zod를 통해 독립적으로 스키마 생성하여 검증함
+    const { z } = require('zod');
+    analyzePipelineSchema = z.object({
+      groupId: z.string().min(1),
+      subjectIndices: z.array(z.number().int().positive()).optional(),
+      mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
+      algorithm: z.string().optional().default('default'),
+    });
+  });
+
+  it("mode: 'SEQUENTIAL'이 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'SEQUENTIAL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'DUAL'이 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'DUAL',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'BTI'가 스키마 검증을 통과함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'BTI',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("mode: 'INVALID' 시 스키마 검증 실패함", () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      mode: 'INVALID',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('mode 미지정 시 default DUAL이 적용됨', () => {
+    if (!analyzePipelineSchema) return;
+    const result = analyzePipelineSchema.safeParse({ groupId: 'grp_test' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as any).mode).toBe('DUAL');
+    }
+  });
+});

--- a/src/02-processes/engine/api/engine.routes.test.ts
+++ b/src/02-processes/engine/api/engine.routes.test.ts
@@ -56,7 +56,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     const { z } = require('zod');
     analyzePipelineSchema = z.object({
       groupId: z.string().min(1),
-      subjectIndices: z.array(z.number().int().positive()).optional(),
+      subjectIndices: z.array(z.number().int().positive()),
       mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
       algorithm: z.string().optional().default('default'),
     });
@@ -66,6 +66,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'SEQUENTIAL',
     });
     expect(result.success).toBe(true);
@@ -75,6 +76,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'DUAL',
     });
     expect(result.success).toBe(true);
@@ -84,6 +86,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'BTI',
     });
     expect(result.success).toBe(true);
@@ -93,6 +96,7 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
     if (!analyzePipelineSchema) return;
     const result = analyzePipelineSchema.safeParse({
       groupId: 'grp_test',
+      subjectIndices: [1, 2],
       mode: 'INVALID',
     });
     expect(result.success).toBe(false);
@@ -100,7 +104,10 @@ describe('engine.routes.ts: analyzePipelineSchema Zod 런타임 검증', () => {
 
   it('mode 미지정 시 default DUAL이 적용됨', () => {
     if (!analyzePipelineSchema) return;
-    const result = analyzePipelineSchema.safeParse({ groupId: 'grp_test' });
+    const result = analyzePipelineSchema.safeParse({
+      groupId: 'grp_test',
+      subjectIndices: [1, 2],
+    });
     expect(result.success).toBe(true);
     if (result.success) {
       expect((result.data as any).mode).toBe('DUAL');

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -77,7 +77,7 @@ router.post('/register', validate(registerSchema), engineController.register);
 // 전체 파이프라인 분석 프록시
 const analyzePipelineSchema = z.object({
   groupId: z.string().min(1),
-  subjectIndices: z.array(z.number().int().positive()).optional(),
+  subjectIndices: z.array(z.number().int().positive()),
   mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
   algorithm: z.string().optional().default('default'),
   params: z

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -77,7 +77,9 @@ router.post('/register', validate(registerSchema), engineController.register);
 // 전체 파이프라인 분석 프록시
 const analyzePipelineSchema = z.object({
   groupId: z.string().min(1),
-  subjectIndices: z.array(z.number().int().positive()),
+  subjectIndices: z.array(z.number().int().positive()).optional(),
+  mode: z.enum(['DUAL', 'SEQUENTIAL', 'BTI']).optional().default('DUAL'),
+  algorithm: z.string().optional().default('default'),
   params: z
     .object({
       stimulusDurationSec: z.number().int().positive().optional(),

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -108,6 +108,38 @@ export const engineProxyService = {
     return toCamelCaseKeys(data) as Record<string, unknown>;
   },
 
+  /** SEQUENTIAL 모드 파이프라인 분석 요청을 파이썬 엔진으로 프록시함 */
+  async analyzeSequentialPipeline(
+    groupId: string,
+    algorithm: string = 'default'
+  ): Promise<Record<string, unknown>> {
+    const engineUrl = engineRegistryService.getEngineUrl();
+
+    const response = await fetch(`${engineUrl}/api/analyze/pipeline`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Engine-Secret': config.dataEngine.secretKey,
+      },
+      body: JSON.stringify({
+        ['group_id']: groupId,
+        ['mode']: 'SEQUENTIAL',
+        ['algorithm']: algorithm,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new AppError(
+        `파이썬 엔진 SEQUENTIAL 파이프라인 분석 실패: ${response.status} ${errorText}`,
+        response.status
+      );
+    }
+
+    const data = await response.json();
+    return toCamelCaseKeys(data) as Record<string, unknown>;
+  },
+
   /** 등록된 파이썬 엔진으로 EEG 스트리밍 시작 요청을 프록시함 */
   async streamStart(
     groupId: string,

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -123,6 +123,7 @@ export const engineProxyService = {
       },
       body: JSON.stringify({
         ['group_id']: groupId,
+        ['subject_indices']: [1, 2], // DE Pydantic PipelineRequest 필수 필드 — SEQUENTIAL 브랜치는 값을 무시하지만 검증을 통과해야 함
         ['mode']: 'SEQUENTIAL',
         ['algorithm']: algorithm,
       }),

--- a/src/02-processes/post-measurement/api/sequential.routes.ts
+++ b/src/02-processes/post-measurement/api/sequential.routes.ts
@@ -12,7 +12,7 @@ const router = Router();
 /** POST /sequential 요청 body 검증 스키마 */
 const sequentialAnalyzeSchema = z.object({
   groupId: z.string().min(1),
-  algorithm: z.string().optional(),
+  algorithm: z.string().default('default'),
 });
 
 /**
@@ -30,25 +30,21 @@ router.post(
       const requesterId = req.user?.id;
 
       // 소유권 검증: groupId의 세션 생성자만 분석 가능함
-      const session = await Session.findOne({ groupId }).sort({
-        subjectIndex: 1,
-      });
+      // subjectIndex: { $ne: null } 필터로 null 세션이 대표 세션으로 선택되는 경우 방지함
+      const session = await Session.findOne({
+        groupId,
+        subjectIndex: { $ne: null },
+      }).sort({ subjectIndex: 1 });
 
       if (!session) {
         throw new AppError(`groupId=${groupId} 세션을 찾을 수 없습니다.`, 404);
       }
 
-      if (
-        session.creatorId === null ||
-        session.creatorId.toString() !== requesterId
-      ) {
+      if (!session.creatorId || !session.creatorId.equals(requesterId!)) {
         throw new AppError('이 세션에 대한 분석 권한이 없습니다.', 403);
       }
 
-      const result = await runSequentialAnalysisPipeline(
-        groupId,
-        algorithm ?? 'default'
-      );
+      const result = await runSequentialAnalysisPipeline(groupId, algorithm);
 
       res.status(200).json({ success: true, result });
     } catch (error) {

--- a/src/02-processes/post-measurement/api/sequential.routes.ts
+++ b/src/02-processes/post-measurement/api/sequential.routes.ts
@@ -1,0 +1,60 @@
+import { Router, Response, NextFunction } from 'express';
+import { authenticate } from '@07-shared/middlewares/authenticate.middleware';
+import { validate } from '@07-shared/middlewares/validate.middleware';
+import { AppError } from '@07-shared/errors';
+import { runSequentialAnalysisPipeline } from '../services/sequential-analysis.service';
+import { Session } from '@06-entities/sessions';
+import { z } from 'zod';
+import type { AuthedRequest } from '@07-shared/types/type';
+
+const router = Router();
+
+/** POST /sequential 요청 body 검증 스키마 */
+const sequentialAnalyzeSchema = z.object({
+  groupId: z.string().min(1),
+  algorithm: z.string().optional(),
+});
+
+/**
+ * POST /api/analyze/sequential
+ * operator "Analyze" 버튼 → SEQUENTIAL 모드 분석 파이프라인 트리거함
+ * 인증 필수 + 세션 소유권 검증함
+ */
+router.post(
+  '/sequential',
+  authenticate,
+  validate(sequentialAnalyzeSchema),
+  async (req: AuthedRequest, res: Response, next: NextFunction) => {
+    try {
+      const { groupId, algorithm } = req.body;
+      const requesterId = req.user?.id;
+
+      // 소유권 검증: groupId의 세션 생성자만 분석 가능함
+      const session = await Session.findOne({ groupId }).sort({
+        subjectIndex: 1,
+      });
+
+      if (!session) {
+        throw new AppError(`groupId=${groupId} 세션을 찾을 수 없습니다.`, 404);
+      }
+
+      if (
+        session.creatorId === null ||
+        session.creatorId.toString() !== requesterId
+      ) {
+        throw new AppError('이 세션에 대한 분석 권한이 없습니다.', 403);
+      }
+
+      const result = await runSequentialAnalysisPipeline(
+        groupId,
+        algorithm ?? 'default'
+      );
+
+      res.status(200).json({ success: true, result });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+export default router;

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * sequential-analysis.service — 통합 수준 검증 (unit-level, MongoDB 없이)
  *
@@ -23,10 +24,7 @@ describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () =
       'utf-8'
     );
     proxySource = fs.readFileSync(
-      path.resolve(
-        __dirname,
-        '../../engine/services/engine-proxy.service.ts'
-      ),
+      path.resolve(__dirname, '../../engine/services/engine-proxy.service.ts'),
       'utf-8'
     );
   });
@@ -90,7 +88,9 @@ describe('AnalysisResult 스키마: SEQUENTIAL + similarity_features 필드 roun
 
 describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () => {
   it('유효한 cosine_pearson_faa 결과가 Zod 파싱을 통과함', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const mockDEResponse = {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.73,
@@ -113,12 +113,20 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
   });
 
   it('Mixed type 중첩 객체가 보존됨 (Zod parse 후 동일 구조)', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const nested = {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.5,
       overall_cosine: 0.6,
-      band_ratio_diff: { alpha: 0.1, beta: 0.2, delta: 0.0, theta: 0.3, gamma: 0.1 },
+      band_ratio_diff: {
+        alpha: 0.1,
+        beta: 0.2,
+        delta: 0.0,
+        theta: 0.3,
+        gamma: 0.1,
+      },
       faa_absolute_diff: null,
     };
     const result = cosinePearsonFAASchema.safeParse(nested);
@@ -130,7 +138,9 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
   });
 
   it('DE 500 응답 시나리오: similarity_score 미포함 응답은 Zod 검증 실패함', () => {
-    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const {
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
     const errorResponse = {
       error: 'Internal server error',
       detail: 'CSV not found',
@@ -142,19 +152,25 @@ describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () =>
 
 describe('similaritySchemaRegistry: 레지스트리 조회 검증', () => {
   it("'cosine_pearson_faa' 키로 스키마 조회 성공함", () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('cosine_pearson_faa');
     expect(schema).toBeDefined();
   });
 
   it("'default' 키로 스키마 조회 성공함", () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('default');
     expect(schema).toBeDefined();
   });
 
   it('미등록 알고리즘은 undefined 반환함', () => {
-    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const {
+      getSimilaritySchema,
+    } = require('../../../07-shared/schemas/similarity/index');
     const schema = getSimilaritySchema('unknown_algorithm_xyz');
     expect(schema).toBeUndefined();
   });

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -71,7 +71,7 @@ describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () =
   });
 
   it('service가 엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
-    expect(serviceSource).toContain('findByIdAndDelete');
+    expect(serviceSource).toContain('deleteMany');
     expect(serviceSource).toContain('throw err');
   });
 });

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * sequential-analysis.service — 통합 수준 검증 (unit-level, MongoDB 없이)
+ *
+ * 실제 mongoose/DB 연결 없이 소스 코드와 모듈 구조를 검증함.
+ * mongodb-memory-server 미설치 환경을 고려하여 정적 소스 검증 + Zod 런타임 검증만 수행함.
+ *
+ * 검증 항목:
+ *   - SEQUENTIAL 파이프라인 service + proxy 연계 구조 확인
+ *   - similarity_features round-trip 에서 Zod 스키마 파싱 확인
+ *   - DB 레이어 분리: 에러 전파 구조 확인
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () => {
+  let serviceSource: string;
+  let proxySource: string;
+
+  beforeAll(() => {
+    serviceSource = fs.readFileSync(
+      path.resolve(__dirname, 'sequential-analysis.service.ts'),
+      'utf-8'
+    );
+    proxySource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../engine/services/engine-proxy.service.ts'
+      ),
+      'utf-8'
+    );
+  });
+
+  it('service가 proxy의 analyzeSequentialPipeline을 호출함', () => {
+    expect(serviceSource).toContain('analyzeSequentialPipeline');
+    expect(proxySource).toContain('analyzeSequentialPipeline');
+  });
+
+  it('proxy가 SEQUENTIAL mode와 algorithm을 DE에 전달함', () => {
+    expect(proxySource).toContain("'SEQUENTIAL'");
+    expect(proxySource).toContain("['algorithm']");
+    expect(proxySource).toContain('/api/analyze/pipeline');
+  });
+
+  it('service가 DE 응답에서 similarity_features를 추출함', () => {
+    // camelCase 변환 후 similarityFeatures 키로 접근함 (toCamelCaseKeys)
+    expect(serviceSource).toContain('similarityFeatures');
+  });
+
+  it('service가 AnalysisResult.create에 올바른 필드를 전달함', () => {
+    expect(serviceSource).toContain('analysis_mode');
+    expect(serviceSource).toContain('similarity_features');
+    expect(serviceSource).toContain('synchronyScore: null');
+    expect(serviceSource).toContain('yScore: null');
+  });
+
+  it('service가 엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
+    expect(serviceSource).toContain('findByIdAndDelete');
+    expect(serviceSource).toContain('throw err');
+  });
+});
+
+describe('AnalysisResult 스키마: SEQUENTIAL + similarity_features 필드 round-trip 검증 (정적)', () => {
+  let schemaSource: string;
+
+  beforeAll(() => {
+    schemaSource = fs.readFileSync(
+      path.resolve(
+        __dirname,
+        '../../../06-entities/analysis-results/model/analysis-result.schema.ts'
+      ),
+      'utf-8'
+    );
+  });
+
+  it('analysis_mode 필드가 스키마에 존재함', () => {
+    expect(schemaSource).toContain('analysis_mode');
+  });
+
+  it('similarity_features 필드가 Schema.Types.Mixed로 존재함', () => {
+    expect(schemaSource).toContain('similarity_features');
+    expect(schemaSource).toContain('Schema.Types.Mixed');
+  });
+
+  it('AnalysisResult 인터페이스에 두 신규 필드가 optional로 선언됨', () => {
+    expect(schemaSource).toContain('analysis_mode?:');
+    expect(schemaSource).toContain('similarity_features?:');
+  });
+});
+
+describe('Zod similarity 스키마: cosine_pearson_faa round-trip 검증', () => {
+  it('유효한 cosine_pearson_faa 결과가 Zod 파싱을 통과함', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const mockDEResponse = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.73,
+      overall_cosine: 0.85,
+      band_ratio_diff: {
+        delta: 0.1,
+        theta: 0.2,
+        alpha: 0.05,
+        beta: 0.15,
+        gamma: 0.08,
+      },
+      faa_absolute_diff: 0.2,
+    };
+    const result = cosinePearsonFAASchema.safeParse(mockDEResponse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.similarity_score).toBe(0.73);
+      expect(result.data.algorithm).toBe('cosine_pearson_faa');
+    }
+  });
+
+  it('Mixed type 중첩 객체가 보존됨 (Zod parse 후 동일 구조)', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const nested = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.5,
+      overall_cosine: 0.6,
+      band_ratio_diff: { alpha: 0.1, beta: 0.2, delta: 0.0, theta: 0.3, gamma: 0.1 },
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(nested);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.band_ratio_diff).toEqual(nested.band_ratio_diff);
+      expect(result.data.faa_absolute_diff).toBeNull();
+    }
+  });
+
+  it('DE 500 응답 시나리오: similarity_score 미포함 응답은 Zod 검증 실패함', () => {
+    const { cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema');
+    const errorResponse = {
+      error: 'Internal server error',
+      detail: 'CSV not found',
+    };
+    const result = cosinePearsonFAASchema.safeParse(errorResponse);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('similaritySchemaRegistry: 레지스트리 조회 검증', () => {
+  it("'cosine_pearson_faa' 키로 스키마 조회 성공함", () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('cosine_pearson_faa');
+    expect(schema).toBeDefined();
+  });
+
+  it("'default' 키로 스키마 조회 성공함", () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('default');
+    expect(schema).toBeDefined();
+  });
+
+  it('미등록 알고리즘은 undefined 반환함', () => {
+    const { getSimilaritySchema } = require('../../../07-shared/schemas/similarity/index');
+    const schema = getSimilaritySchema('unknown_algorithm_xyz');
+    expect(schema).toBeUndefined();
+  });
+});

--- a/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.integration.test.ts
@@ -40,6 +40,24 @@ describe('sequential-analysis.service + engine-proxy 통합 구조 검증', () =
     expect(proxySource).toContain('/api/analyze/pipeline');
   });
 
+  it('proxy가 subject_indices를 DE Pydantic PipelineRequest 검증 통과용으로 포함함', () => {
+    // DE PipelineRequest.subject_indices 는 default 없는 필수 필드임
+    // 누락 시 FastAPI가 422 Unprocessable Entity 반환 — SEQUENTIAL 브랜치 실행 전 차단됨
+    expect(proxySource).toContain("'subject_indices'");
+    expect(proxySource).toMatch(
+      /\['subject_indices'\]\s*:\s*\[\s*1\s*,\s*2\s*\]/
+    );
+  });
+
+  it('proxy SEQUENTIAL 블록에 subject_indices 키가 존재함 (부재 감지 테스트)', () => {
+    // analyzeSequentialPipeline 함수 본문에서 subject_indices 키 존재 여부 확인
+    const sequentialBlock = proxySource.slice(
+      proxySource.indexOf('analyzeSequentialPipeline'),
+      proxySource.indexOf('analyzeSequentialPipeline') + 1000
+    );
+    expect(sequentialBlock).toContain('subject_indices');
+  });
+
   it('service가 DE 응답에서 similarity_features를 추출함', () => {
     // camelCase 변환 후 similarityFeatures 키로 접근함 (toCamelCaseKeys)
     expect(serviceSource).toContain('similarityFeatures');

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
@@ -1,0 +1,89 @@
+/**
+ * sequential-analysis.service.ts — SEQUENTIAL 분석 파이프라인 서비스 검증
+ *
+ * 검증 항목:
+ *   - 서비스가 engineProxyService.analyzeSequentialPipeline을 import 및 호출함
+ *   - 두 subject COMPLETED 검증 로직이 존재함
+ *   - AnalysisResult 생성 시 analysis_mode='SEQUENTIAL' 설정됨
+ *   - 엔진 실패 시 에러를 전파함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('sequential-analysis.service.ts: 소스 정적 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'sequential-analysis.service.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('engineProxyService를 import함', () => {
+    expect(source).toContain('engineProxyService');
+  });
+
+  it('analyzeSequentialPipeline을 호출함', () => {
+    expect(source).toContain('analyzeSequentialPipeline');
+  });
+
+  it("analysis_mode: 'SEQUENTIAL'을 AnalysisResult.create에 전달함", () => {
+    expect(source).toContain("analysis_mode: 'SEQUENTIAL'");
+  });
+
+  it('두 subject COMPLETED 상태 검증 로직이 존재함', () => {
+    expect(source).toContain("'COMPLETED'");
+  });
+
+  it('session1, session2 둘 다 조회함', () => {
+    expect(source).toContain('session1');
+    expect(source).toContain('session2');
+  });
+
+  it('엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
+    expect(source).toContain('findByIdAndDelete');
+    expect(source).toContain('throw err');
+  });
+
+  it('groupId와 algorithm 파라미터를 받음', () => {
+    expect(source).toContain('groupId: string');
+    expect(source).toContain('algorithm');
+  });
+
+  it("algorithm 기본값이 'default'임", () => {
+    expect(source).toContain("algorithm: string = 'default'");
+  });
+
+  it('Promise<AnalysisResultDoc>를 반환함', () => {
+    expect(source).toContain('AnalysisResultDoc');
+  });
+
+  it('SEQUENTIAL 모드에서 synchronyScore와 yScore를 null로 설정함 (ADR-14-004)', () => {
+    expect(source).toContain('synchronyScore: null');
+    expect(source).toContain('yScore: null');
+  });
+});
+
+describe('engine-proxy.service.ts: analyzeSequentialPipeline 메서드 검증', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(
+      __dirname,
+      '../../engine/services/engine-proxy.service.ts'
+    );
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('analyzeSequentialPipeline 메서드가 정의됨', () => {
+    expect(source).toContain('analyzeSequentialPipeline');
+  });
+
+  it("mode: 'SEQUENTIAL'을 요청 body에 포함함", () => {
+    expect(source).toContain("'SEQUENTIAL'");
+  });
+
+  it('algorithm 파라미터를 요청 body에 전달함', () => {
+    expect(source).toContain("['algorithm']");
+  });
+});

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.test.ts
@@ -41,7 +41,7 @@ describe('sequential-analysis.service.ts: 소스 정적 검증', () => {
   });
 
   it('엔진 실패 시 EegRecord 롤백 후 에러를 전파함', () => {
-    expect(source).toContain('findByIdAndDelete');
+    expect(source).toContain('deleteMany');
     expect(source).toContain('throw err');
   });
 

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { Session } from '@06-entities/sessions';
 import { AnalysisResult } from '@06-entities/analysis-results';
 import { EegRecord } from '@06-entities/eeg-records';
@@ -19,6 +18,7 @@ export const runSequentialAnalysisPipeline = async (
   // 멱등성 가드: 이미 SEQUENTIAL 결과가 있으면 스킵함
   const existing = await AnalysisResult.findOne({
     groupId,
+    // eslint-disable-next-line camelcase
     analysis_mode: 'SEQUENTIAL',
   });
   if (existing) {
@@ -64,7 +64,7 @@ export const runSequentialAnalysisPipeline = async (
   const user1Id = (session1.userId as any)._id;
   const user2Id = (session2.userId as any)._id;
 
-  // EegRecord 2건 생성함
+  // EegRecord 문서 초기화 (실제 create는 try 블록 내에서 수행함)
   const consent1 = await Consent.findOne({ userId: user1Id });
   const consent2 = await Consent.findOne({ userId: user2Id });
 
@@ -84,14 +84,17 @@ export const runSequentialAnalysisPipeline = async (
   };
   if (consent2?._id) record2Doc.consentId = consent2._id;
 
-  const record1 = await EegRecord.create(record1Doc);
-  const record2 = await EegRecord.create(record2Doc);
-
-  // DE /analyze/pipeline (mode=SEQUENTIAL) 호출함
+  // DE /analyze/pipeline (mode=SEQUENTIAL) 호출 + AnalysisResult 생성함
+  // EegRecord 생성 후 이후 단계 실패 시 롤백 필요함 — try 블록 내에서 통합 처리함
   let pipelineResult: Record<string, unknown> = {};
   let similarityFeatures: Record<string, unknown> | undefined;
+  let record1: Awaited<ReturnType<typeof EegRecord.create>> | undefined;
+  let record2: Awaited<ReturnType<typeof EegRecord.create>> | undefined;
 
   try {
+    record1 = await EegRecord.create(record1Doc);
+    record2 = await EegRecord.create(record2Doc);
+
     pipelineResult = await engineProxyService.analyzeSequentialPipeline(
       groupId,
       algorithm
@@ -100,36 +103,40 @@ export const runSequentialAnalysisPipeline = async (
       pipelineResult.similarity_features) as
       | Record<string, unknown>
       | undefined;
+
+    // AnalysisResult 생성함 (analysis_mode: SEQUENTIAL)
+    const analysisResult = await AnalysisResult.create({
+      groupId,
+      user1Id,
+      user2Id,
+      record1Id: record1._id,
+      record2Id: record2._id,
+      surveySummary: '',
+      matchingScore:
+        typeof similarityFeatures?.similarity_score === 'number'
+          ? Math.round(similarityFeatures.similarity_score * 100)
+          : 0,
+      synchronyScore: null, // SEQUENTIAL 모드에서 PLV/coherence 미계산 (ADR-14-004)
+      yScore: null,
+      aiComment: '뇌파 반응 유사도 분석이 완료되었습니다.',
+      markdown: (pipelineResult.markdown as string) ?? '',
+      pipelineResult,
+      // eslint-disable-next-line camelcase
+      analysis_mode: 'SEQUENTIAL',
+      // eslint-disable-next-line camelcase
+      similarity_features: similarityFeatures ?? undefined,
+    });
+
+    console.log(
+      `[sequentialAnalysis] groupId=${groupId} SEQUENTIAL 분석 완료, algorithm=${algorithm}`
+    );
+
+    return analysisResult;
   } catch (err) {
     // EegRecord 롤백 후 에러 전파함
-    await EegRecord.findByIdAndDelete(record1._id);
-    await EegRecord.findByIdAndDelete(record2._id);
+    await EegRecord.deleteMany({
+      _id: { $in: [record1?._id, record2?._id].filter(Boolean) },
+    });
     throw err;
   }
-
-  // AnalysisResult 생성함 (analysis_mode: SEQUENTIAL)
-  const analysisResult = await AnalysisResult.create({
-    groupId,
-    user1Id,
-    user2Id,
-    record1Id: record1._id,
-    record2Id: record2._id,
-    surveySummary: '',
-    matchingScore: similarityFeatures?.similarity_score
-      ? Math.round((similarityFeatures.similarity_score as number) * 100)
-      : 0,
-    synchronyScore: null, // SEQUENTIAL 모드에서 PLV/coherence 미계산 (ADR-14-004)
-    yScore: null,
-    aiComment: '뇌파 반응 유사도 분석이 완료되었습니다.',
-    markdown: (pipelineResult.markdown as string) ?? '',
-    pipelineResult,
-    analysis_mode: 'SEQUENTIAL',
-    similarity_features: similarityFeatures ?? undefined,
-  });
-
-  console.log(
-    `[sequentialAnalysis] groupId=${groupId} SEQUENTIAL 분석 완료, algorithm=${algorithm}`
-  );
-
-  return analysisResult;
 };

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -1,0 +1,132 @@
+import { Session } from '@06-entities/sessions';
+import { AnalysisResult } from '@06-entities/analysis-results';
+import { EegRecord } from '@06-entities/eeg-records';
+import { Consent } from '@06-entities/consents';
+import { engineProxyService } from '@02-processes/engine/services/engine-proxy.service';
+import { AppError } from '@07-shared/errors';
+import type { AnalysisResultDoc } from '@06-entities/analysis-results';
+
+/**
+ * SEQUENTIAL 모드 분석 파이프라인 수행함
+ * operator "Analyze" 버튼 클릭 시 호출됨
+ * 두 subject 모두 COMPLETED 상태여야 실행 가능함
+ */
+export const runSequentialAnalysisPipeline = async (
+  groupId: string,
+  algorithm: string = 'default'
+): Promise<AnalysisResultDoc> => {
+  // 멱등성 가드: 이미 SEQUENTIAL 결과가 있으면 스킵함
+  const existing = await AnalysisResult.findOne({
+    groupId,
+    analysis_mode: 'SEQUENTIAL',
+  });
+  if (existing) {
+    console.log(
+      `[sequentialAnalysis] groupId=${groupId} 이미 처리됨, 기존 결과 반환`
+    );
+    return existing;
+  }
+
+  // 두 subject 세션 조회 + COMPLETED 상태 검증함
+  const sessions = await Session.find({ groupId }).populate('userId');
+  const session1 = sessions.find((s) => s.subjectIndex === 1);
+  const session2 = sessions.find((s) => s.subjectIndex === 2);
+
+  if (!session1 || !session2) {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 1 또는 2 세션 미발견`,
+      404
+    );
+  }
+
+  if (session1.status !== 'COMPLETED') {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 1 세션이 COMPLETED 상태가 아님 (현재: ${session1.status})`,
+      422
+    );
+  }
+
+  if (session2.status !== 'COMPLETED') {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} subject 2 세션이 COMPLETED 상태가 아님 (현재: ${session2.status})`,
+      422
+    );
+  }
+
+  if (!session1.userId || !session2.userId) {
+    throw new AppError(
+      `[sequentialAnalysis] groupId=${groupId} 세션에 userId가 바인딩되지 않음`,
+      422
+    );
+  }
+
+  const user1Id = (session1.userId as any)._id;
+  const user2Id = (session2.userId as any)._id;
+
+  // EegRecord 2건 생성함
+  const consent1 = await Consent.findOne({ userId: user1Id });
+  const consent2 = await Consent.findOne({ userId: user2Id });
+
+  const record1Doc: any = {
+    userId: user1Id,
+    sessionId: session1._id,
+    rawDataPath: `data/${groupId}/subject_1.csv`,
+    eegSummary: {},
+  };
+  if (consent1?._id) record1Doc.consentId = consent1._id;
+
+  const record2Doc: any = {
+    userId: user2Id,
+    sessionId: session2._id,
+    rawDataPath: `data/${groupId}/subject_2.csv`,
+    eegSummary: {},
+  };
+  if (consent2?._id) record2Doc.consentId = consent2._id;
+
+  const record1 = await EegRecord.create(record1Doc);
+  const record2 = await EegRecord.create(record2Doc);
+
+  // DE /analyze/pipeline (mode=SEQUENTIAL) 호출함
+  let pipelineResult: Record<string, unknown> = {};
+  let similarityFeatures: Record<string, unknown> | undefined;
+
+  try {
+    pipelineResult = await engineProxyService.analyzeSequentialPipeline(
+      groupId,
+      algorithm
+    );
+    similarityFeatures = (pipelineResult.similarityFeatures ??
+      pipelineResult.similarity_features) as Record<string, unknown> | undefined;
+  } catch (err) {
+    // EegRecord 롤백 후 에러 전파함
+    await EegRecord.findByIdAndDelete(record1._id);
+    await EegRecord.findByIdAndDelete(record2._id);
+    throw err;
+  }
+
+  // AnalysisResult 생성함 (analysis_mode: SEQUENTIAL)
+  const analysisResult = await AnalysisResult.create({
+    groupId,
+    user1Id,
+    user2Id,
+    record1Id: record1._id,
+    record2Id: record2._id,
+    surveySummary: '',
+    matchingScore: similarityFeatures?.similarity_score
+      ? Math.round((similarityFeatures.similarity_score as number) * 100)
+      : 0,
+    synchronyScore: null, // SEQUENTIAL 모드에서 PLV/coherence 미계산 (ADR-14-004)
+    yScore: null,
+    aiComment: '뇌파 반응 유사도 분석이 완료되었습니다.',
+    markdown: (pipelineResult.markdown as string) ?? '',
+    pipelineResult,
+    analysis_mode: 'SEQUENTIAL',
+    similarity_features: similarityFeatures ?? null,
+  });
+
+  console.log(
+    `[sequentialAnalysis] groupId=${groupId} SEQUENTIAL 분석 완료, algorithm=${algorithm}`
+  );
+
+  return analysisResult;
+};

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -5,6 +5,7 @@ import { Consent } from '@06-entities/consents';
 import { engineProxyService } from '@02-processes/engine/services/engine-proxy.service';
 import { AppError } from '@07-shared/errors';
 import type { AnalysisResultDoc } from '@06-entities/analysis-results';
+import type { EegRecordDoc } from '@06-entities/eeg-records';
 
 /**
  * SEQUENTIAL 모드 분석 파이프라인 수행함
@@ -88,8 +89,8 @@ export const runSequentialAnalysisPipeline = async (
   // EegRecord 생성 후 이후 단계 실패 시 롤백 필요함 — try 블록 내에서 통합 처리함
   let pipelineResult: Record<string, unknown> = {};
   let similarityFeatures: Record<string, unknown> | undefined;
-  let record1: Awaited<ReturnType<typeof EegRecord.create>> | undefined;
-  let record2: Awaited<ReturnType<typeof EegRecord.create>> | undefined;
+  let record1: EegRecordDoc | undefined;
+  let record2: EegRecordDoc | undefined;
 
   try {
     record1 = await EegRecord.create(record1Doc);

--- a/src/02-processes/post-measurement/services/sequential-analysis.service.ts
+++ b/src/02-processes/post-measurement/services/sequential-analysis.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Session } from '@06-entities/sessions';
 import { AnalysisResult } from '@06-entities/analysis-results';
 import { EegRecord } from '@06-entities/eeg-records';
@@ -96,7 +97,9 @@ export const runSequentialAnalysisPipeline = async (
       algorithm
     );
     similarityFeatures = (pipelineResult.similarityFeatures ??
-      pipelineResult.similarity_features) as Record<string, unknown> | undefined;
+      pipelineResult.similarity_features) as
+      | Record<string, unknown>
+      | undefined;
   } catch (err) {
     // EegRecord 롤백 후 에러 전파함
     await EegRecord.findByIdAndDelete(record1._id);
@@ -121,7 +124,7 @@ export const runSequentialAnalysisPipeline = async (
     markdown: (pipelineResult.markdown as string) ?? '',
     pipelineResult,
     analysis_mode: 'SEQUENTIAL',
-    similarity_features: similarityFeatures ?? null,
+    similarity_features: similarityFeatures ?? undefined,
   });
 
   console.log(

--- a/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * analysis-result.schema.ts — analysis_mode + similarity_features 필드 검증
  *
@@ -55,7 +56,9 @@ describe('analysis-result.schema.ts: analysis_mode 필드가 올바르게 추가
     // analysis_mode는 인터페이스에서 optional(?)이거나 Mongoose default로 채워짐
     // 인터페이스 필드에 '?'(optional) 또는 default 선언 확인함
     const hasOptionalInInterface = source.match(/analysis_mode\s*\?:/);
-    const hasDefaultInSchema = source.match(/analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/);
+    const hasDefaultInSchema = source.match(
+      /analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/
+    );
     expect(hasOptionalInInterface || hasDefaultInSchema).toBeTruthy();
   });
 });
@@ -70,7 +73,9 @@ describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
     );
     const hasFile = fs.existsSync(schemaPath);
     if (hasFile) {
-      ({ cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
+      ({
+        cosinePearsonFAASchema,
+      } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
     }
   });
 
@@ -80,7 +85,13 @@ describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
       algorithm: 'cosine_pearson_faa',
       similarity_score: 0.73,
       overall_cosine: 0.85,
-      band_ratio_diff: { delta: 0.1, theta: 0.2, alpha: 0.05, beta: 0.15, gamma: 0.08 },
+      band_ratio_diff: {
+        delta: 0.1,
+        theta: 0.2,
+        alpha: 0.05,
+        beta: 0.15,
+        gamma: 0.08,
+      },
       faa_absolute_diff: 0.2,
     };
     const result = cosinePearsonFAASchema.safeParse(validPayload);

--- a/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
@@ -1,0 +1,127 @@
+/**
+ * analysis-result.schema.ts — analysis_mode + similarity_features 필드 검증
+ *
+ * 검증 항목:
+ *   - analysis_mode 필드가 스키마에 정의됨
+ *   - similarity_features 필드가 Mixed 타입으로 정의됨
+ *   - 기존 생성 경로(bti-analysis, post-measurement)에서 analysis_mode 미지정 시
+ *     Mongoose default 'DUAL'이 적용됨 (정적 소스 검증)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('analysis-result.schema.ts: analysis_mode 필드가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'analysis-result.schema.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('AnalysisResult 인터페이스에 analysis_mode 필드가 존재함', () => {
+    expect(source).toContain('analysis_mode');
+  });
+
+  it("인터페이스 analysis_mode에 'DUAL' | 'SEQUENTIAL' | 'BTI' 유니온이 포함됨", () => {
+    expect(source).toContain('DUAL');
+    expect(source).toContain('SEQUENTIAL');
+    expect(source).toContain('BTI');
+  });
+
+  it('Mongoose 스키마에 analysis_mode 필드 정의가 존재함', () => {
+    expect(source).toContain('analysis_mode:');
+  });
+
+  it("스키마 analysis_mode enum에 'DUAL', 'SEQUENTIAL', 'BTI'가 포함됨", () => {
+    expect(source).toContain("'DUAL'");
+    expect(source).toContain("'SEQUENTIAL'");
+    expect(source).toContain("'BTI'");
+  });
+
+  it("스키마 analysis_mode default가 'DUAL'로 설정됨", () => {
+    expect(source).toMatch(/default:\s*['"]DUAL['"]/);
+  });
+
+  it('인터페이스에 similarity_features 필드가 존재함', () => {
+    expect(source).toContain('similarity_features');
+  });
+
+  it('스키마에 similarity_features가 Schema.Types.Mixed로 정의됨', () => {
+    expect(source).toContain('Schema.Types.Mixed');
+  });
+
+  it('기존 AnalysisResult.create 호출 시 analysis_mode 미지정이 허용됨 (optional 또는 default)', () => {
+    // analysis_mode는 인터페이스에서 optional(?)이거나 Mongoose default로 채워짐
+    // 인터페이스 필드에 '?'(optional) 또는 default 선언 확인함
+    const hasOptionalInInterface = source.match(/analysis_mode\s*\?:/);
+    const hasDefaultInSchema = source.match(/analysis_mode:[\s\S]*?default:\s*['"]DUAL['"]/);
+    expect(hasOptionalInInterface || hasDefaultInSchema).toBeTruthy();
+  });
+});
+
+describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
+  let cosinePearsonFAASchema: ReturnType<typeof import('zod').z.object>;
+
+  beforeAll(() => {
+    const schemaPath = path.resolve(
+      __dirname,
+      '../../../07-shared/schemas/similarity/cosine_pearson_faa.schema.ts'
+    );
+    const hasFile = fs.existsSync(schemaPath);
+    if (hasFile) {
+      ({ cosinePearsonFAASchema } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
+    }
+  });
+
+  it('유효한 payload를 올바르게 파싱함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const validPayload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.73,
+      overall_cosine: 0.85,
+      band_ratio_diff: { delta: 0.1, theta: 0.2, alpha: 0.05, beta: 0.15, gamma: 0.08 },
+      faa_absolute_diff: 0.2,
+    };
+    const result = cosinePearsonFAASchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  it('similarity_score가 범위 초과(1.5)면 파싱 실패함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const invalidPayload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 1.5,
+      overall_cosine: 0.85,
+      band_ratio_diff: {},
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(invalidPayload);
+    expect(result.success).toBe(false);
+  });
+
+  it('algorithm 필드 누락 시 파싱 실패함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const invalidPayload = {
+      similarity_score: 0.5,
+      overall_cosine: 0.7,
+      band_ratio_diff: {},
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(invalidPayload);
+    expect(result.success).toBe(false);
+  });
+
+  it('faa_absolute_diff가 null이어도 파싱 성공함', () => {
+    if (!cosinePearsonFAASchema) return;
+    const payload = {
+      algorithm: 'cosine_pearson_faa',
+      similarity_score: 0.5,
+      overall_cosine: 0.6,
+      band_ratio_diff: { alpha: 0.1 },
+      faa_absolute_diff: null,
+    };
+    const result = cosinePearsonFAASchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.test.ts
@@ -72,11 +72,11 @@ describe('cosine_pearson_faa.schema.ts: Zod 스키마 검증', () => {
       '../../../07-shared/schemas/similarity/cosine_pearson_faa.schema.ts'
     );
     const hasFile = fs.existsSync(schemaPath);
-    if (hasFile) {
-      ({
-        cosinePearsonFAASchema,
-      } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
-    }
+    expect(hasFile).toBe(true);
+    if (!hasFile) return;
+    ({
+      cosinePearsonFAASchema,
+    } = require('../../../07-shared/schemas/similarity/cosine_pearson_faa.schema'));
   });
 
   it('유효한 payload를 올바르게 파싱함', () => {

--- a/src/06-entities/analysis-results/model/analysis-result.schema.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 
 /** 1. 문서 필드 타입 정의 */

--- a/src/06-entities/analysis-results/model/analysis-result.schema.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.ts
@@ -14,6 +14,8 @@ export interface AnalysisResult {
   aiComment: string; // AI 분석 코멘트
   markdown: string; // 엔진 분석 markdown 원문
   pipelineResult: Record<string, unknown>; // analyzePipeline 전체 응답 저장
+  analysis_mode?: 'DUAL' | 'SEQUENTIAL' | 'BTI'; // 실험 모드 (ADR-14-002)
+  similarity_features?: Record<string, unknown>; // 유사도 지표 (ADR-14-009 Mixed type)
 }
 
 export interface AnalysisResultMethods {}
@@ -60,6 +62,17 @@ const analysisResultSchema = new Schema<
     aiComment: { type: String, required: true },
     markdown: { type: String, default: '' },
     pipelineResult: { type: Schema.Types.Mixed, default: {} },
+    analysis_mode: {
+      type: String,
+      enum: ['DUAL', 'SEQUENTIAL', 'BTI'],
+      default: 'DUAL',
+    },
+    similarity_features: {
+      type: Schema.Types.Mixed,
+      required: false,
+      // 예시: { algorithm: "cosine_pearson_faa", similarity_score: 0.73, ... }
+      // ADR-14-009: 새 알고리즘 추가 시 shape 변경 자유, 마이그레이션 불필요
+    },
   },
   {
     timestamps: true,

--- a/src/06-entities/analysis-results/model/analysis-result.schema.ts
+++ b/src/06-entities/analysis-results/model/analysis-result.schema.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 
 /** 1. 문서 필드 타입 정의 */
@@ -63,11 +62,13 @@ const analysisResultSchema = new Schema<
     aiComment: { type: String, required: true },
     markdown: { type: String, default: '' },
     pipelineResult: { type: Schema.Types.Mixed, default: {} },
+    // eslint-disable-next-line camelcase
     analysis_mode: {
       type: String,
       enum: ['DUAL', 'SEQUENTIAL', 'BTI'],
       default: 'DUAL',
     },
+    // eslint-disable-next-line camelcase
     similarity_features: {
       type: Schema.Types.Mixed,
       required: false,

--- a/src/06-entities/sessions/model/session.schema.test.ts
+++ b/src/06-entities/sessions/model/session.schema.test.ts
@@ -1,0 +1,60 @@
+/**
+ * session.schema.ts — experimentMode 필드 추가 검증
+ *
+ * 검증 항목:
+ *   - Session 인터페이스에 experimentMode 필드가 추가됨
+ *   - Mongoose 스키마에 experimentMode 필드 정의 존재함
+ *   - enum 값으로 DUAL, SEQUENTIAL, BTI가 정의됨
+ *   - default 값이 'DUAL'로 설정됨
+ *   - required: true가 설정됨
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('session.schema.ts: experimentMode 필드가 올바르게 추가됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'session.schema.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('Session 인터페이스에 experimentMode 필드가 존재함', () => {
+    expect(source).toContain('experimentMode');
+  });
+
+  it('Session 인터페이스에 DUAL | SEQUENTIAL | BTI 유니온 타입이 포함됨', () => {
+    expect(source).toContain('SEQUENTIAL');
+    expect(source).toContain('DUAL');
+    expect(source).toContain('BTI');
+  });
+
+  it('Mongoose 스키마에 experimentMode 필드 정의가 존재함', () => {
+    // 스키마 객체 내에 experimentMode 키 존재함
+    expect(source).toContain('experimentMode:');
+  });
+
+  it("스키마 enum에 'SEQUENTIAL'이 포함됨", () => {
+    expect(source).toContain("'SEQUENTIAL'");
+  });
+
+  it("스키마 enum에 'DUAL'이 포함됨", () => {
+    // 'DUAL' 리터럴이 schema enum 배열에 존재함
+    expect(source).toContain("'DUAL'");
+  });
+
+  it("스키마 enum에 'BTI'이 포함됨", () => {
+    expect(source).toContain("'BTI'");
+  });
+
+  it("스키마 default가 'DUAL'로 설정됨", () => {
+    // experimentMode 필드 default 값 확인함
+    // "default: 'DUAL'" 또는 `default: "DUAL"` 형식으로 존재해야 함
+    expect(source).toMatch(/default:\s*['"]DUAL['"]/);
+  });
+
+  it('스키마 required가 true로 설정됨', () => {
+    expect(source).toContain('required: true');
+  });
+});

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -1,4 +1,5 @@
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
+import { ExperimentMode } from '@07-shared/constants/experiment';
 
 /** * 1. 문서 필드 타입 정의
  * ERD의 필드와 Note A 규칙을 반영함
@@ -21,6 +22,7 @@ export interface Session {
   measuredAt: Date | null; // 측정 시작 시점
   stopReason: 'Natural' | 'ManualEarly' | 'HeadsetLost' | 'ProcessError' | null;
   measuredDurationSeconds: number | null;
+  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI)
 }
 
 /** 2. 인스턴스 메서드 타입 정의 */
@@ -94,6 +96,12 @@ const sessionSchema = new Schema<Session, SessionModel, SessionMethods>(
     measuredDurationSeconds: {
       type: Number,
       default: null,
+    },
+    experimentMode: {
+      type: String,
+      enum: ['DUAL', 'SEQUENTIAL', 'BTI'],
+      required: true,
+      default: 'DUAL',
     },
   },
   {

--- a/src/07-shared/constants/experiment.test.ts
+++ b/src/07-shared/constants/experiment.test.ts
@@ -1,0 +1,73 @@
+/**
+ * experiment.ts — EXPERIMENT_MODES 상수 및 ExperimentMode 타입 검증
+ *
+ * 검증 항목:
+ *   - SEQUENTIAL 모드가 상수에 정의됨
+ *   - DUAL, BTI 모드가 기존과 동일하게 유지됨
+ *   - ExperimentMode 타입이 'SEQUENTIAL' 리터럴을 수용함
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('experiment.ts: EXPERIMENT_MODES 상수가 올바르게 정의됨', () => {
+  let source: string;
+
+  beforeAll(() => {
+    const filePath = path.resolve(__dirname, 'experiment.ts');
+    source = fs.readFileSync(filePath, 'utf-8');
+  });
+
+  it('EXPERIMENT_MODES에 DUAL 모드가 정의됨', () => {
+    expect(source).toContain("DUAL: 'DUAL'");
+  });
+
+  it('EXPERIMENT_MODES에 BTI 모드가 정의됨', () => {
+    expect(source).toContain("BTI: 'BTI'");
+  });
+
+  it('EXPERIMENT_MODES에 SEQUENTIAL 모드가 정의됨', () => {
+    expect(source).toContain("SEQUENTIAL: 'SEQUENTIAL'");
+  });
+
+  it('ExperimentMode 타입이 keyof typeof 방식으로 자동 파생됨', () => {
+    // (typeof X)[keyof typeof X] 또는 typeof X[keyof typeof X] 두 형식 모두 허용함
+    const hasParenForm = source.includes(
+      '(typeof EXPERIMENT_MODES)[keyof typeof EXPERIMENT_MODES]'
+    );
+    const hasNonParenForm = source.includes(
+      'typeof EXPERIMENT_MODES[keyof typeof EXPERIMENT_MODES]'
+    );
+    expect(hasParenForm || hasNonParenForm).toBe(true);
+  });
+
+  it('EXPERIMENT_MODES 객체가 as const로 선언됨', () => {
+    expect(source).toContain('as const');
+  });
+});
+
+describe('experiment.ts: EXPERIMENT_MODES 런타임 값 검증', () => {
+  let EXPERIMENT_MODES: Record<string, string>;
+
+  beforeAll(() => {
+    // 파일이 생성된 후에만 require 실행함
+    const filePath = path.resolve(__dirname, 'experiment.ts');
+    const exists = fs.existsSync(filePath);
+    if (exists) {
+      // ts-jest 환경에서 직접 require 가능함
+      EXPERIMENT_MODES = require('./experiment').EXPERIMENT_MODES;
+    }
+  });
+
+  it('EXPERIMENT_MODES.SEQUENTIAL 값이 문자열 SEQUENTIAL임', () => {
+    expect(EXPERIMENT_MODES['SEQUENTIAL']).toBe('SEQUENTIAL');
+  });
+
+  it('EXPERIMENT_MODES.DUAL 값이 문자열 DUAL임', () => {
+    expect(EXPERIMENT_MODES['DUAL']).toBe('DUAL');
+  });
+
+  it('EXPERIMENT_MODES.BTI 값이 문자열 BTI임', () => {
+    expect(EXPERIMENT_MODES['BTI']).toBe('BTI');
+  });
+});

--- a/src/07-shared/constants/experiment.ts
+++ b/src/07-shared/constants/experiment.ts
@@ -1,0 +1,16 @@
+/**
+ * experiment.ts — 실험 모드 상수 정의
+ *
+ * DUAL: 2PC 동시 측정 모드 (기본값)
+ * BTI: BTI 전용 측정 모드
+ * SEQUENTIAL: 1PC 시분할 측정 모드 (Phase 14 P2)
+ */
+
+export const EXPERIMENT_MODES = {
+  DUAL: 'DUAL',
+  BTI: 'BTI',
+  SEQUENTIAL: 'SEQUENTIAL', // 시분할 측정 (1PC 환경, Phase 14 P2)
+} as const;
+
+export type ExperimentMode =
+  (typeof EXPERIMENT_MODES)[keyof typeof EXPERIMENT_MODES];

--- a/src/07-shared/schemas/similarity/_base.ts
+++ b/src/07-shared/schemas/similarity/_base.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+/**
+ * Similarity 스키마 공통 필드 정의
+ * 모든 알고리즘 스키마의 base
+ */
+export const similarityBaseSchema = z.object({
+  algorithm: z.string(),
+  similarity_score: z.number().min(0).max(1),
+});
+
+export type SimilarityBase = z.infer<typeof similarityBaseSchema>;

--- a/src/07-shared/schemas/similarity/_base.ts
+++ b/src/07-shared/schemas/similarity/_base.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { z } from 'zod';
 
 /**
@@ -6,7 +7,7 @@ import { z } from 'zod';
  */
 export const similarityBaseSchema = z.object({
   algorithm: z.string(),
-  similarity_score: z.number().min(0).max(1),
+  similarity_score: z.number().min(0).max(1), // DE API snake_case 키 그대로 유지함
 });
 
 export type SimilarityBase = z.infer<typeof similarityBaseSchema>;

--- a/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
+++ b/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import { z } from 'zod';
 import { similarityBaseSchema } from './_base';
 

--- a/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
+++ b/src/07-shared/schemas/similarity/cosine_pearson_faa.schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+import { similarityBaseSchema } from './_base';
+
+/**
+ * cosine_pearson_faa 알고리즘 유사도 결과 스키마
+ * DE의 CosinePearsonFAAStrategy.compute() 출력 형식과 일치함
+ */
+export const cosinePearsonFAASchema = similarityBaseSchema.extend({
+  overall_cosine: z.number(),
+  band_ratio_diff: z.record(z.string(), z.number()),
+  faa_absolute_diff: z.number().nullable(),
+});
+
+export type CosinePearsonFAAResult = z.infer<typeof cosinePearsonFAASchema>;

--- a/src/07-shared/schemas/similarity/index.ts
+++ b/src/07-shared/schemas/similarity/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Similarity 스키마 레지스트리
+ * 팀원이 새 알고리즘 추가 시: 새 스키마 파일 생성 후 이 map에 등록함
+ */
+import { z } from 'zod';
+import { cosinePearsonFAASchema } from './cosine_pearson_faa.schema';
+
+export { similarityBaseSchema } from './_base';
+export { cosinePearsonFAASchema } from './cosine_pearson_faa.schema';
+export type { SimilarityBase } from './_base';
+export type { CosinePearsonFAAResult } from './cosine_pearson_faa.schema';
+
+/** algorithm 이름 → Zod 스키마 매핑 (새 알고리즘 등록 위치) */
+export const similaritySchemaRegistry: Record<string, z.ZodTypeAny> = {
+  cosine_pearson_faa: cosinePearsonFAASchema,
+  default: cosinePearsonFAASchema,
+};
+
+/**
+ * algorithm 이름으로 스키마를 조회함
+ * 등록되지 않은 이름이면 undefined 반환
+ */
+export function getSimilaritySchema(
+  algorithm: string
+): z.ZodTypeAny | undefined {
+  return similaritySchemaRegistry[algorithm];
+}

--- a/src/07-shared/schemas/similarity/index.ts
+++ b/src/07-shared/schemas/similarity/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /**
  * Similarity 스키마 레지스트리
  * 팀원이 새 알고리즘 추가 시: 새 스키마 파일 생성 후 이 map에 등록함


### PR DESCRIPTION
## Summary

Phase 14 BE SEQUENTIAL mode 전체 구현 + verify Round 2 fix + team-workflow README 정렬을 main으로 릴리스.

### 포함된 변경 (12 commits)

**Phase 14 SEQUENTIAL 뼈대 (PR #40 merged into dev)**
- `feat(shared)` SEQUENTIAL experiment mode 상수 + 스키마 확장
- `feat(schema)` AnalysisResult에 analysis_mode + similarity_features 확장
- `feat(post-measurement)` sequential-analysis.service — SEQUENTIAL 파이프라인
- `feat(engine)` POST /analyze/sequential 엔드포인트 + 스키마 mode/similarity_features 확장
- `test(post-measurement)` SEQUENTIAL integration tests
- `style` prettier + camelcase lint 일괄 정리
- `fix(engine)` subjectIndices required 유지 (B1 fix)

**Verify Round 2 fix**
- `fix(engine)` SEQUENTIAL proxy body에 subject_indices 포함 (Round 1 CRITICAL)
- `chore(lint)` dist/coverage ESLint scan 제외 (Round 2)

**Team workflow align**
- `docs(readme)` CI 파이프라인 섹션 + issue-based flow + main direct commit 금지

### 검증 (로컬 실측, `61c9e6c`)

- ✅ npm run build (0 errors)
- ✅ npm run lint (0 warnings)
- ✅ npm test (Suites 10 pass, Tests 102 pass)

### 관련 Phase

- Phase 14 CHECKLIST.md: verify Round 2 PASS (execute 내부 verify-reviewer 2라운드 통과)
- 공식 /pf verify는 3 PR 전부 머지 후 실행 예정

---

Ref: `.plans/14-dual-ble-resolution/CHECKLIST.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * EEG 순차 분석 모드 추가: 실험 구성에 따라 DUAL/SEQUENTIAL/BTI 모드 선택 가능

* **Documentation**
  * 프로젝트 파이프라인, 협업 워크플로우, 커밋 컨벤션, CI 파이프라인 문서 확충
  * 변경 로그 및 프로젝트 타임라인 관리 가이드 추가

* **Chores**
  * 개발 환경 설정 및 테스트 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->