### PR TITLE
feat: Phase G DDD/BDD/TDD pilot — Session aggregate + pair-subject use case

### DIFF
--- a/.claude/skills/office-hours-ddd-discovery/SKILL.md
+++ b/.claude/skills/office-hours-ddd-discovery/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: office-hours-ddd-discovery
+description: Six forcing questions (Garry Tan gstack v2.0.0, MIT) adapted for DDD bounded context discovery. Use when starting a new bounded context, validating an aggregate boundary, or pivoting domain model.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Grep
+---
+
+# Office Hours × DDD Discovery
+
+> Origin: garrytan/gstack `office-hours/SKILL.md` v2.0.0 (MIT, Copyright 2026 Garry Tan)
+> Adaptation: ecosystem 의존성 제거 (`gbrain` schema, `~/.gstack/`, cross-skill calls). DDD discovery 맥락으로 재구성.
+> License: MIT — see UPSTREAM.md (full text inline)
+> Companion: docs/patterns/ddd-discovery-via-6q.md
+
+## When to invoke
+
+- Starting a **new bounded context** (greenfield aggregate)
+- Validating an **aggregate root boundary** (existing model)
+- Pivoting **domain model** after discovering edge case mismatch
+
+## 6 Forcing Questions (verbatim from gstack/office-hours, MIT — Copyright 2026 Garry Tan)
+
+Ask these questions **ONE AT A TIME** via AskUserQuestion. Push on each one until the answer is specific, evidence-based, and uncomfortable. Comfort means the team hasn't gone deep enough.
+
+**Smart routing based on bounded-context maturity:**
+- Pre-context (greenfield) → Q1, Q2, Q3
+- Has aggregates (model exists) → Q2, Q4, Q5
+- Has paying users (production) → Q4, Q5, Q6
+- Pure infra/CRUD → Q2, Q4 only
+
+### Q1: Demand Reality
+
+**Ask:** "What's the strongest evidence you have that someone actually wants this — not 'is interested,' not 'signed up for a waitlist,' but would be genuinely upset if it disappeared tomorrow?"
+
+**DDD lens**: surface the **Domain Event** that captures the demand signal. "User clicks save" is not a domain event. "Order placed" with monetary commitment is.
+
+**Push until you hear:** Specific behavior. Someone paying. Someone expanding usage. Someone building their workflow around it.
+
+### Q2: Status Quo
+
+**Ask:** "What are your users doing right now to solve this problem — even badly? What does that workaround cost them?"
+
+**DDD lens**: identify the **Anti-Corruption Layer** seam. Existing workarounds (Excel sheets, copy-paste flows) are evidence of where the new bounded context must integrate.
+
+**Push until you hear:** Specific workflow. Hours/dollars wasted. Tools duct-taped together.
+
+### Q3: Desperate Specificity
+
+**Ask:** "Name the actual human who needs this most. What's their title? What gets them promoted? What gets them fired? What keeps them up at night?"
+
+**DDD lens**: this is the **Domain Expert** who must collaborate on Ubiquitous Language. Without a name, there's no UL. "Operations team" is not a domain expert — "Sarah, fulfillment lead at warehouse 3" is.
+
+**Push until you hear:** A name. A role. A specific consequence.
+
+### Q4: Narrowest Wedge
+
+**Ask:** "What's the smallest possible version of this that someone would pay real money for — this week, not after you build the platform?"
+
+**DDD lens**: this defines the **Aggregate root boundary**. The narrowest wedge is the smallest aggregate that delivers value end-to-end. If you can't ship it as a single aggregate transaction, the boundary is wrong.
+
+**Push until you hear:** One feature. One workflow. Something shippable in days.
+
+### Q5: Observation & Surprise
+
+**Ask:** "Have you actually sat down and watched someone use this without helping them? What did they do that surprised you?"
+
+**DDD lens**: this is **Domain Expert collaboration**, not user testing. Caveat: real user-observation also counts, but the primary signal is **expert language drift** — the moment a domain expert uses a term you didn't expect, your UL is incomplete.
+
+**Push until you hear:** A specific surprise. Something that contradicted assumptions.
+
+### Q6: Future-Fit
+
+**Ask:** "If the world looks meaningfully different in 3 years — and it will — does your product become more essential or less?"
+
+**DDD lens**: this is **Strategic subdomain classification** (core / supporting / generic). Future-essential = core domain (invest). Future-irrelevant = generic (buy). Caveat: fit=3 (lower than other questions) — strategic classification is a board-level decision, not a domain modeling decision.
+
+**Push until you hear:** A specific claim about user-world change.
+
+---
+
+## Smart-skip + STOP
+
+- **Smart-skip**: If the user's answers to earlier questions already cover a later question, skip it. Only ask questions whose answers aren't yet clear.
+- **STOP** after each question. Wait for the response before asking the next.
+
+## Hard constraints
+
+- **One question at a time** (gstack 정책 그대로)
+- **No Q advancement without human response** — never simulate the answer
+- **Sequential Thinking MCP usage**: pre-processing only ("which Q is most critical for this stage?"). **Never use ST to substitute for AskUserQuestion** — human input is the value, not a placeholder.
+- **AskUserQuestion** is the only sanctioned mechanism for the 6Q loop

--- a/.claude/skills/office-hours-ddd-discovery/UPSTREAM.md
+++ b/.claude/skills/office-hours-ddd-discovery/UPSTREAM.md
@@ -1,0 +1,76 @@
+# UPSTREAM — office-hours-ddd-discovery skill
+
+> Adapted from garrytan/gstack
+> Upstream commit: 19e699ab9b69de9e1bf10d4b7c2682703b56f984
+> Date: 2026-05-06
+> Path: office-hours/SKILL.md
+> Upstream version (frontmatter `version`): 2.0.0
+
+## License (MIT — verbatim from garrytan/gstack/LICENSE)
+
+```
+MIT License
+
+Copyright (c) 2026 Garry Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Adaptation rationale (NOT verbatim)
+
+gstack `office-hours/SKILL.md` standalone vendor 불가:
+1. `gbrain` schema → `~/.gstack/builder-profile.jsonl`, `~/.gstack/projects/{repo_slug}/*-design-*.md`, `~/.gstack/analytics/eureka.jsonl` 의존
+2. `/plan-ceo-review`, `/plan-eng-review` cross-skill 의존
+3. `SKILL.md.tmpl` auto-generation (gen:skill-docs script — bun build infra)
+4. "Preamble (run first)" bash 명령 = gstack 환경 가정
+5. `preamble-tier`, `triggers`, `gbrain` frontmatter 키 = gstack ecosystem 전용
+
+→ 6 forcing questions 본문 (Q1-Q6) 만 MIT 표기로 인용 + DDD discovery 맥락 + Sequential Thinking MCP caveat 명시.
+
+## Fair use 범위 (Phase F PLAN.md Round 2 Ambiguity 해소)
+
+- 6Q 본문 verbatim quote (~150 단어) + MIT attribution (Copyright 2026 Garry Tan)
+- MIT 라이선스는 verbatim 인용 + attribution 시 자유 사용 허용 (위 LICENSE 본문 §3 "above copyright notice ... shall be included")
+- 본 adapted skill은 MIT 의무 충족 (위 LICENSE 전문 inline + 본문 attribution)
+
+## Frontmatter 키 정합 (PLAN.md §5 CL-08)
+
+| Key | Pocock tdd | gstack office-hours (reference only) | adapted (this skill) |
+|---|---|---|---|
+| name | ✅ | ✅ | ✅ |
+| description | ✅ | ✅ | ✅ |
+| allowed-tools | ❌ | ✅ | ✅ (3 tools: AskUserQuestion / Read / Grep) |
+| preamble-tier | ❌ | ✅ | ❌ (gstack 전용) |
+| version | ❌ | ✅ | ❌ (gstack 전용) |
+| triggers | ❌ | ✅ | ❌ (gstack 전용) |
+| gbrain | ❌ | ✅ | ❌ (gstack ecosystem 전용) |
+
+→ Pocock tdd 키 집합 + `allowed-tools` (3개) 추가만 채택.
+
+## Sync trigger + procedure (Pocock tdd UPSTREAM.md와 동일 패턴)
+
+**Trigger**: Phase 14a-bis Revision 2026-11-01
+
+**Procedure**:
+1. `gh api repos/garrytan/gstack/commits/main --jq .sha` 후 박제된 SHA `19e699ab`와 비교
+2. SHA 동일 → no-op
+3. SHA 다름 → 6Q 본문 (lines 956-1046) diff. 변경 발견 시:
+   - 별도 PR (Phase G 또는 신규 Phase) — 자동 bump 금지
+   - DONE.md에 `pending-drift` 라벨
+   - 사용자 검토 후 PIN.md 갱신 + ADR amend

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, use the project's domain glossary so that test names and interface vocabulary match the project's language, and respect ADRs in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/.claude/skills/tdd/UPSTREAM.md
+++ b/.claude/skills/tdd/UPSTREAM.md
@@ -1,0 +1,53 @@
+# UPSTREAM — tdd skill
+
+> Vendored from KWONSEOK02/skills (fork of mattpocock/skills)
+> Upstream commit: b843cb5ea74b1fe5e58a0fc23cddef9e66076fb8
+> Date: 2026-04-30
+> Path: skills/engineering/tdd/
+> Files: 6 (SKILL.md + deep-modules.md + interface-design.md + mocking.md + refactoring.md + tests.md)
+> Vendor strategy: full directory verbatim — frontmatter included, no body modification (Phase F PLAN.md §2 D-1 / Round 1 CX-1 정합)
+> Verification: see Phase F Wave 0 PIN.md sha256 hashes
+
+## License (MIT — verbatim)
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Sync trigger + procedure
+
+**Trigger**: Phase 14a-bis Revision 2026-11-01 (parent fate sharing)
+
+**Procedure**:
+1. `gh api repos/KWONSEOK02/skills/commits/main --jq .sha` 후 현재 박제된 SHA `b843cb5e`와 비교
+2. SHA 동일 → no-op (PIN.md `last_sync_check` 갱신만)
+3. SHA 다름 → 6 files diff. 변경 발견 시:
+   - 별도 PR 생성 (Phase G 또는 신규 Phase) — 자동 bump 금지
+   - DONE.md에 `pending-drift` 라벨 추가
+   - 사용자 검토 후 PIN.md 갱신 + ADR amend
+
+## Local addendum
+
+`_local-addendum.md` — Phase D C13 정정 (build-time NOT compile-time)
+
+> Reference: docs/patterns/ddd-tdd-cross-stack.md (spring), docs/patterns/ddd-discovery-via-6q.md (spring/ts)

--- a/.claude/skills/tdd/_local-addendum.md
+++ b/.claude/skills/tdd/_local-addendum.md
@@ -1,0 +1,102 @@
+# `_local-addendum.md` — mind-signal-backend TDD 스킬 로컬 컨텍스트
+
+> 본 파일은 Phase G가 Phase F 박제 `tdd` 스킬(Pocock 9 파일 byte-identical)을 mind-signal-backend에 활성화하면서 추가한 **로컬 컨텍스트**다.
+> Pocock canonical 9 파일은 byte-identical 의무. 본 addendum 1 파일만 로컬 신규.
+> ADR-005 skill-vendor-policy 정합: vendored canonical 파일과 _local-addendum.md를 명확히 분리.
+
+---
+
+## 0. 본 스킬을 mind-signal-backend에서 사용할 때 알아야 할 것
+
+mind-signal-backend는 다음 기술 스택을 쓴다:
+
+| 영역 | 사용 도구 |
+|---|---|
+| 언어 | TypeScript 5.x (strict mode) |
+| 프레임워크 | Express 4 + Mongoose 8 |
+| 테스트 러너 | **Jest 30 단일** (Vitest 도입 금지 — `.claude/rules/test-modification.md`) |
+| HTTP 테스트 | supertest (단, Phase G의 BDD 인수 테스트는 supertest 미사용 — Q1 LOCK) |
+| 통합 테스트 DB | `mongodb-memory-server` (Jest globalSetup 패턴) |
+| 빌드/타입 검사 | `tsc + tsc-alias` |
+| 정적 분석 | ESLint 9 (`--max-warnings 0`) + Prettier |
+| 계층 검사 | `dependency-cruiser` (FSD 규칙 + Phase G R-DDD-1/2) |
+
+Pocock canonical은 언어 독립적으로 작성된 outside-in TDD 흐름. mind-signal-backend에서는 **Jest + supertest + mongodb-memory-server 위에서 동일 흐름** 적용.
+
+---
+
+## 1. mind-signal-backend FSD 계층과 TDD 위치
+
+`.claude/rules/architecture.md` FSD 계층 규칙 (`01-app → 02-processes → 05-features → 06-entities → 07-shared`)에서 TDD의 각 단계가 머무는 위치:
+
+| Pocock 단계 | mind-signal-backend 적용 위치 |
+|---|---|
+| Outside acceptance test | `src/05-features/{domain}/__tests__/*.bdd.test.ts` (Jest describe/test 자연어 Given/When/Then) |
+| Application use case test | `src/05-features/{domain}/services/*.service.test.ts` (mongodb-memory-server) |
+| Domain unit test | `src/06-entities/{domain}/domain/*.aggregate.test.ts` (Jest pure, no mock, no DB) |
+| Repository integration test | `src/06-entities/{domain}/repository/*.repository.test.ts` (mongodb-memory-server) |
+
+본 단계(Phase G) `Session` 도메인에 한정하여 적용. 후속 단계 H/I 진입 시 동일 패턴을 FE/DE에 복제하는 결정은 별도 평가.
+
+---
+
+## 2. mind-signal-backend 한국어 주석 규칙과 Pocock 영문 가이드의 정합
+
+Pocock canonical은 영문 + 코드 예시 중심. mind-signal-backend의 한국어 주석 명사형 종결 규칙(`.claude/rules/code-style.md`)과 충돌하지 않는다.
+
+| 규칙 | 적용 |
+|---|---|
+| 코드 주석 명사형 종결 (~함 / ~완료 / ~처리 / ~반환 / ~생성 / ~사용 / ~임) | 본 스킬을 따라 작성한 모든 신규 코드 주석 의무 |
+| 테스트 describe/test 명칭 | Pocock 권고는 자연어 시나리오. mind-signal에서는 한국어 + Given/When/Then 키워드 혼용 (예: `test('Given operator alice가 ..., When subject bob이 ..., Then ...', ...)`) |
+| 파일 이름 | dot-role suffix 의무 (`session.aggregate.ts` / `pair-subject.service.ts` / `session.repository.ts` / `pair-subject.bdd.test.ts`) |
+
+---
+
+## 3. Pocock canonical과 Phase G LOCK의 정합 확인
+
+Pocock canonical 9 파일은 byte-identical 의무. Phase G가 그 위에 부과한 LOCK:
+
+| Phase G LOCK | Pocock 정합 |
+|---|---|
+| Q1 — BDD 인수 테스트 = Jest 단독 + 서비스 직접 호출 (supertest 미사용) | Pocock outside-in의 "outside" 정의는 HTTP에 한정하지 않음. 서비스 직접 호출도 outside-in 정합 (단위 위 응용 계층) |
+| Q2 — `SessionAggregate` 명칭 분리 | Pocock interface-design.md 정합 (도메인 객체 의도 명확화) |
+| Q3 — 6 상태 그대로 + 1 전이만 시연 | Pocock tests.md 권고 "1 시나리오 = 1 behavior" 정합 |
+| Q4 — group_counters 응용 서비스 책임 | Pocock deep-modules.md "single responsibility" 정합 (도메인 외부 책임 명시) |
+| Q5 — 응용 서비스 = `05-features/sessions/services/` (FSD 규칙) | Pocock 가이드는 위치 미규정 — FSD 규칙이 mind-signal-backend 고유 |
+| Q6 — depcruise 규칙 2개 | Pocock 가이드는 외부 도구 미규정 — depcruise는 mind-signal-backend 고유 |
+
+---
+
+## 4. 본 스킬과 mind-signal-backend의 다른 스킬·문서 간 cross-reference
+
+- **`office-hours-ddd-discovery/SKILL.md`** (같은 vendoring, 6Q 발견 인터뷰) — DDD 도메인 발견 시 사용. 본 스킬과 짝 (TDD outside-in이 BDD 인수에서 시작 → DDD 도메인 발견 → TDD 단위 사이클)
+- **`docs/patterns/ddd-discovery-via-6q.md`** (Phase F 복제 + Phase G 적용 결과 `session-aggregate-6q-applied.md`) — 6Q 답변 박제
+- **`.claude/rules/test-modification.md`** "No Vitest APIs" — 본 스킬을 적용할 때 Jest API만 사용 의무
+- **`.claude/rules/verification-loop.md`** — TDD 사이클 완료 후 `npm run verify` 6단계 PASS 의무
+- **`.plans/G-mind-signal-ddd-bdd-tdd/NAMING-GUIDE.md`** — 본 스킬을 따라 생성한 모든 영어 명사의 한국어 의미 박제
+
+---
+
+## 5. 본 스킬 사용 시 자기 체크리스트
+
+mind-signal-backend에서 본 스킬을 따라 작업할 때 다음을 매 사이클 자기 검증:
+
+- [ ] 테스트를 먼저 빨간색(실패)으로 만들었는가?
+- [ ] 통과시킬 최소 코드만 적었는가? (Minimum Code 게이트)
+- [ ] 신규 의존성 0건 (`package.json` devDependencies 추가 0)?
+- [ ] FSD 계층 import 방향 준수 (`npm run depcruise` PASS)?
+- [ ] 한국어 주석 명사형 종결 위반 0건?
+- [ ] 기존 Jest 테스트 회귀 0건 (`npm test` 결과 동일 PASS 수)?
+- [ ] `eslint-disable` / `ts-ignore` / `test.skip()` 신규 0건?
+
+---
+
+## 6. 본 addendum 변경 시
+
+본 addendum은 mind-signal-backend 로컬. Pocock canonical 9 파일과 무관하게 mind-signal 컨텍스트 변경에 따라 갱신 가능.
+
+Pocock canonical 9 파일 (SKILL.md, deep-modules.md, interface-design.md, mocking.md, refactoring.md, tests.md, UPSTREAM.md, office-hours/SKILL.md, office-hours/UPSTREAM.md)은 **수정 금지** — Phase F가 박제한 SHA256 byte-identical 의무 유지. canonical 갱신 시 Phase F의 14a-bis Revision sync trigger(2026-11-01) 절차를 거친다.
+
+---
+
+**END _local-addendum.md** — mind-signal-backend TDD 스킬 로컬 컨텍스트 박제.

--- a/.claude/skills/tdd/deep-modules.md
+++ b/.claude/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.claude/skills/tdd/interface-design.md
+++ b/.claude/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/refactoring.md
+++ b/.claude/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,61 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -40,6 +40,25 @@ module.exports = {
       from: { path: '^src/05-features' },
       to: { path: '^(fs|path|node:fs|node:path)$' },
     },
+    // (e) R-DDD-1 no-mongoose-in-domain — 도메인 레이어는 Mongoose 또는 schema 파일 import 금지
+    //     순수 타입(session.types.ts)은 정규식이 .schema$만 매칭하므로 허용됨
+    //     @07-shared/constants/experiment (ExperimentMode single source)도 본 규칙 차단 대상 외
+    {
+      name: 'no-mongoose-in-domain',
+      comment: '도메인 레이어는 Mongoose 또는 schema 파일 import 금지 (순수 타입 파일은 허용)',
+      severity: 'error',
+      from: { path: '^src/06-entities/sessions/domain/' },
+      to: { path: '(^mongoose$|^src/06-entities/sessions/model/session\\.schema$)' },
+    },
+    // (f) R-DDD-2 no-redis-socket-in-domain — 도메인 레이어는 인프라(Redis/Socket.io) import 금지
+    //     @07-shared/constants/* 는 본 규칙 정규식이 lib/(redis|socket)만 매칭하므로 허용됨
+    {
+      name: 'no-redis-socket-in-domain',
+      comment: '도메인 레이어는 인프라(Redis/Socket.io)에 의존할 수 없음',
+      severity: 'error',
+      from: { path: '^src/06-entities/sessions/domain/' },
+      to: { path: '^src/07-shared/lib/(redis|socket)' },
+    },
   ],
   options: {
     tsConfig: { fileName: 'tsconfig.json' },

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ npm-debug.log*
 .DS_Store
 Thumbs.db
 
-# Claude Code (개인 설정)
-.claude/
+# Claude Code (개인 설정 — 단, Phase G가 박제한 vendored skills는 예외)
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 
 # 기밀/임시 파일
 secret.txt

--- a/docs/architecture/decisions/ADR-006-session-aggregate-ddd-pilot.md
+++ b/docs/architecture/decisions/ADR-006-session-aggregate-ddd-pilot.md
@@ -1,0 +1,123 @@
+# ADR-006: Session Aggregate DDD/BDD/TDD Pilot (Phase G)
+
+<!-- Append-only after Accepted — documentation.md §Append-only rule 참조. -->
+
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-12
+- **Applies to**: BE
+- **Deciders**: @gs07103
+- **Related**: ADR-004 (engine URL abstraction), Phase 18 engine-proxy-sync (LOCK), `.plans/G-mind-signal-ddd-bdd-tdd/CRITIQUE.md` Round 2 (🟡 5 prerequisites), `DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 단일 근거)
+
+## Context
+
+본 단계(Phase G)는 다음 4 bullet의 **P1 frame** 안에서 진행됨 (Prerequisites P-4 정합 의무 — DISCUSS §1, §2 #6, PRD DR-G, 본 ADR Context 4 위치 일관 표현):
+
+1. **졸업 프로젝트 학습 + 2026-05-26 교수 면담 시연** — 효과 측정 주장 없음. 시연 통과 + 한국어 시나리오 외부 낭독 feedback 1회로 가치 박제.
+2. **산업 표준 패턴 적용** — Vernon 2011 "Effective Aggregate Design Part I" 단일 aggregate + Stemmler 2019 "TypeScript DDD Mongoose Adapter" + Pocock outside-in TDD 9 파일 (MIT) + Garry Tan gstack 6Q discovery (MIT).
+3. **Phase F 박제 자산 활성화** — `feat/F-template-ddd-tdd-augmentation` (2026-05-06 DONE) 작업으로 3 GitHub 템플릿(spring/typescript/python)에 박제된 9 파일을 mind-signal-backend에 SHA256 byte-identical 복제 + 1 신규 `_local-addendum.md`. 박제 자산이 본 단계 적용 없이는 mind-signal에 dead asset.
+4. **새 기여 주장 0건** — 차별점 = 학생 horizon + 한국어 명명 가이드 + Phase F 박제 자산 활성화 (모두 market-tier). 학술적 새 기여 주장 없음 — `arXiv 2007.09863` TDD 효과 학술 inconclusive + Cucumber.io "BDD는 collaboration이지 tooling 아님" 단일 개발자 horizon 제약 인정.
+
+추가 컨텍스트:
+
+- 기존 `Session`이라는 단어가 ① Mongoose DB 모양(`session.schema.ts`) ② 비즈니스 규칙 두 가지를 동시에 가리키고 있어 IDE 자동완성/import 검색/사람 판단에서 혼동 발생 가능. NECESSITY-EVIDENCE.md 5건 인용으로 잠재 위험 박제 (CRITIQUE Round 2 P-1 통과).
+- `code-review-graph` MCP build (130 files / 630 nodes / 4647 edges, 2026-05-12) 실측으로 기존 `pairDeviceProcess(pairingToken, userId)` 시그니처 + `Session.findOne({pairingToken})` 직접 조회 패턴 + `pairingListeners` (LD-12 대안 D) Set 등록 패턴 + `group_counters` 원자 연산이 페어링 흐름에 미사용 (creation 흐름 전용) 등 12 정정 발견.
+- Phase 17.6 (dual-trigger.service.ts 안정 동작) + Phase 18 (engine-proxy-sync LOCK, execute 5/26 이후) 충돌 회피 의무 — `02-processes/engine/` + `pairing.service.ts` 수정 0건 strict.
+
+## Decision
+
+본 단계에서 다음 8 가지 결정 LOCK:
+
+1. **명칭 분리** — Mongoose Model `Session` 이름 그대로 유지 + 도메인 통합체는 `SessionAggregate` 신규 명칭. `src/06-entities/sessions/domain/session.aggregate.ts`.
+2. **Aggregate boundary = 단일 Session 도큐먼트** — 1 `SessionAggregate` = 1 MongoDB document = 1 트랜잭션 단위. 그룹 차원 invariant(같은 `groupId`에 `subjectIndex` 1과 2 unique)는 Mongoose `groupId_subjectIndex_unique` 복합 인덱스가 enforce (aggregate 외부).
+3. **시그니처** — `SessionAggregate.create({id, groupId, subjectIndex, pairingToken, operatorId, mode, expiresAt})` 7 인자 + `pair(userId: string)` 1 인자 (mind-signal-backend `userId` 컨벤션 정합, `subjectId` 명칭 미사용).
+4. **순수 타입 분리** — `src/06-entities/sessions/types/session.types.ts` 신규에 `SessionStatus` 6종 union 단일 정의. `ExperimentMode`는 `@07-shared/constants/experiment` single source 유지(re-export only, drift 회피).
+5. **Repository strangler** — `SessionRepository` (`findById` / `findByPairingToken` / `save` / `saveNew`)가 SessionAggregate ↔ Mongoose 양방향 변환 단일 지점. `findByPairingToken`은 기존 `Session.findOne({pairingToken})` (`pairing.service.ts:94`) 어댑터.
+6. **응용 서비스 병렬 존재** — `PairSubjectService.execute({pairingToken, userId})` 5단계 흐름은 기존 `pairDeviceProcess(pairingToken, userId)`와 동일 시그니처로 병렬 존재(strangler). 본 단계는 기존 `pairing.service.ts` **수정 0건** — 컨트롤러 통합은 후속 PR.
+7. **depcruise 신규 규칙 2** — `R-DDD-1 no-mongoose-in-domain` (`domain/` → `mongoose` 또는 `sessions/model/session.schema` 차단) + `R-DDD-2 no-redis-socket-in-domain` (`domain/` → `07-shared/lib/(redis|socket)` 차단). 순수 타입(`session.types.ts`) + `@07-shared/constants/*` 차단 대상 외 (정규식 매칭 안 됨).
+8. **BDD 인수 = Jest 단독 + 서비스 직접 호출** — Q1 LOCK. supertest / HTTP 라우트 / Express app import 0건. Cucumber.js는 별도 `spike/cucumber-poc` 가지로 격리. 본 단계 정식 도구는 기존 Jest 단일.
+
+추가 결정:
+
+- **도메인 이벤트 = type-only + 메모리 기록** — `SessionPairedEvent { type, sessionId, userId, occurredAt, groupId, subjectIndex, mode }` 타입 정의 + `PairSubjectService.recordedEvents` 배열. `pullDomainEvents()` 발행 큐 / persisted outbox 미채택 (Phase E TS-Q17 A3 정합).
+- **기존 `pairingListeners` 통합 호출은 본 단계 제외** — LD-12 대안 D 호출 흐름은 후속 controller 통합 PR로 분리. 본 단계는 `pairing.service.ts` 수정 0건 의무 (G9) 보존 우선.
+- **AppError 코드 매핑 실측 정합** — 만료 토큰 `401` (`pairing.service.ts:104`), 전이 불가 (이미 PAIRED) `400` (L111), 토큰 없음 `404` (L96), userId 형식 부정합 `400` (L89). rev.2 stale 가정(410/409)은 rev.3 정정으로 폐기.
+
+## Alternatives considered
+
+### Option A: 단일 Session 통합체 (선택)
+
+단일 Session 도큐먼트를 aggregate boundary로 두고 그룹 차원 invariant는 Mongoose 인덱스에 위임함.
+
+**Trade-offs**: 도메인 응집도 명확, 단위 테스트 가볍고 빠름 (DB 없이 1초 8건). 단점 — 그룹 수준 비즈니스 규칙이 코드(도메인) + 인프라(인덱스) 두 곳 책임 (Mongoose 인덱스 변경 시 도메인 invariant 영향).
+
+**Accepted because**: Vernon 2011 "Smaller aggregates preferred" 정합 + mind-signal 동시성 모델(group_counters $inc 원자 연산)이 이미 그룹 단위 unique 보장 + 단일 도큐먼트 트랜잭션이 MongoDB cross-document 트랜잭션보다 비용/복잡도 ↓.
+
+### Option B: Group aggregate (기각)
+
+`groupId` 하나에 1~2 Session을 묶는 큰 통합체로 모델링하고 그룹 차원 invariant를 aggregate에 흡수함.
+
+**Trade-offs**: 그룹 차원 비즈니스 규칙을 한 곳에 집중 가능. 단점 — MongoDB cross-document 트랜잭션 필요 + 동시성 제어 복잡도 ↑ + 그룹 invariant("같은 groupId에 subjectIndex 1과 2 unique")는 이미 Mongoose 인덱스가 enforce하므로 흡수 net value 약함.
+
+**Rejected because**: 비용/복잡도 대비 net value 약함 + Vernon 2011 표준 권고와 반대 방향.
+
+### Option C (status quo): 현재 함수형 service 유지
+
+기존 `pairDeviceProcess` 함수만 유지하고 도메인 layer 신설 없음. Phase F 박제 자산 미활용.
+
+**Trade-offs**: 변경 0건 — 안전. 단점 — Phase F 9 파일이 mind-signal에 dead asset + 5/26 시연 자료 부재 + 학습 가치 0.
+
+**Rejected because**: 본 단계 P1 frame ("Phase F 자산 활성화") 의무 미충족.
+
+## Consequences
+
+이 결정 이후 **더 쉬워지는** 것:
+
+- "세션이라는 개념이 코드에서 한 객체(`SessionAggregate`)로 명확히 표현되며, 페어링 한 줄 흐름이 한 파일(`PairSubjectService`)에 모여 있다"고 시연 시 설명 가능 — 5/26 교수 면담 가시성 확보.
+- 도메인 단위 테스트가 DB 없이 빠르게 돔 (8건 도메인 + 5건 응용 서비스 = 0.5초 이하).
+- 후속 단계(Phase H FE / Phase I DE)가 같은 패턴(통합체 + Repository + 응용 서비스) 적용 시 한국어 명명 가이드 + 6Q 적용 문서 + skill 9 파일 재사용 가능.
+- depcruise R-DDD-1/R-DDD-2가 도메인 layer 무결성(외부 의존 0건) 자동 검사 — 후속 PR에서 실수로 mongoose import 시 즉시 차단.
+
+이 결정 이후 **더 어려워지는** 것:
+
+- `Session` ↔ `SessionAggregate` 두 명칭이 공존 — 신규 작성자는 어느 쪽을 import해야 할지 한국어 명명 가이드(`NAMING-GUIDE.md`) 참조 필요.
+- 통합체-모델 변환기(`SessionRepository`)가 추가 — 새 필드 추가 시 4 곳 수정 필요 (`session.schema.ts` + `session.types.ts` + `session.aggregate.ts` `fromDocument` + `session.repository.ts` `toAggregate`).
+- 기존 `pairDeviceProcess`와 신규 `PairSubjectService`가 병렬 존재 (strangler) — controller 통합 PR이 별도 필요. 두 경로 동시 유지 시 listener 발화 동작 차이 가능 (기존 경로 = listener 발화 / 신규 경로 = 메모리 기록만).
+
+새로 발생하는 **기술 부채** (모든 ADR은 일정 부채 수반함, 명시적 기록 의무):
+
+- **TD-G-1** (Listener 통합 후속 PR) — 신규 `PairSubjectService`가 기존 `pairingListeners` (LD-12 대안 D) fire-and-forget 호출 미수행. controller 통합 시 헬퍼 export 추가 또는 양쪽 fire 방식 결정 필요. 부채 만료 시점 = Phase H/I 또는 Phase G+1 후속 PR.
+- **TD-G-2** (mongodb-memory-server 미설치) — 본 단계 통합 테스트는 Jest mock 기반. 진짜 MongoDB 통합 검증은 후속 인프라 정비 PR (mongodb-memory-server 도입 + Repository 진짜 DB 시나리오 추가). 부채 만료 시점 = CI 인프라 정비 시점.
+- **TD-G-3** (controller 점진 이전 미완) — HTTP `GET /join/:token` 라우트는 여전히 `pairDeviceProcess` 호출. 신규 `PairSubjectService`로 점진 이전 작업이 후속 PR로 남음.
+- **TD-G-4** (`__v` 낙관적 잠금 미활성) — 현재 `toJSON()`에서 `__v` 삭제 중 — 동시성 제어 불가 상태. 본 단계 미변경, 별도 ADR로 처리 예정.
+- **TD-G-5** (Cucumber.js spike 결과 박제 보류) — `spike/cucumber-poc` 가지에서 PoC 검증은 본 phase gate 외. 후속 단계 H/I 진입 전 `SPIKE-CUCUMBER.md` 박제 + 도구 정식 채택 여부 평가 의무.
+
+## Implementation notes
+
+- 가지: `feat/G-ddd-bdd-tdd-pilot` (단일, 11 atomic commit + 1 머지)
+- 진입점:
+  - 도메인: `src/06-entities/sessions/domain/session.aggregate.ts` (199 lines)
+  - 변환기: `src/06-entities/sessions/repository/session.repository.ts` (103 lines)
+  - 순수 타입: `src/06-entities/sessions/types/session.types.ts` (24 lines)
+  - 응용 서비스: `src/05-features/sessions/services/pair-subject.service.ts` (120 lines)
+  - BDD 인수: `src/05-features/sessions/__tests__/pair-subject.bdd.test.ts` (193 lines, 3 시나리오)
+- depcruise 신규 규칙: `.dependency-cruiser.cjs` (forbidden 배열에 (e) R-DDD-1 + (f) R-DDD-2 추가)
+- 6Q 적용 문서: `docs/patterns/session-aggregate-6q-applied.md` (213 lines)
+- Skill vendoring: `.claude/skills/tdd/` + `.claude/skills/office-hours-ddd-discovery/` (9 파일 byte-identical + 1 신규 `_local-addendum.md`)
+- 산출물 PAAR:
+  - `docs/reports/paar-2026-05-12-phase-g-isolation-proof.md` (G9 통과)
+  - `docs/reports/paar-2026-05-12-phase-g-verify-green.md` (G8 통과)
+- Verify: `npm run verify` 6단계 GREEN (288 tests PASS, 회귀 0건)
+
+## References
+
+- Vernon, Vaughn (2011), "Effective Aggregate Design Part I: Modeling a Single Aggregate" — https://www.dddcommunity.org/wp-content/uploads/files/pdf_articles/Vernon_2011_1.pdf
+- Stemmler, Khalil (2019), "How to Design & Persist Aggregates - Domain-Driven Design w/ TypeScript" — https://khalilstemmler.com/articles/typescript-domain-driven-design/aggregate-design-persistence/
+- Pocock, Tim — outside-in TDD guide (MIT) (Phase F vendored)
+- Garry Tan, gstack — Six forcing questions v2.0.0 (MIT) (Phase F vendored)
+- mind-signal `mind-signal-backend/CLAUDE.md` §7 (status enum), §8 (Operator/Subject ubiquitous language)
+- `.plans/G-mind-signal-ddd-bdd-tdd/DISCUSS.md` rev.4 (Q1~Q6 LOCK + P1 frame)
+- `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 12 정정 단일 근거)
+- `.plans/G-mind-signal-ddd-bdd-tdd/CRITIQUE.md` Round 1~5 (Verdict 🟡 PROCEED-WITH-CONDITIONS + Contract/Reality/Completeness Lens PASS)
+- Related ADRs: ADR-004 (엔진 URL 추상화), 후속 미작성 ADR(s) — `__v` 낙관적 잠금, controller 통합 등

--- a/docs/guides/_template.md
+++ b/docs/guides/_template.md
@@ -1,0 +1,97 @@
+# Reference Guide _template
+
+> 이 파일은 새 reference 가이드 작성의 표준 템플릿입니다.
+> 사용법: `cp docs/guides/_template.md docs/guides/<your-guide>.md` 후 7 섹션을 채우세요.
+> 출처: TruthScope BE #22 §0~§5 reference 정합 (Phase F C-D7).
+> 박제 정책: 3 templates byte-identical (Phase F PLAN.md §2 D-2).
+
+---
+
+## §0. Glossary (1 minute orientation)
+
+> 본 가이드에서 사용하는 약어/특수 용어를 1줄씩 풀이. 신규 독자가 §1로 진입하기 전 1분 안에 컨텍스트 잡을 수 있도록.
+>
+> 예: `BE` = backend (Express+TypeScript) / `PR` = Pull Request / `RDS` = AWS managed PostgreSQL / ...
+
+| Term | Meaning |
+|---|---|
+| ... | ... |
+
+---
+
+## §1. Why this guide exists
+
+- 무엇을 해결하는가? (1-2 문장)
+- 누가 읽는가? (target reader: 신규 contributor / 특정 stack 학습자 / etc.)
+- 어떤 알림 (notice) — Phase 의존성, 14a-bis 5 contracts, ADR, 다른 가이드 link
+
+---
+
+## §2. Concrete signature / contract
+
+> "권고" 수준 표현 회피. 실제 사용할 시그니처/스키마/프로토콜을 박제. Code block + 1줄 설명.
+>
+> 예: TS interface, JSON schema, REST endpoint signature, gRPC proto, ...
+
+```{lang}
+// concrete contract here
+```
+
+---
+
+## §3. Recommended → confirmed signature
+
+> §2를 더 좁힌 권고 → 확정 시그니처. PR description body의 실제 템플릿. Windows PowerShell + POSIX 양쪽 호환 명시.
+
+### Linux/macOS (bash)
+
+```bash
+# command here
+```
+
+### Windows (PowerShell)
+
+```powershell
+# command here
+```
+
+---
+
+## §4. SsrfGuard / 안전 가이드 (해당 시)
+
+> 외부 호출이 있다면 SSRF/credential leak/quota 등 정책 명시.
+> 없다면 본 섹션 삭제 가능.
+
+---
+
+## §5. Self-contained reference (Week N self-study)
+
+> 이 가이드만 읽고 작업 시작 가능하도록 self-contained 구성.
+> 외부 link 의존성 최소화. 외부 link 사용 시 마지막 §6 References에 모음.
+
+### 예시 시나리오
+
+1. ...
+2. ...
+3. ...
+
+### 검증 (verify gate)
+
+```bash
+# 작업 후 self-verify command
+```
+
+---
+
+## §6. References
+
+- [Phase F Wave 0 PIN.md](../../.plans/F-template-ddd-tdd-augmentation/upstream-pin/PIN.md) (template-internal — 이 path는 derived repo에 없음, 삭제 가능)
+- (외부 docs / RFCs / blog posts — full URL with date)
+
+---
+
+## §7. Maintenance
+
+- 마지막 갱신: YYYY-MM-DD
+- 다음 검토 예정: YYYY-MM-DD (보통 분기별)
+- Owner: @<handle>

--- a/docs/patterns/ddd-discovery-via-6q.md
+++ b/docs/patterns/ddd-discovery-via-6q.md
@@ -1,0 +1,84 @@
+# DDD Discovery via 6 Forcing Questions
+
+> Companion: `.claude/skills/office-hours-ddd-discovery/SKILL.md`
+> Purpose: 6 forcing questions (Garry Tan gstack v2.0.0, MIT)을 DDD bounded context discovery에 매핑.
+> Scope: spring-template + typescript-template (python-template은 archetype 없음 → deferred)
+
+---
+
+## §1. Why 6Q for DDD?
+
+전통적 DDD discovery (Event Storming / Domain Storytelling)은 **시간**과 **합의된 도메인 전문가**를 가정. 그런데 LLM 에이전트가 새 bounded context를 설계할 때:
+- 도메인 전문가 1명만 있고 시간 30분
+- "유저가 원하는 게 뭔지" 명확히 모름
+- 기존 모델을 pivot할지 새로 만들지 결정 needed
+
+→ Garry Tan의 6 forcing questions는 **founder/operator를 압박해서 bounded context의 demand reality를 surface하는 도구**. DDD discovery에 매핑하면 **30분 내에 aggregate boundary + UL + 전략적 위치 결정**.
+
+---
+
+## §2. 6Q × DDD 매핑 (fit score 1-5)
+
+| Question | gstack 원본 의도 | DDD 매핑 | Fit | 근거 |
+|---|---|---|---|---|
+| **Q1** Demand Reality | 누군가 진짜 원하는가? | **Domain Event** identification (monetary commitment / workflow lock-in) | 4 | "Order placed" with payment = real demand event. Click "save" = noise. |
+| **Q2** Status Quo | 지금 어떻게 해결? | **Anti-Corruption Layer** seam (where to integrate with legacy) | 4 | Existing Excel/spreadsheet workarounds = ACL boundaries. |
+| **Q3** Desperate Specificity | 누구가 가장 절실? | **Domain Expert** identification + Ubiquitous Language seed | 5 | Without a named human, no UL collaboration. "Ops team" ≠ Sarah at warehouse 3. |
+| **Q4** Narrowest Wedge | 가장 작은 wedge? | **Aggregate root boundary** | 5 | Smallest aggregate that ships value end-to-end. Can't ship in single transaction → boundary wrong. |
+| **Q5** Observation & Surprise | 무엇이 놀라웠나? | **Domain Expert collaboration** (UL drift detection) | 4 | Real moment = expert uses term you didn't expect. Real-user observation also counts (caveat). |
+| **Q6** Future-Fit | 3년 후에도 essential? | **Strategic subdomain** (core / supporting / generic) | 3 | Board-level decision, not modeling decision. Lower fit because LLM agent + dev pair often can't decide alone. |
+
+---
+
+## §3. Smart routing for DDD discovery
+
+| Stage | Questions to ask | Skip |
+|---|---|---|
+| **Greenfield** (no aggregate yet) | Q1, Q2, Q3 | Q4-Q6 (premature) |
+| **Has aggregates** (model exists) | Q2, Q4, Q5 | Q1 (already validated by existence), Q6 (defer to roadmap) |
+| **Production** (paying users) | Q4, Q5, Q6 | Q1-Q3 (already validated) |
+| **CRUD-only** (no domain logic) | Q2, Q4 | Q1, Q3, Q5, Q6 (over-engineered) — consider whether DDD is even needed |
+
+---
+
+## §4. Workflow
+
+1. Skill `office-hours-ddd-discovery` invoke (auto trigger on "new bounded context", "aggregate boundary 검증", "domain model pivot")
+2. Stage 식별 (greenfield / has aggregates / production / CRUD-only)
+3. AskUserQuestion으로 한 질문씩 (smart routing 적용)
+4. (선택) Sequential Thinking MCP로 pre-processing — "이 stage에서 가장 critical한 Q는?" 식별
+5. 6Q 종료 후 DDD artifact 작성:
+   - Bounded Context map 1장
+   - Aggregate root + entities + value objects sketch
+   - Ubiquitous Language seed (3-5 terms)
+   - Strategic classification (core / supporting / generic)
+
+---
+
+## §5. Hard constraints (skill SKILL.md와 정합)
+
+- **One question at a time** — gstack 정책 그대로
+- **No Q advancement without human response** — 절대 simulate 금지
+- **Sequential Thinking MCP**: pre-processing only ("which Q is most critical?"). **Never substitute for AskUserQuestion** — 인간 입력이 가치, ST는 placeholder 아님
+- **AskUserQuestion**이 6Q 루프의 유일한 sanctioned 메커니즘
+
+---
+
+## §6. Cross-stack 정합
+
+| Stack | DDD layer | 6Q 적용 시점 |
+|---|---|---|
+| Spring (Java) | Domain (entities/aggregates), Application (use cases), Infrastructure (adapters) | Greenfield context 시작 시 / Aggregate boundary 검증 시 |
+| TypeScript (FSD-DDD hybrid) | entities/ (Domain), features/ (Application), shared/widgets/ (Infrastructure/Presentation) | 동일 |
+| Python | (deferred — archetype 없음) | Phase G 후보 |
+
+> Spring `docs/patterns/ddd-tdd-cross-stack.md` 의 "Domain layer no-mocking" 섹션 참조.
+
+---
+
+## §7. References
+
+- gstack `office-hours/SKILL.md` v2.0.0 — Garry Tan, MIT (UPSTREAM.md inline)
+- Pocock `tdd` skill — Matt Pocock, MIT (`.claude/skills/tdd/SKILL.md`)
+- Phase F PLAN.md (template-internal) — 6Q × DDD 매핑 결정 근거
+- Eric Evans "Domain-Driven Design" (2003) — Bounded Context / Aggregate root / Ubiquitous Language 원전

--- a/docs/patterns/session-aggregate-6q-applied.md
+++ b/docs/patterns/session-aggregate-6q-applied.md
@@ -1,0 +1,213 @@
+# Session Aggregate — 6Q Discovery Applied (Phase G)
+
+> Companion: `docs/patterns/ddd-discovery-via-6q.md` (6 forcing questions 일반 가이드)
+> Companion: `.claude/skills/office-hours-ddd-discovery/SKILL.md`
+> Companion: `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 단일 근거)
+> Purpose: `SessionAggregate` 도메인 모델링 결정을 6Q 형식으로 박제.
+> Scope: mind-signal-backend 단일 저장소. 페어링 흐름(`CREATED → PAIRED`) 한 줄.
+> Frame (P1): 학습/시연 + Phase F 자산 활성화 + 새 기여 주장 0건.
+
+---
+
+## §0. 도입 — 왜 Session을 통합체로 선택했나?
+
+mind-signal-backend의 핵심 비즈니스 단위는 "한 번의 EEG 실험 세션"이다. 이 한 세션이 `CREATED → PAIRED → MEASURING → COMPLETED`의 상태 머신을 거치고, 각 전이에 명확한 트리거(QR 스캔, 측정 시작, 정상 완료, 만료/취소)가 있다. 외부 의존(파이썬 엔진, GenAI API)이 적고, 도메인 규칙이 한 도큐먼트에 응집된다.
+
+후보 비교 (`DISCUSS.md §8`):
+- **Session** ✅ — 상태 머신 명확, 라이프사이클 1 도큐먼트, 5/26 시연 흐름(QR 페어링)과 직접 연관
+- `Measurement` — Python 데이터 엔진과 강결합, BE 단독 경계 흐림 (보류)
+- `AnalysisResult` — GenAI API 외부 의존이 핵심, BE 단독 의미 약함 (보류)
+
+따라서 본 단계 통합체 = `SessionAggregate` (단일). 다른 엔티티(User, EegRecord, AnalysisResult)는 그대로 엔티티 상태 유지.
+
+---
+
+## §1. 6Q 답변 (실측 정합)
+
+본 섹션은 `DOMAIN-MODEL-NOTES.md §3.4`를 그대로 옮긴 표를 코드 참조와 함께 박제한다. 모든 답변은 `code-review-graph` MCP 실측(130 files / 630 nodes / 4647 edges, 2026-05-12) 기반.
+
+### Q1. Invariant — 절대 깨지면 안 되는 규칙
+
+**답변** (두 층위로 분리):
+
+**(a) 단일 Session 도큐먼트 차원** (`SessionAggregate` 책임):
+- `pairingToken !== ''` (빈 토큰 금지)
+- `subjectIndex >= 1` (그룹 내 번호는 1부터)
+- status 전이 그래프 강제 — `canTransitionTo()`가 enforce (`session.schema.ts:131-153`)
+- 만료 후 `CREATED` 상태에서는 `EXPIRED`만 허용 (`session.schema.ts:138`)
+
+**(b) 그룹 차원** (Mongoose 인덱스 책임, aggregate 외부):
+- 같은 `groupId`에 `subjectIndex` 1과 2가 한 번씩만 등장 → `groupId_subjectIndex_unique` 복합 unique 인덱스 (`session.schema.ts:156`)
+
+**근거**: DOMAIN-MODEL-NOTES §1.1 / §3.4 Q1. **본 SessionAggregate는 그룹 invariant를 책임지지 않음** (Q4 정합).
+
+**Code참조**:
+- `session.schema.ts:13-19` (status enum)
+- `session.schema.ts:131-153` (canTransitionTo)
+- `session.schema.ts:156` (복합 unique 인덱스)
+
+---
+
+### Q2. Transitions — 상태 전이 명세
+
+**상태 6종** (`Session['status']` union):
+`CREATED` / `PAIRED` / `MEASURING` / `COMPLETED` / `EXPIRED` / `CANCELLED`
+
+**전이 표** (모든 허용/금지 명세):
+
+| 출발 상태 | 도착 상태 | 허용 | 트리거 메서드 |
+|---|---|---|---|
+| (시작) | CREATED | ✅ | `SessionAggregate.create()` |
+| CREATED | PAIRED | ✅ | `aggregate.pair(userId)` |
+| CREATED | EXPIRED | ✅ | `aggregate.expire()` (5분 타임아웃) |
+| CREATED | CANCELLED | ✅ | `aggregate.cancel(reason)` |
+| CREATED | MEASURING | ❌ | 페어링 미완 — 불허 |
+| PAIRED | MEASURING | ✅ | `aggregate.markMeasuring()` |
+| PAIRED | CANCELLED | ✅ | `aggregate.cancel(reason)` |
+| PAIRED | EXPIRED | ❌ | 이미 페어링됨 — 불허 |
+| MEASURING | COMPLETED | ✅ | `aggregate.complete()` |
+| MEASURING | CANCELLED | ✅ | `aggregate.cancel(reason)` (10초 무응답) |
+| COMPLETED/EXPIRED/CANCELLED | (어디든) | ❌ | 종착 상태 — 어떤 전이도 불허 |
+
+**만료 분기** (`canTransitionTo` 특수 규칙):
+- `isExpired() === true` + `current === 'CREATED'` → `EXPIRED`만 허용 (다른 전이 모두 차단)
+
+**근거**: `session.schema.ts:131-153` 실측. `mind-signal-backend/CLAUDE.md §7` 박제.
+
+**본 단계 시연 범위**:
+- **실제 구현**: `CREATED → PAIRED` (`SessionAggregate.pair(userId)`)
+- **메서드 골조만**: `markMeasuring()`, `complete()`, `expire()`, `cancel()` 4개 — 후속 단계에서 활성화
+
+---
+
+### Q3. Events — 어떤 사실을 발행하는가?
+
+**답변**: `SessionPairedEvent` 단일.
+
+**Shape** (`SessionPairedEvent` 타입 정의):
+
+```typescript
+export type SessionPairedEvent = {
+  type: 'SessionPaired';
+  sessionId: string;
+  userId: string;          // 페어링한 Subject의 userId
+  occurredAt: string;       // ISO 8601
+  groupId: string;          // 8-hex 대문자
+  subjectIndex: number;    // 1 또는 2
+  mode: ExperimentMode;     // DUAL | SEQUENTIAL | BTI | DUAL_2PC
+};
+```
+
+**발행 방식 — 두 가지 동시 수행** (DOMAIN-MODEL-NOTES §3.6 옵션 A — 통합):
+
+1. **메모리 내 기록** (`PairSubjectService.recordedEvents` 배열) — 테스트 검증용
+2. **기존 `pairingListeners` 호출** — 런타임 동작 보존 (LD-12 대안 D, `pairing.service.ts:13/126-135`)
+
+기존 `pairingListeners`의 callback shape는 `cb({ groupId: string; subjectIndex: number | null }) => void | Promise<void>` (`pairing.service.ts:9-12`). 본 신규 도메인 이벤트는 더 풍부한 정보(`type`, `sessionId`, `userId`, `occurredAt`, `mode`)를 포함한다.
+
+**미채택 패턴**:
+- `pullDomainEvents()` 발행 큐 (Phase E TS-Q17 A3 LOCK 정합)
+- Persisted outbox (별도 ADR 검토 대상)
+
+---
+
+### Q4. Consistency Boundary — 트랜잭션 단위는?
+
+**답변**: **단일 Session 도큐먼트**. 1 `SessionAggregate` = 1 MongoDB document = 1 트랜잭션 단위.
+
+**boundary 외부 책임** (aggregate가 책임지지 않음):
+- **그룹 단위 unique** (`groupId+subjectIndex`) → Mongoose `groupId_subjectIndex_unique` 복합 인덱스가 enforce
+- **`group_counters` 원자 할당** (`subjectIndex`) → 기존 `createGroupSessionProcess` (`pairing.service.ts:38-75`) 책임. 본 단계 페어링 흐름에 **미사용** (code-review-graph 실측 — `pairDeviceProcess` callees에 `group_counters` 호출 0건)
+
+**페어링 흐름 ↔ 세션 생성 흐름 분리**:
+- `createGroupSessionProcess` (세션 생성, `group_counters` 사용) — 본 단계 미수정
+- `pairDeviceProcess` (페어링, `Session.findOne({pairingToken})` 직접 조회) — 본 단계 미수정 (strangler — 신규 `PairSubjectService`와 병렬)
+- 두 흐름은 같은 파일에 있지만 **호출 경로가 분리**되어 있음 (callees graph 검증)
+
+**근거**: DOMAIN-MODEL-NOTES §1.2 / §3.4 Q4. DISCUSS rev.4 §9.3 stale 정정 — "본 단계가 카운터 호출을 응용 서비스에 가져오지 않음" 명시.
+
+---
+
+### Q5. Creator — 누가 통합체를 만드는가?
+
+**답변** (두 흐름 분리):
+
+**기존 흐름** (본 단계 미변경):
+- `createGroupSessionProcess(groupId?, creatorId?)` — 운영자(Operator)가 QR 발급 시 호출. `crypto.randomBytes(4)` 8-hex `groupId` 생성 → `group_counters` `$inc`로 `subjectIndex` 원자 할당 → `crypto.randomBytes(3)` 6-hex `pairingToken` 생성 → `new Session({...}).save()` (status `CREATED`, 5분 만료).
+
+**신규 흐름** (본 단계 추가, strangler):
+- `PairSubjectService.execute({pairingToken, userId})` — 피실험자(Subject)가 QR 스캔 시 호출. 페어링 한 줄 흐름만 처리 (`CREATED → PAIRED`). **새 Session 도큐먼트를 만들지 않음** — 기존 도큐먼트의 상태 전이만.
+
+**Aggregate 생성 시점**:
+- DB에서 꺼낼 때: `SessionRepository.fromDocument(doc)` 또는 `SessionRepository.findByPairingToken(token)` 어댑터가 `SessionAggregate.fromDocument()` 호출
+- 신규 생성 시: `SessionAggregate.create({ id, groupId, subjectIndex, pairingToken, operatorId, mode, expiresAt })` 7 인자 factory. 본 단계는 BDD 테스트에서만 직접 호출.
+
+**근거**: DOMAIN-MODEL-NOTES §3.4 Q5. PLAN §6.2 T1.1 코드 스케치.
+
+---
+
+### Q6. Forbidden — 절대 허용하면 안 되는 동작
+
+**답변** (3 종):
+
+**(a) `COMPLETED → MEASURING` 불가**: 측정이 정상 완료된 세션을 다시 측정 중으로 되돌리면 데이터 무결성 깨짐. `canTransitionTo`가 차단 (`session.schema.ts:147` — `COMPLETED: []`).
+
+**(b) 종착 상태에서 전이 0건**: `COMPLETED` / `EXPIRED` / `CANCELLED` 세 상태에서 어떤 전이도 금지. 모두 빈 배열 (`session.schema.ts:147-149`).
+
+**(c) `subjectIndex < 1` 불허**: 피실험자 번호는 1부터 시작. 0이나 음수는 invariant 위반 → `InvariantViolationError`. `SessionAggregate.create()` 입력 검증.
+
+**근거**: DOMAIN-MODEL-NOTES §3.4 Q6. `session.schema.ts:142-150` (transitions 표).
+
+---
+
+## §2. Aggregate Boundary 결정 — "단일 Session 도큐먼트"인 이유
+
+**대안**:
+- **A. 단일 Session** (선택) ✅
+- **B. Group을 통합체로** — `groupId` 하나에 1~2 Session을 묶는 큰 통합체
+
+**대안 B 거부 이유**:
+- 그룹 단위 unique 보장은 Mongoose 인덱스 + `group_counters` 원자 연산이 이미 충분히 처리. aggregate에 흡수 시 동시성 제어 복잡도 ↑
+- 그룹 단위 트랜잭션은 MongoDB에서 cross-document 트랜잭션 필요 — 단일 도큐먼트 쓰기보다 비용/복잡도 ↑
+- 그룹 invariant("같은 groupId에 subjectIndex 1과 2가 unique")는 이미 Mongoose 복합 인덱스가 enforce하므로 aggregate 흡수 net value 약함
+
+**근거**: Vernon 2011 "Effective Aggregate Design Part I" — "Smaller aggregates preferred. Use the aggregate as a unit for data storage operations." (`session.schema.ts:156` 정합).
+
+---
+
+## §3. P1 Frame 정합
+
+본 6Q 답변은 다음 frame 안에서 작성되었음 (학습/시연 + Phase F 자산 활성화 + 새 기여 주장 0건):
+
+1. **학습**: 6Q × DDD 매핑을 mind-signal에 적용해 본 첫 사례 — 학생 horizon 학습 가치
+2. **시연**: 2026-05-26 교수 면담에서 `SessionAggregate` + `PairSubjectService` 흐름과 BDD 시나리오를 한국어로 낭독
+3. **Phase F 자산 활성화**: `.claude/skills/office-hours-ddd-discovery/SKILL.md` (Phase F 박제, SHA256 byte-identical) 활용
+4. **새 기여 주장 0건**: 6Q gstack 원본 (Garry Tan v2.0.0 MIT) + Vernon 2011 + Stemmler 2019 산업 표준 적용. 차별점 = 학생 horizon + 한국어 명명 가이드 + Phase F 자산 활성화 (모두 market-tier)
+
+---
+
+## §4. 후속 단계로 넘기는 결정
+
+- **`pullDomainEvents()` 발행 큐** — 본 단계 미채택. Phase H/I에서 재평가.
+- **Persisted outbox 패턴** — 본 단계 미채택. 별도 ADR.
+- **`__v` 낙관적 잠금** — 현재 `toJSON()`에서 삭제 중. 본 단계 그대로 유지, 별도 ADR.
+- **HTTP 라우트 `GET /join/:token` 리팩토링** — Q1 LOCK으로 본 단계는 응용 서비스 직접 호출만. 컨트롤러 연결은 별도 PR.
+- **나머지 5개 상태 전이의 응용 서비스화** — `PAIRED → MEASURING / MEASURING → COMPLETED / * → EXPIRED / * → CANCELLED` — 후속 단계 평가.
+
+---
+
+## §5. 참조 표
+
+| 항목 | 위치 |
+|---|---|
+| 코드 실측 단일 근거 | `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` |
+| Aggregate 설계 결정 LOCK | `.plans/G-mind-signal-ddd-bdd-tdd/DISCUSS.md` rev.4 (Q1~Q6) |
+| 한국어 명명 가이드 | `.plans/G-mind-signal-ddd-bdd-tdd/NAMING-GUIDE.md` rev.2 |
+| 실행 계획 (Wave 0~3) | `.plans/G-mind-signal-ddd-bdd-tdd/PLAN.md` rev.3 |
+| 6Q 일반 가이드 | `docs/patterns/ddd-discovery-via-6q.md` |
+| 6Q 스킬 (gstack v2.0.0 MIT) | `.claude/skills/office-hours-ddd-discovery/SKILL.md` |
+| Pocock TDD 스킬 (MIT) | `.claude/skills/tdd/SKILL.md` |
+
+---
+
+**END docs/patterns/session-aggregate-6q-applied.md** — Session aggregate 6Q discovery 박제. DOMAIN-MODEL-NOTES §3.4 정합.

--- a/docs/reports/paar-2026-05-12-phase-g-isolation-proof.md
+++ b/docs/reports/paar-2026-05-12-phase-g-isolation-proof.md
@@ -1,0 +1,113 @@
+# Phase G — Isolation Proof (Wave 3 T3.0)
+
+> 작성일: 2026-05-12
+> 가지: `feat/G-ddd-bdd-tdd-pilot`
+> 검증: Phase 18 (`02-processes/engine/`) + Phase 17.6 (`dual-trigger.service.ts`) + 기존 `pairing.service.ts` 수정 0건
+> Gate: G9 (PLAN rev.3 §9)
+
+---
+
+## 1. 검증 명령 + 실제 출력
+
+### 1.1 `src/02-processes/engine/` 수정 0건 (Phase 18 충돌 회피)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat src/02-processes/engine/
+(empty)
+```
+
+→ **0 hunks** ✅. Phase 18 engine-proxy-sync PLAN.md scope와 file overlap 0건.
+
+### 1.2 `src/05-features/sessions/services/pairing.service.ts` 수정 0건 (strangler 보존)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat -- src/05-features/sessions/services/pairing.service.ts
+(empty)
+```
+
+→ **0 hunks** ✅. 기존 함수 `pairDeviceProcess` / `createGroupSessionProcess` / `pairingListeners` / `addPairingCompleteListener` / `removePairingCompleteListener` 5종 모두 보존. 신규 `PairSubjectService`는 병렬 존재 (strangler).
+
+### 1.3 `src/02-processes/measurements/` 수정 0건 (측정 흐름 scope 외)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat src/02-processes/measurements/
+(empty)
+```
+
+→ **0 hunks** ✅.
+
+### 1.4 전체 변경 파일 stat (Phase G scope 내 27 files)
+
+```
+.claude/skills/office-hours-ddd-discovery/SKILL.md       |  93 +
+.claude/skills/office-hours-ddd-discovery/UPSTREAM.md    |  76 +
+.claude/skills/tdd/SKILL.md                              | 109 +
+.claude/skills/tdd/UPSTREAM.md                           |  53 +
+.claude/skills/tdd/_local-addendum.md                    | 102 +
+.claude/skills/tdd/deep-modules.md                       |  33 +
+.claude/skills/tdd/interface-design.md                   |  31 +
+.claude/skills/tdd/mocking.md                            |  59 +
+.claude/skills/tdd/refactoring.md                        |  10 +
+.claude/skills/tdd/tests.md                              |  61 +
+.dependency-cruiser.cjs                                  |  19 +
+.gitignore                                               |   6 +-
+docs/guides/_template.md                                 |  97 +
+docs/patterns/ddd-discovery-via-6q.md                    |  84 +
+docs/patterns/session-aggregate-6q-applied.md            | 213 +
+src/05-features/sessions/__tests__/pair-subject.bdd.test.ts | 193 +
+src/05-features/sessions/services/pair-subject.service.test.ts | 158 +
+src/05-features/sessions/services/pair-subject.service.ts | 120 +
+src/06-entities/sessions/domain/errors.ts                |  42 +
+src/06-entities/sessions/domain/session.aggregate.test.ts | 110 +
+src/06-entities/sessions/domain/session.aggregate.ts     | 199 +
+src/06-entities/sessions/domain/session.event.ts         |  24 +
+src/06-entities/sessions/index.ts                        |  12 +
+src/06-entities/sessions/model/session.schema.ts         |  14 +-
+src/06-entities/sessions/repository/session.repository.test.ts | 158 +
+src/06-entities/sessions/repository/session.repository.ts | 103 +
+src/06-entities/sessions/types/session.types.ts          |  24 +
+
+27 files changed, 2193 insertions(+), 10 deletions(-)
+```
+
+**변경 범위 분류**:
+
+| 범위 | 파일 수 | 변경 |
+|---|---|---|
+| Phase F skill vendoring (Wave 0 T0.1) | 10 | byte-identical 복제 + 1 신규 _local-addendum |
+| docs/patterns + docs/guides (Wave 0 T0.2) | 3 | byte-identical 복제 2 + 신규 6Q applied 1 |
+| .dependency-cruiser.cjs (Wave 0 T0.3) | 1 | R-DDD-1/R-DDD-2 규칙 2 추가 |
+| .gitignore | 1 | `.claude/skills/` unignore (T0.1) |
+| 신규 도메인 layer (Wave 1) | 7 | domain/ 4 + repository/ 2 + types/ 1 |
+| 06-entities/sessions index.ts (Wave 1) | 1 | SessionAggregate/SessionRepository 추가 export |
+| 06-entities/sessions/model/session.schema.ts (Wave 1 T1.0) | 1 | type-only 재구성 14 lines (런타임 동작 0건 변경) — SessionStatus import + L25 코멘트 |
+| 신규 응용 서비스 (Wave 2) | 3 | services/pair-subject.service + .test + __tests__/pair-subject.bdd.test |
+
+**런타임 비즈니스 로직 코드 수정**: **0건**.
+**기존 import path 변경**: **0건** (`Session`/`SessionDoc`/`SessionMethods`/`SessionModel` export 보존, 외부에서 `Session['status']` indexed access 그대로 작동).
+
+---
+
+## 2. Gate G9 통과 확정
+
+PLAN rev.3 §9 Gate G9:
+
+| 항목 | 명령 | 통과 기준 | 결과 |
+|---|---|---|---|
+| Phase 18 engine/ 수정 0건 | `git diff main..HEAD -- src/02-processes/engine/` | 빈 출력 | ✅ |
+| Phase 17.6 dual-trigger.service.ts 수정 0건 | `git diff main..HEAD -- src/02-processes/engine/services/dual-trigger.service.ts` | 빈 출력 | ✅ (engine/ 통째 확인으로 함께 검증) |
+| pairing.service.ts 수정 0건 (rev.3 G9 보강) | `git diff main..HEAD -- src/05-features/sessions/services/pairing.service.ts` | 빈 출력 | ✅ |
+| measurements/ 수정 0건 (scope 외) | `git diff main..HEAD -- src/02-processes/measurements/` | 빈 출력 | ✅ |
+
+**Gate G9 PASS** ✅.
+
+---
+
+## 3. 후속 단계
+
+- T3.1: `npm run verify` 6단계 GREEN 검증 (format:check + typecheck + depcruise + lint + test + build)
+- T3.2: ADR-NNN + RTM 행 박제 (Wave 3 종료)
+
+---
+
+**END paar-2026-05-12-phase-g-isolation-proof.md** — G9 PASS 박제 완료. Phase 18 / 17.6 / pairing.service.ts 수정 0건 확정.

--- a/docs/reports/paar-2026-05-12-phase-g-verify-green.md
+++ b/docs/reports/paar-2026-05-12-phase-g-verify-green.md
@@ -1,0 +1,75 @@
+# Phase G — Verify GREEN (Wave 3 T3.1)
+
+> 작성일: 2026-05-12
+> 가지: `feat/G-ddd-bdd-tdd-pilot`
+> 검증: `npm run verify` 6단계 모두 PASS — Gate G8
+> Baseline 회귀 0건
+
+---
+
+## 1. `npm run verify` 6단계 결과
+
+| # | 단계 | 명령 | 결과 |
+|---|---|---|---|
+| 1 | format:check | `prettier --check "src/**/*.ts"` | ✅ All matched files use Prettier code style! |
+| 2 | typecheck | `tsc --noEmit` | ✅ no errors |
+| 3 | depcruise | `depcruise src --config .dependency-cruiser.cjs` | ✅ no dependency violations found (123 modules / 300 dependencies cruised) |
+| 4 | lint | `eslint . --ext .ts` | ✅ no warnings/errors (--max-warnings 0) |
+| 5 | test | `jest` | ✅ Test Suites: 30 passed, Tests: **288 passed, 0 failed** |
+| 6 | build | `tsc && tsc-alias` | ✅ exit 0 |
+
+**Gate G8 PASS** ✅ — 6/6 단계 통과.
+
+---
+
+## 2. 회귀 안전 (baseline 비교)
+
+| 시점 | Test Suites | Tests | 변화 |
+|---|---|---|---|
+| Phase G 진입 전 (dev HEAD `9442e4d`) | 26 | 267 | baseline |
+| Wave 1 종료 (`31484d5` 직후) | 28 | 280 | +2 suites / +13 tests (T1.1 8 + T1.2 5) |
+| Wave 2 종료 (`ceb0191` 직후) | 30 | 288 | +2 suites / +8 tests (T2.1 5 + T2.2 3) |
+| Wave 3 T3.1 (`npm run verify` 시점) | **30** | **288** | 회귀 0건 ✅ |
+
+**기존 267 + 신규 21 = 288** (rev.3 명시 "≥ 18" 충족 — 실제 21 신규).
+
+**Phase G 신규 21 테스트 분류** (rev.3 정합):
+- AC3 SessionAggregate (T1.1): **8 PASS**
+- AC4 SessionRepository (T1.2): **5 PASS** (3 시나리오 + 2 null 보조)
+- AC5 PairSubjectService (T2.1): **5 PASS** (4 시나리오 + 1 userId 형식 보조)
+- AC6 BDD acceptance (T2.2): **3 PASS**
+
+---
+
+## 3. prettier 적용 7 파일 (T3.1 사전 작업)
+
+`npm run format` 실행 후 다음 7 파일이 prettier 규칙 정합으로 자동 수정됨:
+- `src/05-features/sessions/__tests__/pair-subject.bdd.test.ts`
+- `src/05-features/sessions/services/pair-subject.service.test.ts`
+- `src/05-features/sessions/services/pair-subject.service.ts`
+- `src/06-entities/sessions/domain/session.aggregate.test.ts`
+- `src/06-entities/sessions/domain/session.aggregate.ts`
+- `src/06-entities/sessions/repository/session.repository.test.ts`
+- `src/06-entities/sessions/repository/session.repository.ts`
+
+코드 동작 변경 0건 (whitespace/줄바꿈/괄호 자동 fixup만).
+
+---
+
+## 4. Gate G8 통과 의무 항목 (PLAN rev.3 §9)
+
+- [x] `npm run verify` 6단계 모두 PASS
+- [x] 기존 baseline 회귀 0건 (267 → 288 회귀 0)
+- [x] 신규 테스트 ≥ 18건 — 실제 **21건** PASS
+- [x] `eslint-disable` / `ts-ignore` / `test.skip()` 신규 0건
+- [x] Phase 18 / 17.6 / `pairing.service.ts` 수정 0건 (G9 T3.0 commit `214f481` 사전 확인 완료)
+
+---
+
+## 5. 후속 단계
+
+- T3.2 (다음): ADR-NNN-session-aggregate-ddd-pilot.md 박제 + RTM.md DR-G 행 추가
+
+---
+
+**END paar-2026-05-12-phase-g-verify-green.md** — Gate G8 PASS. 회귀 0건 + 6단계 GREEN + 신규 21 테스트 PASS.

--- a/docs/requirements/RTM.md
+++ b/docs/requirements/RTM.md
@@ -31,6 +31,7 @@
 | FR ID | Title | Source | Implementation | Tests | PR | Status |
 |---|---|---|---|---|---|---|
 | FR-00 | (예시) 세션 생성 API | #0 | `src/05-features/sessions/api/session.routes.ts` | `__tests__/sessions/create.test.ts` | — | Draft |
+| DR-G | Session Aggregate DDD/BDD/TDD Pilot | `.plans/PRD.md` DR-G + `.plans/G-mind-signal-ddd-bdd-tdd/` | `src/06-entities/sessions/{domain,repository,types}` + `src/05-features/sessions/services/pair-subject.service.ts` | `session.aggregate.test.ts` (8) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (3) = 21 | feat/G-ddd-bdd-tdd-pilot | Done (ADR-006 Accepted) |
 
 ---
 

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -14,10 +14,7 @@
  */
 
 import { Types } from 'mongoose';
-import {
-  SessionAggregate,
-  SessionRepository,
-} from '@06-entities/sessions';
+import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
 import { PairSubjectService } from '../services/pair-subject.service';
 
@@ -33,7 +30,7 @@ const makeInMemoryRepo = () => {
     findById: jest.fn(async (id: string) => store.get(id) ?? null),
     findByPairingToken: jest.fn(async (token: string) => {
       const id = tokenIndex.get(token);
-      return id ? store.get(id) ?? null : null;
+      return id ? (store.get(id) ?? null) : null;
     }),
     save: jest.fn(async (aggregate: SessionAggregate) => {
       store.set(aggregate.id, aggregate);

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -1,0 +1,193 @@
+/**
+ * pair-subject.bdd.test.ts — Phase G BDD 형식 인수 테스트
+ *
+ * Q1 LOCK — Jest 단독 + 서비스 직접 호출 (supertest / HTTP 라우트 / Express app import 0건).
+ * Cucumber.js는 별도 spike 가지에서만 검증. 본 단계 정식 도구 = Jest.
+ *
+ * 비개발자(연구원·교수)가 시나리오 텍스트를 읽고 "그래, 그게 맞아"라고 판단할 수 있도록 작성함.
+ * 5/26 교수 면담 시연용 — 한국어 자연어 시나리오 3건을 직접 낭독.
+ *
+ * 시나리오 3건 (PLAN rev.3 §7.2 + AppError 코드 실측 정합):
+ *   1. SEQUENTIAL 모드 첫 페어링 성공 — CREATED → PAIRED + SessionPairedEvent 발행
+ *   2. 만료된 토큰 — AppError 401 throw
+ *   3. 이미 사용된 토큰 (status PAIRED) — AppError 400 throw
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionAggregate,
+  SessionRepository,
+} from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+import { PairSubjectService } from '../services/pair-subject.service';
+
+/**
+ * 테스트 환경 헬퍼 — SessionRepository를 in-memory Map으로 모킹함.
+ * 진짜 MongoDB 미연결 (CI 환경 + 본 프로젝트 통합 테스트 패턴 정합).
+ */
+const makeInMemoryRepo = () => {
+  const store = new Map<string, SessionAggregate>();
+  const tokenIndex = new Map<string, string>(); // pairingToken → id
+
+  const repo: jest.Mocked<SessionRepository> = {
+    findById: jest.fn(async (id: string) => store.get(id) ?? null),
+    findByPairingToken: jest.fn(async (token: string) => {
+      const id = tokenIndex.get(token);
+      return id ? store.get(id) ?? null : null;
+    }),
+    save: jest.fn(async (aggregate: SessionAggregate) => {
+      store.set(aggregate.id, aggregate);
+    }),
+    saveNew: jest.fn(async (aggregate: SessionAggregate) => {
+      store.set(aggregate.id, aggregate);
+      tokenIndex.set(aggregate.pairingToken, aggregate.id);
+    }),
+  } as unknown as jest.Mocked<SessionRepository>;
+
+  return repo;
+};
+
+describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
+  describe('Scenario: SEQUENTIAL 모드의 첫 페어링이 성공함', () => {
+    test(
+      'Given operator alice가 SEQUENTIAL 모드 세션을 생성했고, ' +
+        'When subject bob (userId)이 pairingToken으로 합류 요청을 보내면, ' +
+        'Then 세션 상태가 CREATED 에서 PAIRED 로 전이하고 ' +
+        'SessionPairedEvent (userId/groupId/subjectIndex/mode 포함)가 발행됨',
+      async () => {
+        // Given — operator alice가 SEQUENTIAL 모드 세션을 생성함
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const session = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'A1B2C3D4',
+          subjectIndex: 1,
+          pairingToken: 'TOK001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+        await repo.saveNew(session);
+
+        // When — subject bob (userId)이 pairingToken 'TOK001'로 합류 요청을 보냄
+        const userId = new Types.ObjectId().toString();
+        const service = new PairSubjectService(repo);
+        const result = await service.execute({
+          pairingToken: 'TOK001',
+          userId,
+        });
+
+        // Then — 세션 상태가 PAIRED로 전이됨 + SessionPairedEvent 발행 검증
+        const reloaded = await repo.findById(session.id);
+        expect(reloaded).not.toBeNull();
+        expect(reloaded!.status).toBe('PAIRED');
+        expect(reloaded!.userId).toBe(userId);
+        expect(reloaded!.pairedAt).not.toBeNull();
+
+        // 이벤트 모양 검증 — userId / groupId / subjectIndex / mode 모두 포함됨
+        expect(result.event.type).toBe('SessionPaired');
+        expect(result.event.sessionId).toBe(session.id);
+        expect(result.event.userId).toBe(userId);
+        expect(result.event.groupId).toBe('A1B2C3D4');
+        expect(result.event.subjectIndex).toBe(1);
+        expect(result.event.mode).toBe('SEQUENTIAL');
+        expect(typeof result.event.occurredAt).toBe('string');
+      }
+    );
+  });
+
+  describe('Scenario: 만료된 토큰으로 페어링 시 실패함', () => {
+    test(
+      'Given 만료된 pairingToken을 가진 세션이 존재하고, ' +
+        'When subject가 그 토큰으로 합류 시도하면, ' +
+        'Then AppError 401 throw + 세션 status가 EXPIRED로 영속됨',
+      async () => {
+        // Given — 만료된 세션 (expiresAt < 현재 시각)
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const expiredSession = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'EXPIRED1',
+          subjectIndex: 1,
+          pairingToken: 'EXP001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() - 1000), // 1초 전에 만료됨
+        });
+        await repo.saveNew(expiredSession);
+
+        // When — subject가 만료된 토큰으로 합류 시도함
+        const userId = new Types.ObjectId().toString();
+        const service = new PairSubjectService(repo);
+
+        // Then — AppError 401 throw
+        let captured: AppError | null = null;
+        try {
+          await service.execute({ pairingToken: 'EXP001', userId });
+        } catch (err) {
+          captured = err as AppError;
+        }
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(401);
+
+        // 세션 status가 EXPIRED로 영속됨
+        const reloaded = await repo.findById(expiredSession.id);
+        expect(reloaded!.status).toBe('EXPIRED');
+      }
+    );
+  });
+
+  describe('Scenario: 이미 사용된 토큰으로 페어링 시 실패함', () => {
+    test(
+      'Given 이미 PAIRED 상태인 세션이 존재하고, ' +
+        'When 다른 subject가 같은 토큰으로 합류 시도하면, ' +
+        'Then AppError 400 throw + 기존 페어링 정보 보존됨',
+      async () => {
+        // Given — 이미 PAIRED 상태 세션
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const firstUserId = new Types.ObjectId().toString();
+        const session = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'PAIRED01',
+          subjectIndex: 1,
+          pairingToken: 'PRD001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+        await repo.saveNew(session);
+
+        // 첫 번째 페어링 성공
+        const service = new PairSubjectService(repo);
+        await service.execute({
+          pairingToken: 'PRD001',
+          userId: firstUserId,
+        });
+        const afterFirst = await repo.findById(session.id);
+        expect(afterFirst!.status).toBe('PAIRED');
+        expect(afterFirst!.userId).toBe(firstUserId);
+
+        // When — 두 번째 subject가 같은 토큰으로 합류 시도함
+        const secondUserId = new Types.ObjectId().toString();
+        let captured: AppError | null = null;
+        try {
+          await service.execute({
+            pairingToken: 'PRD001',
+            userId: secondUserId,
+          });
+        } catch (err) {
+          captured = err as AppError;
+        }
+
+        // Then — AppError 400 throw + 기존 페어링 정보 보존됨
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(400);
+
+        const afterSecond = await repo.findById(session.id);
+        expect(afterSecond!.status).toBe('PAIRED');
+        expect(afterSecond!.userId).toBe(firstUserId); // 첫 페어링 그대로 유지됨
+      }
+    );
+  });
+});

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -1,0 +1,158 @@
+/**
+ * pair-subject.service.test.ts — PairSubjectService 단위 테스트
+ *
+ * SessionRepository는 jest.fn() mock으로 격리함 — 진짜 DB 미연결.
+ * PLAN rev.3 §7.1 시나리오 4건 (AppError 400/401/404 실측 정합).
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionAggregate,
+  SessionRepository,
+} from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+import { PairSubjectService } from './pair-subject.service';
+
+const makeAggregate = (
+  override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+) => {
+  return SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: new Date(Date.now() + 60_000),
+    ...override,
+  });
+};
+
+const makeRepoMock = () => {
+  return {
+    findById: jest.fn(),
+    findByPairingToken: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+    saveNew: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<SessionRepository> & {
+    findByPairingToken: jest.Mock;
+    save: jest.Mock;
+  };
+};
+
+describe('PairSubjectService', () => {
+  test('1. happy path — 유효 토큰 + 유효 userId → CREATED → PAIRED + 이벤트 발행', async () => {
+    const aggregate = makeAggregate();
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(aggregate);
+
+    const service = new PairSubjectService(repo);
+    const result = await service.execute({
+      pairingToken: 'TOK001',
+      userId,
+    });
+
+    expect(repo.findByPairingToken).toHaveBeenCalledWith('TOK001');
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(result.session.status).toBe('PAIRED');
+    expect(result.session.userId).toBe(userId);
+    expect(result.event.type).toBe('SessionPaired');
+    expect(result.event.userId).toBe(userId);
+    expect(result.event.groupId).toBe('A1B2C3D4');
+    expect(result.event.subjectIndex).toBe(1);
+    expect(result.event.mode).toBe('SEQUENTIAL');
+
+    // 메모리 기록 확인
+    const events = service.drainRecordedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('SessionPaired');
+  });
+
+  test('2. 만료 토큰 → AppError 401 throw + 세션 status EXPIRED 영속', async () => {
+    const expired = makeAggregate({
+      expiresAt: new Date(Date.now() - 1000), // 이미 만료됨
+    });
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(expired);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'TOK001', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(401);
+    // expire()로 status 변경 + repo.save 호출 검증
+    expect(expired.status).toBe('EXPIRED');
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  test('3. 이미 PAIRED 상태 토큰 → AppError 400 throw', async () => {
+    const aggregate = makeAggregate();
+    aggregate.pair(new Types.ObjectId().toString()); // 사전 페어링 완료
+    expect(aggregate.status).toBe('PAIRED');
+
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(aggregate);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'TOK001', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(400);
+    // 이미 PAIRED 상태에서는 save 호출 0건 (전이 불가 시 expire/save 분기 안 탐)
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  test('4. 존재하지 않는 토큰 → AppError 404 throw', async () => {
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(null);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'NOPE000', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(404);
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  test('보조: userId 형식 부정합 → AppError 400 throw + repo 호출 0건', async () => {
+    const repo = makeRepoMock();
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({
+        pairingToken: 'TOK001',
+        userId: 'not-an-objectid',
+      });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(400);
+    // userId 검증 실패 시 토큰 조회 0건
+    expect(repo.findByPairingToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -6,10 +6,7 @@
  */
 
 import { Types } from 'mongoose';
-import {
-  SessionAggregate,
-  SessionRepository,
-} from '@06-entities/sessions';
+import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
 import { PairSubjectService } from './pair-subject.service';
 

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -1,0 +1,120 @@
+/**
+ * pair-subject.service.ts — 피실험자 페어링 응용 서비스 (Application Service)
+ *
+ * Phase G strangler 패턴 — 기존 pairing.service.ts::pairDeviceProcess(pairingToken, userId)와
+ * 병렬 존재함. 동일 시그니처 + Repository 어댑터 경유 + 도메인 invariant 강제.
+ *
+ * execute({pairingToken, userId}) 5단계 흐름 (pairing.service.ts:83-138 정합):
+ *   1. Types.ObjectId.isValid(userId) 형식 검증 → 실패 시 AppError 400
+ *   2. repository.findByPairingToken(pairingToken) — 미존재 시 AppError 404
+ *   3. aggregate.pair(userId) — 만료 시 expire() + save + AppError 401 / 전이 불가 시 AppError 400
+ *   4. repository.save(aggregate) — 영속화
+ *   5. SessionPairedEvent 메모리 기록 (recordedEvents)
+ *
+ * NOTE — 기존 pairingListeners (LD-12 대안 D) 통합 호출은 본 단계에서 제외함.
+ *   이유: 기존 pairing.service.ts 수정 0건 의무 (G9) 보존 — listener Set을 외부 노출하려면
+ *         기존 파일 수정 필요. 후속 controller 통합 PR에서 별도 결정 (헬퍼 export 또는
+ *         controller 레벨에서 양쪽 fire).
+ *   영향: 본 PairSubjectService를 직접 호출하는 경로(BDD 테스트)에서는 listener 미발화.
+ *         기존 HTTP 라우트는 여전히 pairDeviceProcess 사용 — listener 발화 동작 보존.
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionRepository,
+  SessionAggregate,
+  InvalidStatusTransitionError,
+} from '@06-entities/sessions';
+import type { SessionPairedEvent } from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+
+/** PairSubjectService.execute() 입력 인자 */
+export interface PairSubjectInput {
+  pairingToken: string;
+  userId: string;
+}
+
+/** PairSubjectService.execute() 결과 */
+export interface PairSubjectResult {
+  session: SessionAggregate;
+  event: SessionPairedEvent;
+}
+
+export class PairSubjectService {
+  private readonly repo: SessionRepository;
+  private recordedEvents: SessionPairedEvent[] = [];
+
+  constructor(repo?: SessionRepository) {
+    this.repo = repo ?? new SessionRepository();
+  }
+
+  /**
+   * 피실험자 페어링 한 번의 시도를 실행함.
+   *
+   * @throws AppError 400 — userId 형식 부정합 또는 status 전이 불가
+   * @throws AppError 401 — 토큰 만료
+   * @throws AppError 404 — 토큰 없음
+   */
+  async execute(input: PairSubjectInput): Promise<PairSubjectResult> {
+    // 1. userId 형식 검증 (기존 pairDeviceProcess L88-90 정합)
+    if (!Types.ObjectId.isValid(input.userId)) {
+      throw new AppError('유효하지 않은 사용자 ID 형식입니다', 400);
+    }
+
+    // 2. 토큰으로 직접 조회 (기존 Session.findOne({pairingToken}) 어댑터)
+    const aggregate = await this.repo.findByPairingToken(input.pairingToken);
+    if (!aggregate) {
+      throw new AppError(
+        '존재하지 않거나 유효하지 않은 토큰입니다',
+        404
+      );
+    }
+
+    // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제
+    try {
+      aggregate.pair(input.userId);
+    } catch (err) {
+      if (err instanceof InvalidStatusTransitionError) {
+        // 만료 시 EXPIRED 영속화 + 401 throw (기존 pairing.service.ts L101-105 정합)
+        if (aggregate.isExpired()) {
+          aggregate.expire();
+          await this.repo.save(aggregate);
+          throw new AppError(
+            '페어링 토큰이 만료되었습니다. 다시 시도해주세요.',
+            401
+          );
+        }
+        // 그 외 전이 불가 (이미 PAIRED 등) → 400 (기존 L108-112 정합)
+        throw new AppError(
+          `현재 세션 상태(${aggregate.status})에서는 페어링할 수 없습니다.`,
+          400
+        );
+      }
+      throw err;
+    }
+
+    // 4. 영속화
+    await this.repo.save(aggregate);
+
+    // 5. 도메인 이벤트 메모리 기록 (LD-12 listener 통합은 후속 controller 통합 PR로 분리함)
+    const event: SessionPairedEvent = {
+      type: 'SessionPaired',
+      sessionId: aggregate.id,
+      userId: input.userId,
+      occurredAt: new Date().toISOString(),
+      groupId: aggregate.groupId,
+      subjectIndex: aggregate.subjectIndex,
+      mode: aggregate.mode,
+    };
+    this.recordedEvents.push(event);
+
+    return { session: aggregate, event };
+  }
+
+  /** 기록된 도메인 이벤트 목록을 반환하고 내부 버퍼를 비움 — 테스트 검증용 */
+  drainRecordedEvents(): ReadonlyArray<SessionPairedEvent> {
+    const events = [...this.recordedEvents];
+    this.recordedEvents = [];
+    return events;
+  }
+}

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -64,10 +64,7 @@ export class PairSubjectService {
     // 2. 토큰으로 직접 조회 (기존 Session.findOne({pairingToken}) 어댑터)
     const aggregate = await this.repo.findByPairingToken(input.pairingToken);
     if (!aggregate) {
-      throw new AppError(
-        '존재하지 않거나 유효하지 않은 토큰입니다',
-        404
-      );
+      throw new AppError('존재하지 않거나 유효하지 않은 토큰입니다', 404);
     }
 
     // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제

--- a/src/06-entities/sessions/domain/errors.ts
+++ b/src/06-entities/sessions/domain/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * errors.ts — 세션 도메인 전용 에러 클래스 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건 (순수 도메인 layer).
+ * 응용 서비스(PairSubjectService)가 본 에러를 잡아 AppError로 매핑함.
+ */
+
+import type { SessionStatus } from '../types/session.types';
+
+/**
+ * InvariantViolationError — 단일 Session 도큐먼트 차원의 불변식이 깨졌을 때 발생함.
+ *
+ * 예시: SessionAggregate.create() 호출 시 pairingToken === '' 또는 subjectIndex < 1.
+ * 그룹 단위 invariant(같은 groupId의 subjectIndex unique)는 본 에러 책임 외 — Mongoose 인덱스가 enforce함.
+ */
+export class InvariantViolationError extends Error {
+  public readonly name = 'InvariantViolationError';
+
+  constructor(reason: string) {
+    super(`Session aggregate invariant violated: ${reason}`);
+    Object.setPrototypeOf(this, InvariantViolationError.prototype);
+  }
+}
+
+/**
+ * InvalidStatusTransitionError — 허용되지 않은 상태 전이를 시도했을 때 발생함.
+ *
+ * 예시: COMPLETED에서 markMeasuring() 호출 / 만료된 CREATED에서 PAIRED 전이 시도.
+ * 응용 서비스가 본 에러를 잡아 만료 시 AppError 401, 그 외 전이 불가 시 AppError 400으로 매핑함.
+ */
+export class InvalidStatusTransitionError extends Error {
+  public readonly name = 'InvalidStatusTransitionError';
+  public readonly from: SessionStatus;
+  public readonly to: SessionStatus;
+
+  constructor(from: SessionStatus, to: SessionStatus) {
+    super(`Invalid status transition: ${from} -> ${to}`);
+    this.from = from;
+    this.to = to;
+    Object.setPrototypeOf(this, InvalidStatusTransitionError.prototype);
+  }
+}

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * session.aggregate.test.ts — SessionAggregate 단위 테스트
+ *
+ * Mongoose / Redis / mongodb-memory-server 의존 0건 — 순수 도메인 단위 테스트.
+ * DOMAIN-MODEL-NOTES §3.1 정합 / PLAN rev.3 §6.2 시나리오 8건.
+ */
+
+import { SessionAggregate } from './session.aggregate';
+import {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './errors';
+
+describe('SessionAggregate', () => {
+  const baseParams = (override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}) => ({
+    id: 'session-id-1',
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: 'operator-1',
+    mode: 'SEQUENTIAL' as const,
+    expiresAt: new Date(Date.now() + 60_000), // 1분 뒤 만료
+    ...override,
+  });
+
+  describe('create()', () => {
+    test('1. happy path — SEQUENTIAL 모드 + 유효 인자 → 상태 CREATED', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      expect(aggregate.status).toBe('CREATED');
+      expect(aggregate.id).toBe('session-id-1');
+      expect(aggregate.groupId).toBe('A1B2C3D4');
+      expect(aggregate.subjectIndex).toBe(1);
+      expect(aggregate.pairingToken).toBe('TOK001');
+      expect(aggregate.operatorId).toBe('operator-1');
+      expect(aggregate.mode).toBe('SEQUENTIAL');
+      expect(aggregate.userId).toBeNull();
+      expect(aggregate.pairedAt).toBeNull();
+    });
+
+    test('2. invariant 위반 — empty pairingToken → InvariantViolationError', () => {
+      expect(() =>
+        SessionAggregate.create(baseParams({ pairingToken: '' }))
+      ).toThrow(InvariantViolationError);
+    });
+
+    test('3. invariant 위반 — subjectIndex < 1 → InvariantViolationError', () => {
+      expect(() =>
+        SessionAggregate.create(baseParams({ subjectIndex: 0 }))
+      ).toThrow(InvariantViolationError);
+      expect(() =>
+        SessionAggregate.create(baseParams({ subjectIndex: -1 }))
+      ).toThrow(InvariantViolationError);
+    });
+  });
+
+  describe('pair()', () => {
+    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      const userId = 'user-bob';
+      const before = Date.now();
+      aggregate.pair(userId);
+      const after = Date.now();
+
+      expect(aggregate.status).toBe('PAIRED');
+      expect(aggregate.userId).toBe(userId);
+      expect(aggregate.pairedAt).not.toBeNull();
+      const pairedTime = aggregate.pairedAt!.getTime();
+      expect(pairedTime).toBeGreaterThanOrEqual(before);
+      expect(pairedTime).toBeLessThanOrEqual(after);
+    });
+
+    test('5. 실패 — isExpired() === true → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(
+        baseParams({ expiresAt: new Date(Date.now() - 1000) }) // 이미 만료됨
+      );
+      expect(() => aggregate.pair('user-bob')).toThrow(
+        InvalidStatusTransitionError
+      );
+      // 상태는 그대로 CREATED (만료 처리는 별도 expire() 호출 책임)
+      expect(aggregate.status).toBe('CREATED');
+    });
+
+    test('6. 실패 — status === PAIRED에서 재호출 → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      aggregate.pair('user-bob');
+      expect(() => aggregate.pair('user-charlie')).toThrow(
+        InvalidStatusTransitionError
+      );
+      // userId는 첫 페어링 그대로 유지됨
+      expect(aggregate.userId).toBe('user-bob');
+    });
+  });
+
+  describe('markMeasuring() & cancel()', () => {
+    test('7. markMeasuring() 실패 — CREATED에서 호출 → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      expect(() => aggregate.markMeasuring()).toThrow(
+        InvalidStatusTransitionError
+      );
+      expect(aggregate.status).toBe('CREATED');
+    });
+
+    test('8. cancel() happy — PAIRED에서 CANCELLED 전이', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      aggregate.pair('user-bob');
+      aggregate.cancel('ManualEarly');
+      expect(aggregate.status).toBe('CANCELLED');
+    });
+  });
+});

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -12,7 +12,9 @@ import {
 } from './errors';
 
 describe('SessionAggregate', () => {
-  const baseParams = (override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}) => ({
+  const baseParams = (
+    override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+  ) => ({
     id: 'session-id-1',
     groupId: 'A1B2C3D4',
     subjectIndex: 1,

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -90,9 +90,7 @@ export class SessionAggregate {
   }
 
   /** DB 도큐먼트 → 통합체 변환 — Repository 내부에서만 호출함 */
-  static fromDocument(
-    doc: SessionAggregateDocumentFields
-  ): SessionAggregate {
+  static fromDocument(doc: SessionAggregateDocumentFields): SessionAggregate {
     return new SessionAggregate(
       doc._id,
       doc.groupId,

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -1,0 +1,199 @@
+/**
+ * session.aggregate.ts — Session 도메인 통합체 (Aggregate Root)
+ *
+ * Vernon 2011 "Effective Aggregate Design Part I" 단일 aggregate 패턴 적용함.
+ * 단일 Session 도큐먼트 = 1 aggregate = 1 트랜잭션 단위.
+ * 그룹 invariant(groupId+subjectIndex unique)는 본 클래스 책임 외 — Mongoose 인덱스가 enforce함.
+ *
+ * Pure TypeScript — Mongoose / Redis / Socket.io 의존 0건 (depcruise R-DDD-1/R-DDD-2 통과).
+ * SessionStatus는 ../types/session.types에서 import (schema 직접 import 0건).
+ */
+
+import type { SessionStatus, ExperimentMode } from '../types/session.types';
+import {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './errors';
+
+/** SessionAggregate.create() factory 입력 인자 7종 */
+export interface SessionAggregateCreateParams {
+  id: string;
+  groupId: string;
+  subjectIndex: number;
+  pairingToken: string;
+  operatorId: string | null;
+  mode: ExperimentMode;
+  expiresAt: Date;
+}
+
+/** SessionAggregate.fromDocument() 입력 인자 (DB 도큐먼트 → 통합체 변환용) */
+export interface SessionAggregateDocumentFields {
+  _id: string;
+  groupId: string;
+  subjectIndex: number;
+  pairingToken: string;
+  creatorId: string | null;
+  experimentMode: ExperimentMode;
+  expiresAt: Date;
+  status: SessionStatus;
+  userId: string | null;
+  pairedAt: Date | null;
+}
+
+/** 세션 취소 사유 (Session schema stopReason 정합) */
+export type CancelReason =
+  | 'Natural'
+  | 'ManualEarly'
+  | 'HeadsetLost'
+  | 'ProcessError';
+
+export class SessionAggregate {
+  private constructor(
+    private readonly _id: string,
+    private readonly _groupId: string,
+    private readonly _subjectIndex: number,
+    private readonly _pairingToken: string,
+    private readonly _operatorId: string | null,
+    private readonly _mode: ExperimentMode,
+    private readonly _expiresAt: Date,
+    private _status: SessionStatus,
+    private _userId: string | null,
+    private _pairedAt: Date | null
+  ) {}
+
+  /**
+   * Static factory — invariant 검증 강제함.
+   *
+   * @throws InvariantViolationError pairingToken === '' 또는 subjectIndex < 1
+   */
+  static create(params: SessionAggregateCreateParams): SessionAggregate {
+    if (!params.pairingToken) {
+      throw new InvariantViolationError('empty pairing token');
+    }
+    if (params.subjectIndex < 1) {
+      throw new InvariantViolationError(
+        `subjectIndex must be >= 1, got ${params.subjectIndex}`
+      );
+    }
+    return new SessionAggregate(
+      params.id,
+      params.groupId,
+      params.subjectIndex,
+      params.pairingToken,
+      params.operatorId,
+      params.mode,
+      params.expiresAt,
+      'CREATED',
+      null,
+      null
+    );
+  }
+
+  /** DB 도큐먼트 → 통합체 변환 — Repository 내부에서만 호출함 */
+  static fromDocument(
+    doc: SessionAggregateDocumentFields
+  ): SessionAggregate {
+    return new SessionAggregate(
+      doc._id,
+      doc.groupId,
+      doc.subjectIndex,
+      doc.pairingToken,
+      doc.creatorId,
+      doc.experimentMode,
+      doc.expiresAt,
+      doc.status,
+      doc.userId,
+      doc.pairedAt
+    );
+  }
+
+  /**
+   * 피실험자를 세션에 연결함 — CREATED → PAIRED 전이.
+   *
+   * @throws InvalidStatusTransitionError 만료(isExpired) 또는 status !== 'CREATED'
+   */
+  pair(userId: string): void {
+    if (this.isExpired()) {
+      throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
+    }
+    if (this._status !== 'CREATED') {
+      throw new InvalidStatusTransitionError(this._status, 'PAIRED');
+    }
+    this._status = 'PAIRED';
+    this._userId = userId;
+    this._pairedAt = new Date();
+  }
+
+  /** PAIRED → MEASURING — 본 단계 시연 외, 메서드 골조만 */
+  markMeasuring(): void {
+    if (this._status !== 'PAIRED') {
+      throw new InvalidStatusTransitionError(this._status, 'MEASURING');
+    }
+    this._status = 'MEASURING';
+  }
+
+  /** MEASURING → COMPLETED — 본 단계 시연 외 */
+  complete(): void {
+    if (this._status !== 'MEASURING') {
+      throw new InvalidStatusTransitionError(this._status, 'COMPLETED');
+    }
+    this._status = 'COMPLETED';
+  }
+
+  /** CREATED → EXPIRED — 만료 처리, PairSubjectService 흐름에서 호출함 */
+  expire(): void {
+    if (this._status !== 'CREATED') {
+      throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
+    }
+    this._status = 'EXPIRED';
+  }
+
+  /** * → CANCELLED — 종착 상태에서는 호출 불가 */
+  cancel(_reason: CancelReason): void {
+    if (
+      this._status === 'COMPLETED' ||
+      this._status === 'EXPIRED' ||
+      this._status === 'CANCELLED'
+    ) {
+      throw new InvalidStatusTransitionError(this._status, 'CANCELLED');
+    }
+    this._status = 'CANCELLED';
+  }
+
+  /** 만료 여부 — expiresAt < 현재 시각 */
+  isExpired(): boolean {
+    return this._expiresAt.getTime() < Date.now();
+  }
+
+  // ===== getters =====
+  get id(): string {
+    return this._id;
+  }
+  get groupId(): string {
+    return this._groupId;
+  }
+  get subjectIndex(): number {
+    return this._subjectIndex;
+  }
+  get pairingToken(): string {
+    return this._pairingToken;
+  }
+  get operatorId(): string | null {
+    return this._operatorId;
+  }
+  get mode(): ExperimentMode {
+    return this._mode;
+  }
+  get expiresAt(): Date {
+    return this._expiresAt;
+  }
+  get status(): SessionStatus {
+    return this._status;
+  }
+  get userId(): string | null {
+    return this._userId;
+  }
+  get pairedAt(): Date | null {
+    return this._pairedAt;
+  }
+}

--- a/src/06-entities/sessions/domain/session.event.ts
+++ b/src/06-entities/sessions/domain/session.event.ts
@@ -1,0 +1,24 @@
+/**
+ * session.event.ts — 세션 도메인 이벤트 타입 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건 (순수 타입).
+ * 발행 큐(pullDomainEvents) 미채택 (Phase E TS-Q17 A3 LOCK 정합).
+ * 응용 서비스가 메모리 내 배열에 기록 + 기존 pairingListeners 호출 (LD-12 대안 D 통합)함.
+ */
+
+import type { ExperimentMode } from '../types/session.types';
+
+/**
+ * SessionPairedEvent — 피실험자가 세션에 합류했다는 사실을 표현함.
+ *
+ * 기존 pairing.service.ts pairingListeners callback({groupId, subjectIndex})와 정보 통합됨.
+ */
+export type SessionPairedEvent = {
+  type: 'SessionPaired';
+  sessionId: string;
+  userId: string; // 페어링한 Subject의 userId (subjectId 명칭 미사용 — mind-signal 컨벤션)
+  occurredAt: string; // ISO 8601
+  groupId: string;
+  subjectIndex: number;
+  mode: ExperimentMode;
+};

--- a/src/06-entities/sessions/index.ts
+++ b/src/06-entities/sessions/index.ts
@@ -1,1 +1,13 @@
 export * from './model/session.schema';
+export { SessionAggregate } from './domain/session.aggregate';
+export type {
+  SessionAggregateCreateParams,
+  SessionAggregateDocumentFields,
+  CancelReason,
+} from './domain/session.aggregate';
+export type { SessionPairedEvent } from './domain/session.event';
+export {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './domain/errors';
+export { SessionRepository } from './repository/session.repository';

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -1,5 +1,9 @@
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 import { ExperimentMode } from '@07-shared/constants/experiment';
+import type { SessionStatus } from '../types/session.types';
+
+// SessionStatus re-export — 외부에서 schema 또는 types 양쪽 경로로 import 호환함
+export type { SessionStatus };
 
 /** * 1. 문서 필드 타입 정의
  * ERD의 필드와 Note A 규칙을 반영함
@@ -10,19 +14,13 @@ export interface Session {
   pairingToken: string; // 고유 페어링 토큰임
   userId: Types.ObjectId | null; // 페어링 성공 시 바인딩되는 사용자 ID임
   creatorId: Types.ObjectId | null; // 세션 생성자(운영자) ID임
-  status:
-    | 'CREATED'
-    | 'PAIRED'
-    | 'MEASURING'
-    | 'COMPLETED'
-    | 'EXPIRED'
-    | 'CANCELLED';
+  status: SessionStatus; // 세션 상태 6종 (session.types.ts 단일 정의 참조)
   pairedAt: Date | null; // 페어링 완료 시점
   expiresAt: Date; // 토큰 만료 시점
   measuredAt: Date | null; // 측정 시작 시점
   stopReason: 'Natural' | 'ManualEarly' | 'HeadsetLost' | 'ProcessError' | null;
   measuredDurationSeconds: number | null;
-  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI)
+  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI | DUAL_2PC)
 }
 
 /** 2. 인스턴스 메서드 타입 정의 */

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -54,7 +54,10 @@ const makeAggregate = (
  * Mongoose SessionDoc-like 객체 생성기 — Repository.toAggregate가 읽는 필드만 포함함.
  * 실제 Mongoose Hydration 결과를 mock 형태로 모사함.
  */
-const makeDocLike = (aggregate: SessionAggregate, statusOverride?: SessionAggregate['status']) => ({
+const makeDocLike = (
+  aggregate: SessionAggregate,
+  statusOverride?: SessionAggregate['status']
+) => ({
   _id: aggregate.id,
   groupId: aggregate.groupId,
   subjectIndex: aggregate.subjectIndex,

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -1,0 +1,158 @@
+/**
+ * session.repository.test.ts — SessionRepository 통합 테스트
+ *
+ * Mongoose Model의 정적 메서드(findById / findOne / findByIdAndUpdate / create)를 Jest mock으로 격리함.
+ * 기존 mind-signal-backend 통합 테스트 패턴 정합 (CI는 외부 MongoDB 미연결 — mock 의무, .claude/rules/test-modification.md).
+ *
+ * 진짜 MongoDB 통합 검증은 후속 인프라 정비 후 별도 PR (mongodb-memory-server 도입 시).
+ * PLAN rev.3 §6.3 "mongodb-memory-server" 명시는 본 프로젝트 실제 패턴과 불일치로 mock 기반 통합 테스트로 채택함.
+ *
+ * 시나리오 3건:
+ *   1. saveNew → findById 왕복 (같은 상태 복원)
+ *   2. saveNew → findByPairingToken 왕복 (토큰 인덱스 정합)
+ *   3. save 상태 전이 영속 (CREATED → PAIRED)
+ */
+
+import { Types } from 'mongoose';
+import { Session } from '../model/session.schema';
+import { SessionAggregate } from '../domain/session.aggregate';
+import { SessionRepository } from './session.repository';
+
+jest.mock('../model/session.schema', () => ({
+  Session: {
+    findById: jest.fn(),
+    findOne: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+type AnyMock = jest.Mock;
+const SessionMock = Session as unknown as {
+  findById: AnyMock;
+  findOne: AnyMock;
+  findByIdAndUpdate: AnyMock;
+  create: AnyMock;
+};
+
+const makeAggregate = (
+  override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+) => {
+  return SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: new Date(Date.now() + 60_000),
+    ...override,
+  });
+};
+
+/**
+ * Mongoose SessionDoc-like 객체 생성기 — Repository.toAggregate가 읽는 필드만 포함함.
+ * 실제 Mongoose Hydration 결과를 mock 형태로 모사함.
+ */
+const makeDocLike = (aggregate: SessionAggregate, statusOverride?: SessionAggregate['status']) => ({
+  _id: aggregate.id,
+  groupId: aggregate.groupId,
+  subjectIndex: aggregate.subjectIndex,
+  pairingToken: aggregate.pairingToken,
+  creatorId: aggregate.operatorId,
+  userId: aggregate.userId,
+  experimentMode: aggregate.mode,
+  expiresAt: aggregate.expiresAt,
+  status: statusOverride ?? aggregate.status,
+  pairedAt: aggregate.pairedAt,
+});
+
+describe('SessionRepository (통합 — Mongoose Model mock)', () => {
+  let repo: SessionRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = new SessionRepository();
+  });
+
+  test('1. saveNew → findById 왕복 (같은 상태 복원)', async () => {
+    const original = makeAggregate();
+    const docLike = makeDocLike(original);
+
+    SessionMock.create.mockResolvedValueOnce(docLike);
+    SessionMock.findById.mockResolvedValueOnce(docLike);
+
+    await repo.saveNew(original);
+    const restored = await repo.findById(original.id);
+
+    expect(SessionMock.create).toHaveBeenCalledTimes(1);
+    expect(SessionMock.findById).toHaveBeenCalledWith(original.id);
+    expect(restored).not.toBeNull();
+    expect(restored!.id).toBe(original.id);
+    expect(restored!.groupId).toBe('A1B2C3D4');
+    expect(restored!.subjectIndex).toBe(1);
+    expect(restored!.pairingToken).toBe('TOK001');
+    expect(restored!.mode).toBe('SEQUENTIAL');
+    expect(restored!.status).toBe('CREATED');
+  });
+
+  test('2. saveNew → findByPairingToken 왕복 (토큰 인덱스 정합)', async () => {
+    const original = makeAggregate({ pairingToken: 'TOK999' });
+    const docLike = makeDocLike(original);
+
+    SessionMock.create.mockResolvedValueOnce(docLike);
+    SessionMock.findOne.mockResolvedValueOnce(docLike);
+
+    await repo.saveNew(original);
+    const restored = await repo.findByPairingToken('TOK999');
+
+    expect(SessionMock.findOne).toHaveBeenCalledWith({
+      pairingToken: 'TOK999',
+    });
+    expect(restored).not.toBeNull();
+    expect(restored!.pairingToken).toBe('TOK999');
+    expect(restored!.id).toBe(original.id);
+  });
+
+  test('3. save 상태 전이 영속 (CREATED → PAIRED)', async () => {
+    const aggregate = makeAggregate();
+    const userId = new Types.ObjectId().toString();
+    aggregate.pair(userId);
+
+    SessionMock.findByIdAndUpdate.mockResolvedValueOnce(makeDocLike(aggregate));
+    await repo.save(aggregate);
+
+    expect(SessionMock.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const callArgs = SessionMock.findByIdAndUpdate.mock.calls[0];
+    expect(callArgs[0]).toBe(aggregate.id);
+
+    const fields = callArgs[1] as {
+      status: string;
+      userId: Types.ObjectId | null;
+      pairedAt: Date | null;
+      groupId: string;
+      subjectIndex: number;
+    };
+    expect(fields.status).toBe('PAIRED');
+    expect(fields.userId).not.toBeNull();
+    expect(String(fields.userId)).toBe(userId);
+    expect(fields.pairedAt).not.toBeNull();
+    expect(fields.groupId).toBe('A1B2C3D4');
+    expect(fields.subjectIndex).toBe(1);
+
+    const options = callArgs[2] as { upsert: boolean };
+    expect(options.upsert).toBe(false);
+  });
+
+  test('보조: findById 미존재 시 null 반환', async () => {
+    SessionMock.findById.mockResolvedValueOnce(null);
+    const result = await repo.findById('does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  test('보조: findByPairingToken 미존재 시 null 반환', async () => {
+    SessionMock.findOne.mockResolvedValueOnce(null);
+    const result = await repo.findByPairingToken('NOPE000');
+    expect(result).toBeNull();
+  });
+});

--- a/src/06-entities/sessions/repository/session.repository.ts
+++ b/src/06-entities/sessions/repository/session.repository.ts
@@ -1,0 +1,103 @@
+/**
+ * session.repository.ts — SessionAggregate ↔ Mongoose Session 도큐먼트 양방향 변환 어댑터
+ *
+ * Stemmler 2019 "How to Design & Persist Aggregates" strangler 패턴 적용함.
+ * 도메인 통합체(순수 클래스)와 Mongoose Model(DB 영속) 사이의 단일 변환 지점.
+ * 응용 서비스(PairSubjectService)가 본 Repository만 호출 — Mongoose Model 직접 사용 0건.
+ *
+ * FSD 06-entities 레이어 — domain/ 으로의 import 0건 (역방향 import 금지, depcruise 통과).
+ */
+
+import { Types } from 'mongoose';
+import { Session } from '../model/session.schema';
+import { SessionAggregate } from '../domain/session.aggregate';
+import type { SessionDoc, SessionStatus } from '../model/session.schema';
+
+export class SessionRepository {
+  /**
+   * ID로 세션 조회 후 SessionAggregate로 변환함.
+   * @returns 미존재 시 null 반환
+   */
+  async findById(id: string): Promise<SessionAggregate | null> {
+    const doc = await Session.findById(id);
+    return doc ? this.toAggregate(doc) : null;
+  }
+
+  /**
+   * 페어링 토큰으로 세션 조회 후 SessionAggregate로 변환함.
+   * 기존 pairing.service.ts::pairDeviceProcess L94의 Session.findOne({pairingToken}) 어댑터.
+   * @returns 미존재 시 null 반환
+   */
+  async findByPairingToken(token: string): Promise<SessionAggregate | null> {
+    const doc = await Session.findOne({ pairingToken: token });
+    return doc ? this.toAggregate(doc) : null;
+  }
+
+  /**
+   * 통합체의 현재 상태를 DB에 영속화함 (기존 도큐먼트 갱신).
+   * 신규 도큐먼트 생성은 saveNew()를 사용함.
+   */
+  async save(aggregate: SessionAggregate): Promise<void> {
+    const fields = this.toDocumentFields(aggregate);
+    await Session.findByIdAndUpdate(aggregate.id, fields, { upsert: false });
+  }
+
+  /** 새 통합체를 DB에 신규 저장함 (Session.create()). */
+  async saveNew(aggregate: SessionAggregate): Promise<void> {
+    const fields = this.toDocumentFields(aggregate);
+    await Session.create({
+      _id: this.toObjectId(aggregate.id),
+      pairingToken: aggregate.pairingToken,
+      expiresAt: aggregate.expiresAt,
+      experimentMode: aggregate.mode,
+      ...fields,
+    });
+  }
+
+  /** Mongoose 도큐먼트 → SessionAggregate 변환함 */
+  private toAggregate(doc: SessionDoc): SessionAggregate {
+    return SessionAggregate.fromDocument({
+      _id: String(doc._id),
+      groupId: doc.groupId,
+      subjectIndex: doc.subjectIndex ?? 0,
+      pairingToken: doc.pairingToken,
+      creatorId: doc.creatorId ? String(doc.creatorId) : null,
+      experimentMode: doc.experimentMode,
+      expiresAt: doc.expiresAt,
+      status: doc.status,
+      userId: doc.userId ? String(doc.userId) : null,
+      pairedAt: doc.pairedAt,
+    });
+  }
+
+  /**
+   * SessionAggregate → Mongoose 도큐먼트 갱신 필드로 변환함.
+   * save()는 본 결과만, saveNew()는 본 결과 + pairingToken/expiresAt/experimentMode 추가.
+   */
+  private toDocumentFields(
+    aggregate: SessionAggregate
+  ): {
+    groupId: string;
+    subjectIndex: number;
+    creatorId: Types.ObjectId | null;
+    status: SessionStatus;
+    userId: Types.ObjectId | null;
+    pairedAt: Date | null;
+  } {
+    return {
+      groupId: aggregate.groupId,
+      subjectIndex: aggregate.subjectIndex,
+      creatorId: aggregate.operatorId
+        ? this.toObjectId(aggregate.operatorId)
+        : null,
+      status: aggregate.status,
+      userId: aggregate.userId ? this.toObjectId(aggregate.userId) : null,
+      pairedAt: aggregate.pairedAt,
+    };
+  }
+
+  /** 문자열 ID → Mongoose ObjectId 변환함 (유효성 검증은 호출 측 책임) */
+  private toObjectId(id: string): Types.ObjectId {
+    return new Types.ObjectId(id);
+  }
+}

--- a/src/06-entities/sessions/repository/session.repository.ts
+++ b/src/06-entities/sessions/repository/session.repository.ts
@@ -74,9 +74,7 @@ export class SessionRepository {
    * SessionAggregate → Mongoose 도큐먼트 갱신 필드로 변환함.
    * save()는 본 결과만, saveNew()는 본 결과 + pairingToken/expiresAt/experimentMode 추가.
    */
-  private toDocumentFields(
-    aggregate: SessionAggregate
-  ): {
+  private toDocumentFields(aggregate: SessionAggregate): {
     groupId: string;
     subjectIndex: number;
     creatorId: Types.ObjectId | null;

--- a/src/06-entities/sessions/types/session.types.ts
+++ b/src/06-entities/sessions/types/session.types.ts
@@ -1,0 +1,24 @@
+/**
+ * session.types.ts — 세션 도메인 순수 타입 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건.
+ * depcruise R-DDD-1 차단 대상 외 (정규식이 .schema$만 매칭하므로 .types$ 통과).
+ *
+ * - SessionStatus: 본 파일에서 단일 정의
+ * - ExperimentMode: @07-shared/constants/experiment를 single source로 유지 (re-export만 제공, drift 회피)
+ */
+
+/** 세션 상태 6종 union — CLAUDE.md §7 박제 + session.schema.ts 정합 */
+export type SessionStatus =
+  | 'CREATED'
+  | 'PAIRED'
+  | 'MEASURING'
+  | 'COMPLETED'
+  | 'EXPIRED'
+  | 'CANCELLED';
+
+/**
+ * ExperimentMode re-export — @07-shared/constants/experiment가 single source.
+ * 본 파일은 도메인 layer가 동일 타입을 import할 때 경로 정합을 제공함.
+ */
+export type { ExperimentMode } from '@07-shared/constants/experiment';


### PR DESCRIPTION
## Summary

Phase G — mind-signal-backend DDD/BDD/TDD pilot (학습/시연 단계, 2026-05-26 교수 면담 시연용).

- **P1 frame**: 학습/시연 + Phase F 박제 자산 활성화 + 새 기여 주장 0건 (산업 표준 패턴 Vernon 2011 / Stemmler 2019 / Pocock TDD / gstack 6Q 적용)
- **Scope**: 페어링 흐름(`CREATED → PAIRED`) 한 줄 — `SessionAggregate` + `SessionRepository` + `PairSubjectService` + BDD 3 시나리오
- **11 atomic commits** (Wave 0~3, T0.1~T3.2)
- **Gate 10/10 PASS** + **CRITIQUE 4-Lens 4 Rounds PASS** (Critical 0건)
- **`npm run verify` 6단계 GREEN** — 30 suites / **288 tests PASS** (기존 267 + 신규 21, 회귀 0건)

## 11 Atomic Commits

| Wave | SHA | Task | 메시지 |
|---|---|---|---|
| 0 | aa78a2f | T0.1 | feat(skills): vendor Pocock TDD + office-hours-ddd-discovery |
| 0 | 5219a34 | T0.2 | docs(patterns): 6Q discovery + session aggregate 6Q applied + _template |
| 0 | bc4145a | T0.3 | chore(depcruise): no-mongoose-in-domain + no-redis-socket-in-domain |
| 1 | 470b522 | T1.0 | refactor(sessions): extract pure types to session.types.ts |
| 1 | e27ef41 | T1.1 | feat(sessions): SessionAggregate domain class (8 tests PASS) |
| 1 | 31484d5 | T1.2 | feat(sessions): SessionRepository adapter (5 tests PASS) |
| 2 | 435195f | T2.1 | feat(sessions): pair-subject use case service (5 tests PASS) |
| 2 | ceb0191 | T2.2 | test(sessions): pair-subject BDD acceptance (3 scenarios PASS) |
| 3 | 214f481 | T3.0 | test(verify): Phase 18 / 17.6 / pairing.service.ts untouched |
| 3 | 2c3c09f | T3.1 | chore(verify): npm run verify GREEN with regression 0 |
| 3 | 11593af | T3.2 | docs(adr): ADR-006 session aggregate DDD pilot + RTM row |

## Key Decisions (ADR-006 Accepted)

1. **명칭 분리** — `Session` Mongoose Model + `SessionAggregate` 도메인
2. **Aggregate boundary = 단일 Session 도큐먼트** (그룹 invariant = Mongoose `groupId_subjectIndex_unique` 인덱스 책임)
3. **시그니처** — `create()` 7 인자 + `pair(userId)` 1 인자 (mind-signal `userId` 컨벤션)
4. **순수 타입 분리** — `session.types.ts` SessionStatus 단일 정의 + ExperimentMode re-export from `@07-shared/constants/experiment`
5. **Repository strangler** — `findById` / `findByPairingToken` / `save` / `saveNew`
6. **PairSubjectService 병렬 존재** — 기존 `pairing.service.ts` 수정 0건 (G9 strict, controller 통합은 후속 PR)
7. **depcruise R-DDD-1/R-DDD-2** — domain/ → mongoose/schema 차단 + 인프라 차단
8. **BDD Jest 단독 + 서비스 직접 호출** (Q1 LOCK, supertest 미사용)

## Code-Review-Graph 실측 12 정정 반영

rev.2 stale 가정 모두 rev.3 LOCK으로 정정:

1. pairingToken 단수 / 2. experimentMode 4종 (SINGLE 미존재) / 3. 그룹 invariant Mongoose 인덱스 / 4. create() 7 인자 / 5. pair(userId) 1 인자 / 6. execute({userId}) (subjectId 명칭 미사용) / 7. findByPairingToken / 8. pairingListeners 통합 (LOCK이지만 본 단계 미적용 — G9 strict 보존, TD-G-1 후속 PR) / 9. AppError 코드 실측 401/400/404 (rev.2 stale 410/409) / 10. ExperimentMode single source / 11. lookupTokenAndAllocate 제거 (group_counters 페어링 흐름 미사용) / 12. session.schema.ts L25 코멘트 오타 정정

## Gate 10/10 PASS

| Gate | 항목 | 결과 |
|---|---|---|
| G1 | Phase F 9 skill SHA256 byte-identical | ✅ |
| G2 | 6Q × Session 적용 문서 6 섹션 | ✅ |
| G3 | SessionAggregate 단위 테스트 ≥ 8 | ✅ 8 PASS |
| G4 | SessionRepository 통합 테스트 ≥ 3 | ✅ 5 PASS |
| G5 | PairSubjectService 단위 테스트 ≥ 4 | ✅ 5 PASS |
| G6 | BDD 인수 시나리오 ≥ 3 | ✅ 3 PASS |
| G7 | depcruise R-DDD-1/2 위반 0 | ✅ 0 violations |
| G8 | npm run verify 6단계 GREEN + 회귀 0 | ✅ 288 PASS |
| G9 | Phase 18 / 17.6 / pairing.service.ts 수정 0건 | ✅ 빈 출력 |
| G10 | ADR-006 Accepted + RTM 행 | ✅ Done |

## CRITIQUE 4-Lens 4 Rounds PASS

- Round 1+2 (deep-feature-critique): 🟠 PIVOT → 🟡 PROCEED-WITH-CONDITIONS (5 prerequisites)
- Round 3 (Contract Lens, codex `019e1ad8`): PASS (Critical 0)
- Round 4 (Reality Lens, Wave 1 전 사전 적용): PASS — DOMAIN-MODEL-NOTES 12 정정 모든 산출물 반영 누락 0건
- Round 5 (Completeness Lens): PASS — G1~G7 통과 + BDD ↔ Q1 invariant 커버 + AppError 코드 rev.3 정합
- Round 6 (Runtime Contract Lens): PASS — G1~G10 + verify GREEN + Prerequisites 4/5

## Tech Debt 명시 (ADR-006 Consequences)

후속 PR로 분리된 5건:
- TD-G-1 Listener 통합 (`pairingListeners` 호출) — controller 통합 PR
- TD-G-2 mongodb-memory-server 도입 + 진짜 DB 통합 테스트
- TD-G-3 HTTP controller 점진 이전 (`pairDeviceProcess` → `PairSubjectService`)
- TD-G-4 `__v` 낙관적 잠금 활성화 (별도 ADR)
- TD-G-5 Cucumber.js spike 결과 박제 (`SPIKE-CUCUMBER.md`)

## Prerequisites 4/5 + 시간 의존 1/5

- ✅ P-1 사전 측정 (`NECESSITY-EVIDENCE.md` ≥ 3 인용)
- ✅ P-2 사후 측정 항목 명세 (DISCUSS §9.2)
- ⏳ P-3 외부 feedback — **2026-05-26 시연 후 24시간 내** `docs/reports/paar-2026-05-26-phase-g-demo.md` 박제 (잔존)
- ✅ P-4 Frame 전환 (DISCUSS rev.4 §1/§2 + PRD DR-G + ADR-006 Context 4 위치)
- ✅ P-5 BDD 빼기 결정 — P3 미채택 LOCK

**2026-06-16** 사후 측정 + CRITIQUE Revision trigger 자동 재평가 (Phase H/I 진입 자격 판정).

## Test plan

- [x] `npm run verify` 6단계 GREEN — 로컬 검증 완료 (`docs/reports/paar-2026-05-12-phase-g-verify-green.md`)
- [x] 기존 baseline 회귀 0건 (267 → 288 PASS, 회귀 0)
- [x] Phase 18 / Phase 17.6 / `pairing.service.ts` 수정 0건 (`docs/reports/paar-2026-05-12-phase-g-isolation-proof.md`)
- [x] depcruise R-DDD-1/R-DDD-2 위반 0건
- [x] `eslint-disable` / `ts-ignore` / `test.skip()` 신규 0건
- [ ] CI 6단계 GREEN (PR 검증)
- [ ] dev 머지 후 5/26 시연 P-3 박제 의무

## Merge Strategy

`--no-ff` 머지 commit 채택 — 11 atomic commit 보존 (Phase F 정합).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 세션 페어링 기능이 개선된 도메인 계층 구현 추가

* **테스트**
  * 세션 페어링 서비스 및 도메인 모델에 대한 BDD/단위 테스트 추가

* **문서**
  * Phase G DDD/BDD/TDD 파일럿 아키텍처 결정사항(ADR-006) 추가
  * TDD 및 DDD 발견 기법 관련 가이드 및 스킬 문서 추가

* **Chores**
  * 세션 도메인 계층 의존성 제약 규칙 추가
  * 버전 관리 설정 업데이트

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->