### PR TITLE
Phase 17 + 17.6 dual-2pc → main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "dist/01-app/app.js",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.10.0"
   },
   "scripts": {
     "dev": "open-cli http://localhost:5000/api-docs && ts-node-dev --respawn --transpile-only -r tsconfig-paths/register ./src/01-app/app.ts",

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -9,6 +9,7 @@ import indexRouter from '@01-app/app.router';
 import { config } from '@07-shared/config/config';
 import { SocketService } from '@07-shared/lib/socket';
 import { AuthProviderRegistry } from '@05-features/auth/services/providers/auth-provider.registry';
+import { registerPairingTriggerListener } from '@01-app/startup-listeners';
 
 const app = express();
 app.use(cors());
@@ -59,6 +60,9 @@ async function connectDB() {
     });
 
     console.log('MongoDB 연결 성공');
+
+    // DUAL_2PC pairing + operator-join startup listener 등록함 (LD-23)
+    registerPairingTriggerListener();
 
     // 소셜 인증 공급자 초기화
     AuthProviderRegistry.initialize();

--- a/src/01-app/startup-listeners.ts
+++ b/src/01-app/startup-listeners.ts
@@ -1,0 +1,33 @@
+import { addPairingCompleteListener } from '@05-features/sessions/services/pairing.service';
+import { addOperatorJoinListener } from '@05-features/sessions/services/join-operator.service';
+import {
+  dualTriggerService,
+  operatorJoinedGroups,
+} from '@02-processes/engine/services/dual-2pc-trigger.service';
+
+let listenersRegistered = false;
+
+/**
+ * BE startup 시 pairing + operator-join listener 등록함.
+ * LD-32: 중복 호출 시 idempotent 보장됨.
+ * 호출 위치: src/01-app/app.ts의 connectDB() 내부, MongoDB 연결 직후 (LD-23).
+ *
+ * @returns true — 최초 등록 성공, false — 이미 등록됨
+ */
+export function registerPairingTriggerListener(): boolean {
+  if (listenersRegistered) return false;
+
+  // 페어링 완료 → 3조건 체크 + 자동 trigger 처리함
+  addPairingCompleteListener(async ({ groupId }) => {
+    await dualTriggerService.maybeTriggerDualAssignGroup(groupId);
+  });
+
+  // operator join 완료 → 플래그 등록 + 3조건 체크 처리함
+  addOperatorJoinListener(async ({ groupId }) => {
+    operatorJoinedGroups.add(groupId);
+    await dualTriggerService.maybeTriggerDualAssignGroup(groupId);
+  });
+
+  listenersRegistered = true;
+  return true;
+}

--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { engineRegistryService } from '../services/engine-registry.service';
 import { engineProxyService } from '../services/engine-proxy.service';
+import { dualTriggerService } from '../services/dual-2pc-trigger.service';
 import { stopMeasurementService } from '@02-processes/measurements/services/measurement.service';
 import { AppError } from '@07-shared/errors';
 import { SocketService } from '@07-shared/lib/socket';
@@ -186,6 +187,64 @@ export const engineController = {
       res.status(200).json({ ...engineResult, allCompleted });
     } catch (error) {
       next(error);
+    }
+  },
+
+  /** registry 상태 snapshot 반환함 (FE polling 용) */
+  getRegistryStatus: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const groupId = req.query.groupId as string;
+      if (!groupId || typeof groupId !== 'string') {
+        throw new AppError('groupId 쿼리 필수', 400);
+      }
+      const status = dualTriggerService.getRegistryStatus(groupId);
+      res.status(200).json(status);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  /** 양쪽 DE에 assign-group 트리거 요청 처리함 */
+  dualTrigger: async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { groupId } = req.body;
+      const subjects = await dualTriggerService.collectPendingSubjects(groupId);
+      if (subjects.length !== 2) {
+        throw new AppError('양쪽 DE 모두 pending 상태가 아님', 503);
+      }
+      const result = await dualTriggerService.triggerAssignGroup(
+        groupId,
+        subjects
+      );
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  /** DE startup pending 등록 처리함 */
+  registerPending: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { subjectIndex, engineUrl, secretKey } = req.body;
+      engineRegistryService.registerPending(subjectIndex, engineUrl, secretKey);
+      res.status(200).json({ status: 'registered' });
+    } catch (err) {
+      next(err);
+    }
+  },
+
+  /** DE 종료 시 pending entry 삭제 처리함 */
+  unregisterPending: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { subjectIndex, engineUrl, secretKey } = req.body;
+      engineRegistryService.unregisterPending(
+        subjectIndex,
+        engineUrl,
+        secretKey
+      );
+      res.status(200).json({ deleted: true });
+    } catch (err) {
+      next(err);
     }
   },
 

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -481,4 +481,46 @@ router.post(
   engineController.stopAll
 );
 
+// ===== Phase 17.6 — DUAL_2PC trigger gap hotfix 라우트 (LD-31) =====
+
+// registry 상태 snapshot 조회 (FE polling 용)
+router.get('/registry-status', engineController.getRegistryStatus);
+
+// 양쪽 DE에 assign-group 트리거 요청 처리함
+const dualTriggerSchema = z.object({
+  groupId: z.string().min(1),
+});
+
+router.post(
+  '/dual-trigger',
+  validate(dualTriggerSchema),
+  engineController.dualTrigger
+);
+
+// DE startup pending 등록 처리함
+const registerPendingSchema = z.object({
+  subjectIndex: z.union([z.literal(1), z.literal(2)]),
+  engineUrl: z.string().url(),
+  secretKey: z.string().min(1),
+});
+
+router.post(
+  '/register-pending',
+  validate(registerPendingSchema),
+  engineController.registerPending
+);
+
+// DE 종료 시 pending entry 삭제 처리함
+const unregisterPendingSchema = z.object({
+  subjectIndex: z.union([z.literal(1), z.literal(2)]),
+  engineUrl: z.string().url(),
+  secretKey: z.string().min(1),
+});
+
+router.delete(
+  '/register-pending',
+  validate(unregisterPendingSchema),
+  engineController.unregisterPending
+);
+
 export default router;

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
@@ -1,0 +1,461 @@
+/**
+ * dual-2pc-trigger.service.ts — Unit 테스트 (Phase 17.6 T-BE-1 ~ T-BE-12)
+ *
+ * 검증 항목:
+ *   T-BE-1: 양쪽 1회 성공 → ready=true
+ *   T-BE-2: 한쪽 3회 fail → cleanupGroup + dual-session-failed emit
+ *   T-BE-3: 동시 trigger 2회 멱등 (inFlight lock)
+ *   T-BE-4: status cache 상태 변화 검증
+ *   T-BE-5: AbortError 처리 → cleanup 호출
+ *   T-BE-6: maybeTriggerDualAssignGroup 3조건 충족 시 자동 trigger
+ *   T-BE-7: partial-failure 후 재trigger → already_registered 보상 등록
+ *   T-BE-8: 4xx non-retryable 즉시 fail
+ *   T-BE-9: registerPending secret mismatch → 403
+ *   T-BE-10: unregisterPending idempotent + secret 검증
+ *   T-BE-11: getRegistryStatus 기본값 반환
+ *   T-BE-12: registerPairingTriggerListener 2회 호출 idempotent
+ */
+
+// ===== config mock — 시크릿 키 주입 =====
+jest.mock('@07-shared/config/config', () => ({
+  config: {
+    dataEngine: { secretKey: 'valid-secret' },
+  },
+}));
+
+// ===== SocketService mock =====
+jest.mock('@07-shared/lib/socket', () => ({
+  SocketService: {
+    emitToGroup: jest.fn(),
+  },
+}));
+
+// ===== Session mock — Mongoose 격리 =====
+jest.mock('@06-entities/sessions', () => ({
+  Session: {
+    find: jest.fn(),
+  },
+}));
+
+// ===== 전역 fetch mock =====
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// ===== 표준 subjects fixture =====
+const subjects = [
+  {
+    groupId: 'grp-001',
+    url: 'http://de-1.ngrok-free.dev',
+    subjectIndex: 1 as const,
+  },
+  {
+    groupId: 'grp-001',
+    url: 'http://de-2.ngrok-free.dev',
+    subjectIndex: 2 as const,
+  },
+];
+
+// 성공 응답 helper
+function mockSuccess(status = 'registered') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ status }),
+  };
+}
+
+// 실패 응답 helper
+function mockFail(statusCode: number, errCode?: string) {
+  return {
+    ok: false,
+    status: statusCode,
+    json: async () => (errCode ? { detail: { error: errCode } } : {}),
+  };
+}
+
+describe('dualTriggerService — Phase 17.6', () => {
+  let dualTriggerService: typeof import('./dual-2pc-trigger.service').dualTriggerService;
+  let engineRegistryService: typeof import('./engine-registry.service').engineRegistryService;
+  let SocketService: { emitToGroup: jest.Mock };
+
+  beforeEach(() => {
+    // 모듈 상태 격리 — 각 테스트마다 fresh module
+    jest.resetModules();
+
+    // config mock 재등록
+    jest.mock('@07-shared/config/config', () => ({
+      config: {
+        dataEngine: { secretKey: 'valid-secret' },
+      },
+    }));
+
+    // SocketService mock 재등록
+    jest.mock('@07-shared/lib/socket', () => ({
+      SocketService: {
+        emitToGroup: jest.fn(),
+      },
+    }));
+
+    // Session mock 재등록
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn(),
+      },
+    }));
+
+    mockFetch.mockReset();
+
+    dualTriggerService =
+      require('./dual-2pc-trigger.service').dualTriggerService;
+    engineRegistryService =
+      require('./engine-registry.service').engineRegistryService;
+    SocketService = require('@07-shared/lib/socket').SocketService;
+    // Session mock 참조는 T-BE-6에서 직접 re-import 패턴으로 사용됨
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  });
+
+  // ============================================================
+  // T-BE-1: 양쪽 1회 성공 → ready=true
+  // ============================================================
+
+  it('T-BE-1: 양쪽 1회 성공 → ready=true', async () => {
+    // RC4-C-1 fix: fetch mock에 json() 메서드 필수
+    mockFetch
+      .mockResolvedValueOnce(mockSuccess('registered'))
+      .mockResolvedValueOnce(mockSuccess('registered'));
+
+    const result = await dualTriggerService.triggerAssignGroup(
+      'grp-001',
+      subjects
+    );
+
+    expect(result.status).toBe('triggered');
+    const status = dualTriggerService.getRegistryStatus('grp-001');
+    expect(status.ready).toBe(true);
+  });
+
+  // ============================================================
+  // T-BE-2: 한쪽 3회 fail → cleanupGroup + dual-session-failed emit
+  // ============================================================
+
+  it('T-BE-2: 한쪽 3회 fail → cleanupGroup + dual-session-failed emit', async () => {
+    const cleanupSpy = jest.spyOn(engineRegistryService, 'cleanupGroup');
+
+    mockFetch
+      // subject 1: 성공
+      .mockResolvedValueOnce(mockSuccess('registered'))
+      // subject 2: 3회 fail (502)
+      .mockResolvedValueOnce(mockFail(502))
+      .mockResolvedValueOnce(mockFail(502))
+      .mockResolvedValueOnce(mockFail(502));
+
+    await dualTriggerService.triggerAssignGroup('grp-001', subjects);
+
+    expect(cleanupSpy).toHaveBeenCalledWith('grp-001');
+    expect(SocketService.emitToGroup).toHaveBeenCalledWith(
+      'grp-001',
+      'dual-session-failed',
+      expect.objectContaining({
+        groupId: 'grp-001',
+        error: expect.any(String),
+      })
+    );
+
+    const status = dualTriggerService.getRegistryStatus('grp-001');
+    expect(status.ready).toBe(false);
+  });
+
+  // ============================================================
+  // T-BE-3: 동시 trigger 2회 멱등 (inFlight lock)
+  // ============================================================
+
+  it('T-BE-3: 동시 trigger 2회 → inFlight lock으로 1번만 실행됨', async () => {
+    mockFetch.mockResolvedValue(mockSuccess('registered'));
+
+    const p1 = dualTriggerService.triggerAssignGroup('grp-001', subjects);
+    const p2 = dualTriggerService.triggerAssignGroup('grp-001', subjects);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    const statuses = [r1.status, r2.status].sort();
+    // 하나는 triggered, 하나는 in_progress (또는 already_ready)
+    expect(
+      statuses.includes('in_progress') || statuses.includes('already_ready')
+    ).toBe(true);
+
+    // iter 2 M-2 fix: race 안정화 — fetch 호출 수는 2~4 범위
+    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(4);
+  });
+
+  // ============================================================
+  // T-BE-4: status cache 상태 변화 검증
+  // ============================================================
+
+  it('T-BE-4: 초기 상태 → in_progress → ready 상태 전이 검증됨', async () => {
+    // 초기: statusCache 미진입 → 기본값
+    const initial = dualTriggerService.getRegistryStatus('grp-004');
+    expect(initial).toEqual({
+      ready: false,
+      registered: 0,
+      attempts: 0,
+      inFlight: false,
+    });
+
+    // trigger 후 ready=true
+    mockFetch
+      .mockResolvedValueOnce(mockSuccess('registered'))
+      .mockResolvedValueOnce(mockSuccess('registered'));
+
+    await dualTriggerService.triggerAssignGroup('grp-004', [
+      { ...subjects[0], groupId: 'grp-004' },
+      { ...subjects[1], groupId: 'grp-004' },
+    ]);
+
+    const after = dualTriggerService.getRegistryStatus('grp-004');
+    expect(after.ready).toBe(true);
+    expect(after.inFlight).toBe(false);
+  });
+
+  // ============================================================
+  // T-BE-5: AbortError → cleanup 호출
+  // ============================================================
+
+  it('T-BE-5: fetch AbortError → 3회 retry 후 cleanup 호출됨', async () => {
+    // RC5-fix: fake timer 대신 fetch mock에서 AbortError 직접 throw
+    mockFetch.mockImplementation(() =>
+      Promise.reject(
+        new DOMException('The operation was aborted', 'AbortError')
+      )
+    );
+
+    const cleanupSpy = jest.spyOn(engineRegistryService, 'cleanupGroup');
+
+    await dualTriggerService.triggerAssignGroup('grp-005', subjects);
+
+    expect(cleanupSpy).toHaveBeenCalledWith('grp-005');
+    // AbortError는 parentSignal.aborted=false이므로 retry 3회 × 2 subjects = 최대 6회
+    // 단, parentSignal aborted가 아니면 retry 됨
+    expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ============================================================
+  // T-BE-6: maybeTriggerDualAssignGroup 3조건 충족 시 자동 trigger
+  // ============================================================
+
+  it('T-BE-6: maybeTriggerDualAssignGroup — 3조건 충족 시 자동 trigger 호출됨', async () => {
+    // RC5-H-2 fix: jest.resetModules() 이후 re-import
+    jest.resetModules();
+    jest.mock('@07-shared/config/config', () => ({
+      config: { dataEngine: { secretKey: 'valid-secret' } },
+    }));
+    jest.mock('@07-shared/lib/socket', () => ({
+      SocketService: { emitToGroup: jest.fn() },
+    }));
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'grp-006',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'grp-006',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const freshRegistryModule = await import('./engine-registry.service');
+
+    // pending subjects 등록
+    freshRegistryModule.engineRegistryService.registerPending(
+      1,
+      'http://de-1.ngrok-free.dev',
+      'valid-secret'
+    );
+    freshRegistryModule.engineRegistryService.registerPending(
+      2,
+      'http://de-2.ngrok-free.dev',
+      'valid-secret'
+    );
+
+    // operatorJoined 플래그 설정
+    freshModule.operatorJoinedGroups.add('grp-006');
+
+    // fetch mock 설정
+    mockFetch
+      .mockResolvedValueOnce(mockSuccess('registered'))
+      .mockResolvedValueOnce(mockSuccess('registered'));
+
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('grp-006');
+
+    expect(triggerSpy).toHaveBeenCalledWith('grp-006', expect.any(Array));
+  });
+
+  // ============================================================
+  // T-BE-7: partial-failure 후 재trigger → already_registered 보상 등록
+  // ============================================================
+
+  it('T-BE-7: 재trigger 시 already_registered → BE registerDual 보상 등록됨', async () => {
+    const registerDualSpy = jest.spyOn(engineRegistryService, 'registerDual');
+
+    // grp-007 전용 subjects fixture — groupId 일치 필수
+    const subjects007 = [
+      {
+        groupId: 'grp-007',
+        url: 'http://de-1.ngrok-free.dev',
+        subjectIndex: 1 as const,
+      },
+      {
+        groupId: 'grp-007',
+        url: 'http://de-2.ngrok-free.dev',
+        subjectIndex: 2 as const,
+      },
+    ];
+
+    // 1차 trigger: subject 1 성공 / subject 2 fail × 3
+    mockFetch
+      .mockResolvedValueOnce(mockSuccess('registered'))
+      .mockResolvedValueOnce(mockFail(502))
+      .mockResolvedValueOnce(mockFail(502))
+      .mockResolvedValueOnce(mockFail(502))
+      // 2차 trigger: subject 1 already_registered / subject 2 success
+      .mockResolvedValueOnce(mockSuccess('already_registered'))
+      .mockResolvedValueOnce(mockSuccess('registered'));
+
+    // 1차 trigger
+    await dualTriggerService.triggerAssignGroup('grp-007', subjects007);
+    // 1차 후 registerDualSpy 초기화
+    registerDualSpy.mockClear();
+
+    // 2차 trigger
+    await dualTriggerService.triggerAssignGroup('grp-007', subjects007);
+
+    // 보상 등록: subject 1 already_registered → BE registerDual 직접 호출됨
+    expect(registerDualSpy).toHaveBeenCalledWith(
+      'grp-007',
+      1,
+      expect.any(String),
+      expect.any(String)
+    );
+  });
+
+  // ============================================================
+  // T-BE-8: 4xx non-retryable 즉시 fail
+  // ============================================================
+
+  it('T-BE-8: 401 invalid_secret → retry 없이 즉시 fail됨', async () => {
+    mockFetch.mockResolvedValue(mockFail(401, 'invalid_secret'));
+
+    await dualTriggerService.triggerAssignGroup('grp-008', subjects);
+
+    // non-retryable이므로 양쪽 × 1회 = 최대 2회 (3회 retry 아님)
+    expect(mockFetch.mock.calls.length).toBeLessThanOrEqual(2);
+
+    const status = dualTriggerService.getRegistryStatus('grp-008');
+    expect(status.ready).toBe(false);
+    expect(status.lastError).toBe('invalid_secret');
+  });
+
+  // ============================================================
+  // T-BE-9: registerPending secret mismatch → AppError 403
+  // ============================================================
+
+  it('T-BE-9: registerPending secret mismatch → AppError 403 발생함', () => {
+    expect(() =>
+      engineRegistryService.registerPending(1, 'http://test', 'wrong-secret')
+    ).toThrow();
+
+    try {
+      engineRegistryService.registerPending(1, 'http://test', 'wrong-secret');
+    } catch (err: unknown) {
+      expect((err as { statusCode?: number }).statusCode).toBe(403);
+    }
+  });
+
+  // ============================================================
+  // T-BE-10: DELETE /register-pending idempotent + secret 검증
+  // ============================================================
+
+  it('T-BE-10: unregisterPending — 정상 삭제 + idempotent + secret 검증됨', () => {
+    // 정상 등록
+    engineRegistryService.registerPending(1, 'http://de-1', 'valid-secret');
+    expect(engineRegistryService.getPendingSubjects()).toHaveLength(1);
+
+    // 정상 삭제
+    engineRegistryService.unregisterPending(1, 'http://de-1', 'valid-secret');
+    expect(engineRegistryService.getPendingSubjects()).toEqual([]);
+
+    // 이미 없음 → idempotent (throw 금지)
+    expect(() =>
+      engineRegistryService.unregisterPending(1, 'http://de-1', 'valid-secret')
+    ).not.toThrow();
+
+    // secret mismatch → 403
+    engineRegistryService.registerPending(1, 'http://de-1', 'valid-secret');
+    expect(() =>
+      engineRegistryService.unregisterPending(1, 'http://de-1', 'wrong-secret')
+    ).toThrow();
+    try {
+      engineRegistryService.unregisterPending(1, 'http://de-1', 'wrong-secret');
+    } catch (err: unknown) {
+      expect((err as { statusCode?: number }).statusCode).toBe(403);
+    }
+  });
+
+  // ============================================================
+  // T-BE-11: getRegistryStatus 기본값 반환
+  // ============================================================
+
+  it('T-BE-11: getRegistryStatus — 미진입 groupId 시 기본값 반환됨', () => {
+    const status = dualTriggerService.getRegistryStatus('grp-never-triggered');
+    expect(status).toEqual({
+      ready: false,
+      registered: 0,
+      attempts: 0,
+      inFlight: false,
+    });
+  });
+
+  // ============================================================
+  // T-BE-12: registerPairingTriggerListener 2회 호출 idempotent
+  // ============================================================
+
+  it('T-BE-12: registerPairingTriggerListener 2회 호출 시 2번째는 false 반환됨', async () => {
+    jest.resetModules();
+    jest.mock('@07-shared/config/config', () => ({
+      config: { dataEngine: { secretKey: 'valid-secret' } },
+    }));
+    jest.mock('@07-shared/lib/socket', () => ({
+      SocketService: { emitToGroup: jest.fn() },
+    }));
+    jest.mock('@06-entities/sessions', () => ({
+      Session: { find: jest.fn() },
+    }));
+
+    const freshModule = await import('./dual-2pc-trigger.service');
+
+    const result1 = freshModule.registerPairingTriggerListener();
+    const result2 = freshModule.registerPairingTriggerListener();
+
+    // 1회차: 등록 성공 → true
+    expect(result1).toBe(true);
+    // 2회차: 이미 등록됨 → false (idempotent)
+    expect(result2).toBe(false);
+  });
+});

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
@@ -38,6 +38,7 @@ jest.mock('@06-entities/sessions', () => ({
 }));
 
 // ===== 전역 fetch mock =====
+const originalFetch = global.fetch;
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -116,6 +117,11 @@ describe('dualTriggerService — Phase 17.6', () => {
   afterEach(() => {
     jest.clearAllMocks();
     jest.clearAllTimers();
+  });
+
+  afterAll(() => {
+    // 전역 fetch 원복 — 테스트 파일 간 상태 누수 방지함
+    global.fetch = originalFetch;
   });
 
   // ============================================================

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
@@ -447,11 +447,18 @@ describe('dualTriggerService — Phase 17.6', () => {
     jest.mock('@06-entities/sessions', () => ({
       Session: { find: jest.fn() },
     }));
+    jest.mock('@05-features/sessions/services/pairing.service', () => ({
+      addPairingCompleteListener: jest.fn(),
+    }));
+    jest.mock('@05-features/sessions/services/join-operator.service', () => ({
+      addOperatorJoinListener: jest.fn(),
+    }));
 
-    const freshModule = await import('./dual-2pc-trigger.service');
+    const { registerPairingTriggerListener } =
+      await import('@01-app/startup-listeners');
 
-    const result1 = freshModule.registerPairingTriggerListener();
-    const result2 = freshModule.registerPairingTriggerListener();
+    const result1 = registerPairingTriggerListener();
+    const result2 = registerPairingTriggerListener();
 
     // 1회차: 등록 성공 → true
     expect(result1).toBe(true);

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.ts
@@ -1,0 +1,472 @@
+/**
+ * Phase 17.6 — DUAL_2PC trigger gap hotfix
+ *
+ * 3-condition AND 충족 시 양쪽 DE에 /control/assign-group POST 호출함.
+ * 멱등 lock + status cache + abort signal + exponential backoff retry 구현함.
+ */
+
+import { Session } from '@06-entities/sessions';
+import { config } from '@07-shared/config/config';
+import { SocketService } from '@07-shared/lib/socket';
+import { engineRegistryService } from './engine-registry.service';
+
+// ===== 공개 인터페이스 타입 =====
+
+/** FE polling 용 registry 상태 snapshot */
+export interface RegistryStatus {
+  ready: boolean;
+  registered: 0 | 1 | 2;
+  attempts: number;
+  inFlight: boolean;
+  lastError?:
+    | 'subject_1_failed'
+    | 'subject_2_failed'
+    | 'both_failed'
+    | 'invalid_secret'
+    | 'not_pending_mode'
+    | 'group_id_conflict'
+    | 'precondition_unmet';
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+/** DE pending 정보 — groupId + url + subjectIndex 묶음 */
+export interface DePendingInfo {
+  groupId: string;
+  url: string;
+  subjectIndex: 1 | 2;
+}
+
+/** dualTriggerService 공개 API */
+export interface DualTriggerService {
+  /**
+   * 양쪽 DE에 /control/assign-group POST 호출함.
+   * Promise.allSettled + 3회 retry exponential backoff 적용함.
+   * 멱등: inFlight.has(groupId) 시 즉시 in_progress 반환함.
+   *
+   * @param groupId - 실험 그룹 ID
+   * @param subjects - DePendingInfo 배열 (subjectIndex 1, 2 각각)
+   * @returns 트리거 결과 status
+   */
+  triggerAssignGroup(
+    groupId: string,
+    subjects: DePendingInfo[]
+  ): Promise<{ status: 'triggered' | 'in_progress' | 'already_ready' }>;
+
+  /**
+   * registry 상태 snapshot 반환함 (FE polling 용).
+   * statusCache 미진입 groupId 시 기본값 반환함 (RC5-M-1 fix).
+   *
+   * @param groupId - 조회 대상 그룹 ID
+   * @returns RegistryStatus — 기본값 ready=false, registered=0
+   */
+  getRegistryStatus(groupId: string): RegistryStatus;
+
+  /**
+   * 실험 시작 직전 status cache invalidate + 진행 중 retry abort 처리함.
+   *
+   * @param groupId - 초기화 대상 그룹 ID
+   */
+  resetStatus(groupId: string): void;
+
+  /**
+   * pending registry 조회 후 DePendingInfo[] 반환함.
+   * 양쪽 DE 모두 pending 상태가 아니면 빈 배열 반환함 (LD-13).
+   *
+   * @param groupId - 트리거 대상 groupId (각 entry에 attach됨)
+   * @returns subjectIndex 1, 2 둘 다 pending 시 길이 2 배열
+   */
+  collectPendingSubjects(groupId: string): Promise<DePendingInfo[]>;
+
+  /**
+   * 페어링 + operator-join 3-condition 체크 후 자동 trigger 시도함.
+   * pairing listener / operator-join listener 에서 호출됨 (LD-12 대안 D).
+   *
+   * @param groupId - 체크 대상 groupId
+   */
+  maybeTriggerDualAssignGroup(groupId: string): Promise<void>;
+}
+
+// ===== 모듈 레벨 상태 =====
+
+/** 현재 trigger 진행 중인 groupId Set — 멱등 lock (LD-5) */
+export const inFlight = new Set<string>();
+
+/** stale lock 안전 장치 타이머 Map */
+export const inFlightTimeouts = new Map<string, NodeJS.Timeout>();
+
+/** 진행 중 retry abort controller Map (LD-19 resetStatus 지원) */
+export const inFlightControllers = new Map<string, AbortController>();
+
+/** status GC 타이머 Map (LD-6 30분 idle GC) */
+export const gcTimeouts = new Map<string, NodeJS.Timeout>();
+
+/** groupId → RegistryStatus 캐시 (LD-6) */
+export const statusCache = new Map<string, RegistryStatus>();
+
+/** operator-join 완료 그룹 Set — BE 메모리 저장 (LD-11) */
+export const operatorJoinedGroups = new Set<string>();
+
+// ===== 상수 =====
+
+/** stale lock 자동 해제 시간 ms (retry worst 31s + buffer) */
+const STALE_LOCK_MS = 60_000;
+
+/** status cache 자동 GC 시간 ms (30분) */
+const STATUS_GC_MS = 30 * 60_000;
+
+/** retry 기본 delay ms */
+const RETRY_BASE_MS = 1000;
+
+/** retry delay 상한 ms */
+const RETRY_CAP_MS = 8000;
+
+/** retry 횟수 */
+const RETRY_COUNT = 3;
+
+/** per-attempt fetch timeout ms */
+const PER_ATTEMPT_TIMEOUT_MS = 8000;
+
+// ===== module-internal 에러 클래스 (LD-14, RC5-H-1 fix) =====
+
+/** 4xx non-retryable 에러 — retry 없이 즉시 fail 처리됨 */
+class NonRetryableError extends Error {
+  public readonly isOperational = true;
+
+  constructor(
+    public errCode: string,
+    public httpStatus: number
+  ) {
+    super(`DE ${httpStatus}: ${errCode}`);
+    this.name = 'NonRetryableError';
+  }
+}
+
+/** 409 conflict 에러 — DE 재시작 필요 (LD-14) */
+class ConflictError extends Error {
+  public readonly isOperational = true;
+
+  constructor(
+    public errCode: string,
+    public currentGroupId?: string
+  ) {
+    super(`DE_CONFLICT:${errCode}:${currentGroupId}`);
+    this.name = 'ConflictError';
+  }
+}
+
+// ===== 내부 헬퍼 =====
+
+/**
+ * 단일 DE에 /control/assign-group POST 호출 + 3회 retry 처리함.
+ * LD-14 분기: 4xx non-retryable, 5xx retryable, 200 already_registered 보상 등록함.
+ *
+ * @param s - DePendingInfo (groupId, url, subjectIndex)
+ * @param parentSignal - inFlightControllers abort signal (LD-24)
+ */
+async function callWithRetry(
+  s: DePendingInfo,
+  parentSignal: AbortSignal
+): Promise<void> {
+  for (let attempt = 1; attempt <= RETRY_COUNT; attempt++) {
+    // attempts 카운터 증가 (statusCache 반드시 존재 — triggerAssignGroup에서 초기화됨)
+    const cached = statusCache.get(s.groupId);
+    if (cached) cached.attempts++;
+
+    try {
+      // per-attempt timeout + parent abort 결합 (LD-19, LD-21 — Node 20.3+ 필요)
+      const signal = AbortSignal.any([
+        parentSignal,
+        AbortSignal.timeout(PER_ATTEMPT_TIMEOUT_MS),
+      ]);
+
+      const res = await fetch(`${s.url}/control/assign-group`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Engine-Secret': config.dataEngine.secretKey,
+        },
+        // eslint-disable-next-line camelcase
+        body: JSON.stringify({ group_id: s.groupId }),
+        signal,
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      // ===== 200 OK 분기 =====
+      if (res.ok) {
+        // LD-15 보상 경로: already_registered 시 BE가 직접 registerDual 호출함
+        if (
+          (data as Record<string, unknown>)?.status === 'already_registered'
+        ) {
+          engineRegistryService.registerDual(
+            s.groupId,
+            s.subjectIndex,
+            s.url,
+            config.dataEngine.secretKey
+          );
+          console.log(
+            `[보상 등록] DE already_registered → BE registerDual: subject=${s.subjectIndex}`
+          );
+        }
+        return; // success (registered 또는 already_registered 보상 모두 정상 처리됨)
+      }
+
+      // ===== 비-200 분기: LD-14 분류 처리 =====
+      const errBody = data as Record<string, unknown>;
+      const errCode =
+        (errBody?.detail as Record<string, unknown>)?.error ?? 'unknown';
+
+      // 401 invalid_secret / 400 not_pending_mode → non-retryable, 즉시 throw
+      if (res.status === 401 || res.status === 400) {
+        throw new NonRetryableError(String(errCode), res.status);
+      }
+      // 409 group_id_conflict → non-retryable, 복구 안내 (DE 재시작 필요)
+      if (res.status === 409) {
+        const current =
+          (errBody?.detail as Record<string, unknown>)?.current ?? undefined;
+        throw new ConflictError(
+          String(errCode),
+          current !== undefined ? String(current) : undefined
+        );
+      }
+      // 502 backend_register_failed / 5xx 기타 → retryable
+      throw new Error(`DE ${res.status}: ${JSON.stringify(data)}`);
+    } catch (err) {
+      // NonRetryableError / ConflictError → retry 안 함, 즉시 상위로 전파
+      if (err instanceof NonRetryableError || err instanceof ConflictError) {
+        throw err;
+      }
+      // AbortError (parent abort) → 즉시 전파, retry 안 함
+      if ((err as Error).name === 'AbortError' && parentSignal.aborted) {
+        throw err;
+      }
+      // 마지막 attempt → 전파
+      if (attempt === RETRY_COUNT) throw err;
+      // backoff 후 재시도
+      const delay = Math.min(RETRY_BASE_MS * 2 ** (attempt - 1), RETRY_CAP_MS);
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+// ===== startup listener 멱등 guard (LD-32) =====
+let listenersRegistered = false;
+
+// ===== 공개 서비스 객체 =====
+
+export const dualTriggerService: DualTriggerService = {
+  async triggerAssignGroup(groupId, subjects) {
+    // 1. 멱등 guard — inFlight 중복 방지 (LD-5)
+    if (inFlight.has(groupId)) return { status: 'in_progress' };
+    // 1b. 이미 양쪽 등록 완료 guard
+    if (engineRegistryService.isFullyRegistered(groupId, 2)) {
+      return { status: 'already_ready' };
+    }
+
+    // 2. lock + abort controller + stale timeout (LD-19)
+    inFlight.add(groupId);
+    const controller = new AbortController();
+    inFlightControllers.set(groupId, controller);
+
+    const staleLockTimer = setTimeout(() => {
+      // stale lock 강제 해제
+      controller.abort();
+      inFlightControllers.delete(groupId);
+      inFlight.delete(groupId);
+      inFlightTimeouts.delete(groupId);
+    }, STALE_LOCK_MS);
+    // process 종료 시 타이머가 Node를 block하지 않도록 unref 적용함
+    staleLockTimer.unref();
+    inFlightTimeouts.set(groupId, staleLockTimer);
+
+    // 초기 status 설정
+    statusCache.set(groupId, {
+      ready: false,
+      registered: 0,
+      attempts: 0,
+      inFlight: true,
+      startedAt: Date.now(),
+    });
+
+    try {
+      // 3. Promise.allSettled — 부분 성공 처리 (LD-3, LD-24)
+      const results = await Promise.allSettled(
+        subjects.map((s) => callWithRetry(s, controller.signal))
+      );
+
+      const successCount = results.filter(
+        (r) => r.status === 'fulfilled'
+      ).length;
+      const fail1 = results[0]?.status === 'rejected';
+      const fail2 = results[1]?.status === 'rejected';
+
+      // 4. 결과 분기
+      if (successCount === subjects.length && subjects.length > 0) {
+        statusCache.set(groupId, {
+          ...statusCache.get(groupId)!,
+          ready: true,
+          registered: 2,
+          inFlight: false,
+          finishedAt: Date.now(),
+        });
+        return { status: 'triggered' };
+      }
+
+      // 5. 부분 또는 전체 실패 → cleanup + emit (LD-4, LD-28)
+      engineRegistryService.cleanupGroup(groupId);
+
+      // lastError 결정: LD-14 NonRetryableError/ConflictError errCode 우선 사용
+      let lastError: RegistryStatus['lastError'];
+      const rej0 = results[0] as PromiseRejectedResult | undefined;
+      const rej1 = results[1] as PromiseRejectedResult | undefined;
+      const e0 = rej0?.reason;
+      const e1 = rej1?.reason;
+
+      if (fail1 && fail2) {
+        // NonRetryableError가 있으면 구체 errCode 우선 사용 (LD-14)
+        if (e0 instanceof NonRetryableError || e0 instanceof ConflictError) {
+          lastError = e0.errCode as RegistryStatus['lastError'];
+        } else if (
+          e1 instanceof NonRetryableError ||
+          e1 instanceof ConflictError
+        ) {
+          lastError = e1.errCode as RegistryStatus['lastError'];
+        } else {
+          lastError = 'both_failed';
+        }
+      } else if (fail1) {
+        if (e0 instanceof NonRetryableError || e0 instanceof ConflictError) {
+          lastError = e0.errCode as RegistryStatus['lastError'];
+        } else {
+          lastError = 'subject_1_failed';
+        }
+      } else {
+        if (e1 instanceof NonRetryableError || e1 instanceof ConflictError) {
+          lastError = e1.errCode as RegistryStatus['lastError'];
+        } else {
+          lastError = 'subject_2_failed';
+        }
+      }
+
+      statusCache.set(groupId, {
+        ...statusCache.get(groupId)!,
+        ready: false,
+        registered: 0,
+        inFlight: false,
+        lastError,
+        finishedAt: Date.now(),
+      });
+
+      // 실패 socket emit — best-effort 보조 (LD-8, LD-28)
+      SocketService.emitToGroup(groupId, 'dual-session-failed', {
+        groupId,
+        error: lastError ?? 'both_failed',
+      });
+
+      return { status: 'triggered' };
+    } finally {
+      // 6. lock 해제 (try/finally 보장, LD-5)
+      inFlight.delete(groupId);
+      const t = inFlightTimeouts.get(groupId);
+      if (t) clearTimeout(t);
+      inFlightTimeouts.delete(groupId);
+      inFlightControllers.delete(groupId);
+
+      // 기존 GC 타이머 교체 (중복 누적 방지, iter 1 M-2 fix)
+      const existingGc = gcTimeouts.get(groupId);
+      if (existingGc) clearTimeout(existingGc);
+      const gcTimer = setTimeout(() => {
+        statusCache.delete(groupId);
+        gcTimeouts.delete(groupId);
+      }, STATUS_GC_MS);
+      // process 종료 시 GC 타이머가 Jest/Node를 block하지 않도록 unref 적용함
+      gcTimer.unref();
+      gcTimeouts.set(groupId, gcTimer);
+    }
+  },
+
+  getRegistryStatus(groupId) {
+    // RC5-M-1 fix: statusCache 미진입 시 기본값 반환함
+    return (
+      statusCache.get(groupId) ?? {
+        ready: false,
+        registered: 0,
+        attempts: 0,
+        inFlight: false,
+      }
+    );
+  },
+
+  resetStatus(groupId) {
+    // 1. retry loop abort (LD-19)
+    const controller = inFlightControllers.get(groupId);
+    if (controller) {
+      controller.abort();
+      inFlightControllers.delete(groupId);
+    }
+    // 2. lock 해제
+    inFlight.delete(groupId);
+    const t = inFlightTimeouts.get(groupId);
+    if (t) clearTimeout(t);
+    inFlightTimeouts.delete(groupId);
+    // 3. GC 타이머 해제
+    const gc = gcTimeouts.get(groupId);
+    if (gc) clearTimeout(gc);
+    gcTimeouts.delete(groupId);
+    // 4. status cache 삭제
+    statusCache.delete(groupId);
+  },
+
+  async collectPendingSubjects(groupId) {
+    const pending = engineRegistryService.getPendingSubjects();
+    // subjectIndex 1, 2 둘 다 있어야 trigger 가능 (LD-13, LD-25)
+    if (pending.length < 2) return [];
+    const hasSubject1 = pending.some((p) => p.subjectIndex === 1);
+    const hasSubject2 = pending.some((p) => p.subjectIndex === 2);
+    if (!hasSubject1 || !hasSubject2) return [];
+    // caller가 inject한 groupId를 각 entry에 attach함 (LD-25)
+    return pending.map((p) => ({
+      groupId,
+      url: p.url,
+      subjectIndex: p.subjectIndex,
+    }));
+  },
+
+  async maybeTriggerDualAssignGroup(groupId) {
+    // Mongoose Session 조회 — 3-condition AND 체크 (LD-1)
+    const sessions = await Session.find({ groupId });
+    if (sessions.length === 0) return;
+
+    const mode = sessions[0].experimentMode;
+    if (mode !== 'DUAL_2PC') return; // DUAL_2PC 모드가 아니면 skip
+
+    const subject1Paired = sessions.some(
+      (s) => s.subjectIndex === 1 && s.status === 'PAIRED'
+    );
+    const subject2Paired = sessions.some(
+      (s) => s.subjectIndex === 2 && s.status === 'PAIRED'
+    );
+    const operatorJoined = operatorJoinedGroups.has(groupId);
+
+    // 3조건 AND 체크 (LD-1)
+    if (!subject1Paired || !subject2Paired || !operatorJoined) return;
+
+    // pending DE 정보 조회 (LD-13)
+    const subjects = await dualTriggerService.collectPendingSubjects(groupId);
+    if (subjects.length !== 2) return;
+
+    await dualTriggerService.triggerAssignGroup(groupId, subjects);
+  },
+};
+
+/**
+ * BE startup 시 pairing + operator-join listener를 등록함.
+ * LD-32: 중복 호출 시 idempotent 처리됨.
+ * 호출 위치: src/01-app/app.ts의 connectDB() 내부, MongoDB 연결 직후 (LD-23).
+ */
+export function registerPairingTriggerListener(): boolean {
+  if (listenersRegistered) return false;
+  listenersRegistered = true;
+  return true;
+}

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.ts
@@ -250,9 +250,6 @@ async function callWithRetry(
   }
 }
 
-// ===== startup listener 멱등 guard (LD-32) =====
-let listenersRegistered = false;
-
 // ===== 공개 서비스 객체 =====
 
 export const dualTriggerService: DualTriggerService = {
@@ -459,14 +456,3 @@ export const dualTriggerService: DualTriggerService = {
     await dualTriggerService.triggerAssignGroup(groupId, subjects);
   },
 };
-
-/**
- * BE startup 시 pairing + operator-join listener를 등록함.
- * LD-32: 중복 호출 시 idempotent 처리됨.
- * 호출 위치: src/01-app/app.ts의 connectDB() 내부, MongoDB 연결 직후 (LD-23).
- */
-export function registerPairingTriggerListener(): boolean {
-  if (listenersRegistered) return false;
-  listenersRegistered = true;
-  return true;
-}

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -19,6 +19,15 @@ interface EngineRegistration {
   registeredAt: number;
 }
 
+// ===== Phase 17.6 — pending registry (LD-10) =====
+/** subjectIndex → pending entry (groupId 미정 상태) */
+interface PendingEntry {
+  url: string;
+  registeredAt: number;
+}
+
+const pendingRegistry = new Map<1 | 2, PendingEntry>();
+
 export const engineRegistryService = {
   // ===== 기존 메서드 — backward compat 유지 (engine-proxy.service.ts 5곳 호출 보존) =====
 
@@ -157,5 +166,57 @@ export const engineRegistryService = {
     dualRegistry.delete(groupId);
     registeredCallbacks.delete(groupId);
     console.log(`DUAL_2PC 엔진 레지스트리 정리 완료: groupId=${groupId}`);
+  },
+
+  // ===== Phase 17.6 — pending registry 메서드 (LD-10, LD-16, LD-26) =====
+
+  /**
+   * DE startup 시 본인 ngrok/LAN URL을 BE에 사전 등록함.
+   * groupId 미정 상태에서 호출됨 (assign-group 전).
+   *
+   * @param subjectIndex - 피실험자 순번 (1-based: 1 또는 2)
+   * @param url - DE의 ngrok 또는 LAN URL
+   * @param secretKey - 검증용 시크릿 키
+   * @throws AppError 403 — secretKey 불일치 시
+   */
+  registerPending(subjectIndex: 1 | 2, url: string, secretKey: string): void {
+    if (secretKey !== config.dataEngine.secretKey) {
+      throw new AppError('유효하지 않은 시크릿 키입니다.', 403);
+    }
+    pendingRegistry.set(subjectIndex, { url, registeredAt: Date.now() });
+    console.log(`pending 등록 완료: subjectIndex=${subjectIndex}, url=${url}`);
+  },
+
+  /**
+   * pending 상태인 양쪽 DE 정보 반환함.
+   *
+   * @returns subjectIndex + url 배열 (최대 2개)
+   */
+  getPendingSubjects(): Array<{ subjectIndex: 1 | 2; url: string }> {
+    const result: Array<{ subjectIndex: 1 | 2; url: string }> = [];
+    for (const [subjectIndex, entry] of pendingRegistry.entries()) {
+      result.push({ subjectIndex, url: entry.url });
+    }
+    return result;
+  },
+
+  /**
+   * DE process 종료 시 pending entry 삭제함. 멱등 동작 보장.
+   *
+   * @param subjectIndex - 삭제할 피실험자 순번
+   * @param url - 등록 시 사용한 URL (검증용)
+   * @param secretKey - 검증용 시크릿 키
+   * @throws AppError 403 — secretKey 불일치 시
+   */
+  unregisterPending(subjectIndex: 1 | 2, url: string, secretKey: string): void {
+    if (secretKey !== config.dataEngine.secretKey) {
+      throw new AppError('유효하지 않은 시크릿 키입니다.', 403);
+    }
+    const entry = pendingRegistry.get(subjectIndex);
+    if (entry && entry.url === url) {
+      pendingRegistry.delete(subjectIndex);
+      console.log(`pending 삭제 완료: subjectIndex=${subjectIndex}`);
+    }
+    // entry 없으면 idempotent — 아무 동작 안 함
   },
 };

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -201,6 +201,8 @@ function startDualMeasurement(groupId: string): void {
         timestamp_ms: Date.now(),
       });
     } catch (err) {
+      // T4 fix: 반쪽 등록 잔류 방지 — dualRegistry cleanup 호출함 (LD-4)
+      engineRegistryService.cleanupGroup(groupId);
       // 실패 통보 (60초 timeout + streamStart 실패 포함)
       SocketService.emitToGroup(groupId, 'dual-session-failed', {
         groupId,

--- a/src/05-features/sessions/services/join-operator.service.ts
+++ b/src/05-features/sessions/services/join-operator.service.ts
@@ -3,6 +3,29 @@ import { Session } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
 import { config } from '@07-shared/config/config';
 
+// ===== operator join 완료 listener registry =====
+
+type OperatorJoinCallback = (data: { groupId: string }) => void | Promise<void>;
+const operatorJoinListeners = new Set<OperatorJoinCallback>();
+
+/**
+ * operator join 완료 시 호출될 콜백 등록함.
+ *
+ * @param cb - groupId를 받는 콜백 함수
+ */
+export function addOperatorJoinListener(cb: OperatorJoinCallback): void {
+  operatorJoinListeners.add(cb);
+}
+
+/**
+ * operator join 완료 콜백 등록 해제함.
+ *
+ * @param cb - 제거할 콜백 함수
+ */
+export function removeOperatorJoinListener(cb: OperatorJoinCallback): void {
+  operatorJoinListeners.delete(cb);
+}
+
 /**
  * [Service] operator join 프로세스 수행함.
  *
@@ -41,6 +64,15 @@ export async function joinAsOperator(token: string): Promise<{
   const sessions = await Session.find({ groupId });
   if (sessions.length === 0) {
     throw new AppError('세션을 찾을 수 없습니다.', 404);
+  }
+
+  // operator join 완료 listener 호출 (LD-12 대안 D)
+  for (const cb of operatorJoinListeners) {
+    try {
+      await cb({ groupId });
+    } catch (err) {
+      console.error('operatorJoinListener 에러:', err);
+    }
   }
 
   return { groupId, experimentMode: 'DUAL_2PC' };

--- a/src/05-features/sessions/services/join-operator.service.ts
+++ b/src/05-features/sessions/services/join-operator.service.ts
@@ -67,12 +67,11 @@ export async function joinAsOperator(token: string): Promise<{
   }
 
   // operator join 완료 listener 호출 (LD-12 대안 D)
+  // fire-and-forget — listener 내부 retry/timeout이 응답 블로킹 방지함
   for (const cb of operatorJoinListeners) {
-    try {
-      await cb({ groupId });
-    } catch (err) {
+    void Promise.resolve(cb({ groupId })).catch((err) => {
       console.error('operatorJoinListener 에러:', err);
-    }
+    });
   }
 
   return { groupId, experimentMode: 'DUAL_2PC' };

--- a/src/05-features/sessions/services/pairing.service.ts
+++ b/src/05-features/sessions/services/pairing.service.ts
@@ -122,15 +122,16 @@ export const pairDeviceProcess = async (
   const saved = await session.save();
 
   // 페어링 완료 listener 호출 (LD-12 대안 D)
+  // fire-and-forget — listener 내부 retry/timeout이 응답 블로킹 방지함
   for (const cb of pairingListeners) {
-    try {
-      await cb({
+    void Promise.resolve(
+      cb({
         groupId: session.groupId,
         subjectIndex: session.subjectIndex,
-      });
-    } catch (err) {
+      })
+    ).catch((err) => {
       console.error('pairingListener 에러:', err);
-    }
+    });
   }
 
   return saved;

--- a/src/05-features/sessions/services/pairing.service.ts
+++ b/src/05-features/sessions/services/pairing.service.ts
@@ -4,6 +4,32 @@ import mongoose from 'mongoose';
 import { AppError } from '@07-shared/errors';
 import crypto from 'crypto';
 
+// ===== 페어링 완료 listener registry =====
+
+type PairingCallback = (data: {
+  groupId: string;
+  subjectIndex: number | null;
+}) => void | Promise<void>;
+const pairingListeners = new Set<PairingCallback>();
+
+/**
+ * 페어링 완료 시 호출될 콜백 등록함.
+ *
+ * @param cb - groupId + subjectIndex를 받는 콜백 함수
+ */
+export function addPairingCompleteListener(cb: PairingCallback): void {
+  pairingListeners.add(cb);
+}
+
+/**
+ * 페어링 완료 콜백 등록 해제함.
+ *
+ * @param cb - 제거할 콜백 함수
+ */
+export function removePairingCompleteListener(cb: PairingCallback): void {
+  pairingListeners.delete(cb);
+}
+
 /**
  * [Service] 운영자용 그룹 세션 생성 프로세스 정의함
  * $inc 원자적 연산으로 동시 요청 시에도 고유한 subjectIndex 보장함
@@ -92,5 +118,20 @@ export const pairDeviceProcess = async (
   session.userId = new Types.ObjectId(userId);
   session.pairedAt = new Date();
 
-  return await session.save();
+  // RC5-H-3 fix: return await 단일 expr 분리 필수
+  const saved = await session.save();
+
+  // 페어링 완료 listener 호출 (LD-12 대안 D)
+  for (const cb of pairingListeners) {
+    try {
+      await cb({
+        groupId: session.groupId,
+        subjectIndex: session.subjectIndex,
+      });
+    } catch (err) {
+      console.error('pairingListener 에러:', err);
+    }
+  }
+
+  return saved;
 };


### PR DESCRIPTION
## Summary
Phase 17 wiring + Phase 17.6 trigger gap hotfix + CodeRabbit Quick Win 3건 누적을 main으로 propagate.

## 누적 commits
- Phase 17 wiring (PR #46): DUAL_2PC measurement + sessions + engine registry
- Phase 17.6 trigger gap hotfix (PR #48 → #49): dual-2pc-trigger.service + 4 routes + listener registry
- CodeRabbit Quick Win 3건: fire-and-forget listener (join-operator/pairing) + global.fetch mock isolation

## 검증
- 267 Jest tests PASS / 26 suites
- depcruise 0 violations / lint 0 warnings / build OK

## Heroku 영향
**BE Heroku는 main push 시 자동 재배포 트리거됨** — v57 (cc037467, 2026-04-24) → v61+로 17 + 17.6 + Quick Win 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)