### PR TITLE
docs(architecture): stamp ADR-005 transition date + fix pre-push range

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,14 +9,23 @@ if [ "$CURRENT_BRANCH" = "main" ]; then
   exit 1
 fi
 
-# Gate 2: 마지막 10 커밋 메시지 Conventional Commits 형식 검증
+# Gate 2: push 대상 신규 커밋만 Conventional Commits 형식 검증 (origin/dev..HEAD 범위)
+# 과거 dev 히스토리는 체크에서 제외함 — origin/dev 없으면 fallback으로 최근 10개
 PATTERN='^(feat|fix|docs|chore|refactor|test|ci|revert|perf|style)(\(.+\))?!?: .+$'
-INVALID=$(git log --format=%s -10 --no-merges | grep -vE "$PATTERN" || true)
-if [ -n "$INVALID" ]; then
-  echo "BLOCKED: commit message convention violation:"
-  echo "$INVALID"
-  echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
-  exit 1
+if git rev-parse --verify origin/dev >/dev/null 2>&1; then
+  SUBJECTS=$(git log --format=%s --no-merges origin/dev..HEAD)
+else
+  SUBJECTS=$(git log --format=%s --no-merges -10 HEAD)
+fi
+
+if [ -n "$SUBJECTS" ]; then
+  INVALID=$(echo "$SUBJECTS" | grep -vE "$PATTERN" || true)
+  if [ -n "$INVALID" ]; then
+    echo "BLOCKED: commit message convention violation:"
+    echo "$INVALID"
+    echo "Fix: git reset --soft HEAD~N and rewrite commits. DO NOT force push."
+    exit 1
+  fi
 fi
 
 # Gate 3: uncommitted 변경 없음 확인 (untracked 파일 포함)

--- a/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
+++ b/docs/architecture/decisions/ADR-005-ci-advisory-transition.md
@@ -31,13 +31,10 @@ blocking 효과가 없음:
 1. `.github/workflows/commitlint.yml`의 `continue-on-error: true` → `false` 교체 PR
 2. GitHub repo Settings > Branch protection > Required status checks에 `commitlint` 추가
 
-> ⚠️ **Transition date 미박제 (작성 시점)**: Wave 2 머지가 완료되면 이 ADR을 편집하여
-> 실제 머지 날짜를 아래 `Transition date` 필드에 기입할 것.
-
 ## Transition date
 
-- **Wave 2 머지일**: TBD (Wave 2 머지 직후 이 ADR 편집하여 날짜 박제)
-- **Blocking 전환 기한**: Wave 2 머지일 + 14 days (D+14)
+- **Wave 2 머지일**: 2026-04-21 (BE PR #42 `fd57a31` create merge)
+- **Blocking 전환 기한**: 2026-05-05 (Wave 2 머지일 + 14 days)
 
 ## Alternatives considered
 


### PR DESCRIPTION
## Summary
- ADR-005 Transition date 박제: Wave 2 머지일 `2026-04-21` (PR #42 `fd57a31` create merge) → Blocking 전환 기한 `2026-05-05`
- `.githooks/pre-push` 범위 버그 수정: HEAD last 10 → `origin/dev..HEAD` (과거 dev 히스토리 검증 제외, 팀 전체 push 차단 버그 해소)

## Why
- Wave 2 머지 이후 14일 블로킹 전환 기한이 ADR-005에 TBD로 남아 있었음 → 실제 날짜 박제
- pre-push hook이 push 대상 신규 commits만 체크해야 하는데 HEAD 기준 last 10을 무차별 검증 → 이미 머지된 과거 commit이 팀 전체 push를 차단하던 문제

## Test plan
- [x] 로컬에서 수정된 hook으로 `--no-verify` 없이 push 통과
- [ ] CI green (docs/chore 변경이라 큰 리스크 없음)

Co-authored-by: gs07103 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * CI/CD 전환 일정이 확정되었습니다. (Wave 2 머지: 2026-04-21, Blocking 전환: 2026-05-05)

* **개선**
  * 커밋 검증 로직이 개선되어 푸시 시 더 정확한 검사를 수행합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->