### PR TITLE
feat(sessions): introduce Clock port + race fix (ADR-007, A-7 + A-6)

### DIFF
--- a/docs/architecture/decisions/ADR-007-clock-port-at-session-seam.md
+++ b/docs/architecture/decisions/ADR-007-clock-port-at-session-seam.md
@@ -1,0 +1,101 @@
+# ADR-007: Clock Port at Session Pairing Seam (PR-A7)
+
+<!-- Append-only after Accepted — documentation.md §Append-only rule 참조. -->
+
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-13
+- **Applies to**: BE
+- **Deciders**: @gs07103
+- **Related**: ADR-006 (Session Aggregate DDD Pilot), 이슈 #52, `.plans/H-deep-module-poc/RESULT.md` (Phase H GO, A-7 race trigger 발견), `.plans/I-pr-a7-clock-port/{DISCUSS,PLAN}.md`
+
+## Context
+
+Phase H deep-module-poc(2026-05-13 GO 결정)에서 다음 race condition 발견:
+
+`PairSubjectService.execute({pairingToken, userId})` 한 호출 안에서 시간을 3곳에서 독립 관찰함:
+1. `SessionAggregate.pair()` 내부 `isExpired()` 1차 호출 (`session.aggregate.ts:163` `Date.now()`)
+2. catch 분기 `isExpired()` 2차 재호출 (`pair-subject.service.ts:76`)
+3. `SessionPairedEvent.occurredAt` (`pair-subject.service.ts:101` `new Date().toISOString()`)
+
+PAIRED 상태 + boundary clock 시나리오에서 race 발생 가능:
+- 1차 `isExpired()` = false (T-1ms < expiresAt = T) → SA L117 status !== 'CREATED'로 `InvalidStatusTransitionError` throw
+- 2차 `isExpired()` = true (T+1ms ≥ expiresAt = T, 시간 진행) → `expire()` 호출 → SA L143 status !== 'CREATED'로 새 `InvalidStatusTransitionError` throw
+- 결과: `InvalidStatusTransitionError`가 `AppError`로 감싸지지 않고 외부 raw 노출 (5xx + 영문 도메인 에러 메시지)
+
+또한 hardcoded `Date.now()` / `new Date()`로 test에서 시간 분기를 결정적으로 재현 불가능.
+
+근거: Phase H codex 5.5 r2 강한 인정 (thread `019e1f19-f5b3-7150-90b7-e71bd3066b23`) + Claude 4-Lens rebuttal Lens 3 + plan-review W2 코드 트레이스 (이슈 #52 본문).
+
+## Decision
+
+본 단계에서 다음 5 가지 결정 LOCK:
+
+1. **Clock port 신규** — `src/07-shared/clock/{clock.ts, system-clock.ts, fixed-clock.ts, index.ts}` 신규. `interface Clock { now(): Date }` + SystemClock(production) + FixedClock(test). FSD 07-shared 레이어 정합 (06-entities, 05-features 모두 import 방향 정합).
+
+2. **시그니처 변경 — Method param + Date 전달** (Approach A) — `SessionAggregate`:
+   - `pair(userId: string, now: Date): void` — Date 인자 추가, 내부 `isExpired(now)` 호출 + `_pairedAt = now` 박제
+   - `isExpired(now: Date): boolean` — `Date.now()` 제거, 주입 Date와 `expiresAt` 비교
+
+3. **PS Clock 1회 관찰 + A-6 동반 fix** — `PairSubjectService`:
+   - `constructor(repo: SessionRepository, clock: Clock)` — 둘 다 required (A-6 PS constructor optional default soft seam 해소)
+   - `execute()` 진입 시 `const now = this.clock.now()` 1회 관찰 → SA `pair(userId, now)` / `isExpired(now)` / `event.occurredAt = now.toISOString()`에 동일 Date 객체 전달
+   - 한 호출 단위 내 시간 결정성 보장 → race 차단의 인터페이스 강제
+
+4. **Composition root는 PR-A1 (controller wiring)으로 분리** — 현재 PS는 controller가 호출하지 않음(importers_of=0). 본 PR은 BDD/unit test에서만 명시 주입(`new PairSubjectService(stubRepo, new FixedClock(testNow))`). production `SystemClock` 단일 인스턴스 생성 위치는 PR-A1에서 DI 패턴 정식 결정.
+
+5. **`fromDocument` 영향 0건** — Approach A는 SA에 Clock 미주입. `SessionAggregate.fromDocument(doc)` 시그니처 변경 0. A-8(fromDocument invariant locality) 별건 PR과 독립.
+
+## Alternatives considered
+
+### Option A: Method param + Date 전달 (선택)
+- 장점: race production 차단 **인터페이스 강제** (caller가 다른 시점 주입 불가) / SA pure domain 유지 (infra 의존 0) / Two-adapter rule 정합 (DEEPENING.md L29) / Phase H Step 5 시나리오 5 결정성 자연 보장
+- 단점: SA 시그니처 변경 → 기존 SA test 8건 + SR test L123 + PS test 5건 + BDD 3건 갱신
+- 채택 이유: race를 production code 차원에서 영구 차단 + Matt Pocock vendor skill `improve-codebase-architecture` 원리 100% 정합
+
+### Option B: Constructor inject SA
+- 장점: caller 시그니처 변경 최소 (pair/isExpired no-arg 유지)
+- 단점: race 차단이 SA 내부 캐싱 약속에 의존 (인터페이스 강제 불가) / SA가 Clock 의존 보유 (pure domain 깨짐) / `fromDocument` hydration 경로에서 Clock 주입 복잡 (A-8과 충돌)
+- 거부 이유: 같은 SystemClock 인스턴스를 공유해도 `now()`가 매번 새 Date 반환 → catch 분기 `isExpired()` 재호출 시 race 잔존. race 차단을 SA 내부 메모이제이션 약속에 맡기는 것은 LANGUAGE.md §Locality 약화
+
+### Option C: Static Clock + jest.useFakeTimers()
+- 장점: 시그니처 변경 0
+- 단점: production race 그대로 잔존 (test mock trick) / static `Date.now()`는 in-place 수정 위치 아님 → DEEPENING.md §Seam discipline 위반 / adapter 1개 (Two-adapter rule 미충족, mock은 의미 있는 substitution 아님)
+- 거부 이유: 본 PR의 본질 목표(race를 production에서 영구 차단)에 미달
+
+## Consequences
+
+### 긍정 결과
+- **race 차단**: 한 `execute()` 호출 단위 내 시간 관찰 1회 = 시간 결정성 인터페이스 강제. `InvalidStatusTransitionError` 외부 raw 노출 경로 차단
+- **test 결정성**: `FixedClock` 주입으로 boundary 직전/직후 결정적 재현 가능 — Phase H tdd-spec §2.4 시나리오 4 Context A/B/C + §2.5 시나리오 5 PASS 입증
+- **A-6 soft seam 동반 해소**: PS constructor required 격상으로 composition root 명시화 (DEEPENING.md §Seam discipline 정합)
+
+### 부정 결과 (수용)
+- SA test 8 → 9 갱신 + SR test L123 + PS test 5건 + BDD 3건 시그니처 정합 갱신 필요
+- `fromDocument` 영향 0건이지만, A-8(invariant locality)는 본 PR scope 외 잔존 — 별건 후속 PR
+
+### 회귀 0 박제 (이슈 #52 PR description 정합)
+- Phase G 21 test → 본 PR 후 36 PASS (SA 9 + SR 5 + PS 5 + BDD 8 + clock 4 + 외 sessions test = 73 sessions+clock 영역 PASS)
+- 기존 거동(paired/expired/retry-after-paired의 AppError statusCode + message) 불변
+- `pairing.service.ts` 수정 0건 (Phase G G9 의무 유지)
+- depcruise R-DDD-1/R-DDD-2 위반 0건 (06-entities → 07-shared 방향 정합)
+
+### 후속 의무
+- PR-A1 (controller wiring): production `SystemClock` 단일 인스턴스 composition root 정식 결정
+- PR-A8 (fromDocument invariant locality): SA `fromDocument` invariant 분담 ADR
+
+## References
+
+- 이슈 #52: https://github.com/KWONSEOK02/mind-signal-backend/issues/52
+- Phase H GO: `Team-project/.plans/H-deep-module-poc/RESULT.md`
+- Phase H tdd-spec: `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md` §2 5 시나리오
+- Phase H codex r2: thread `019e1f19-f5b3-7150-90b7-e71bd3066b23` (A-7 강한 인정)
+- vendor skill 원리: `.claude/skills/improve-codebase-architecture/`
+  - LANGUAGE.md L31-32 §Locality / L38 "the interface is the test surface"
+  - DEEPENING.md L27-32 §Seam discipline / L29 "Two adapters means a real one" / L36 "Tests assert on observable outcomes through the interface, not internal state"
+- plan-review Round 1 (`feature-dev:code-reviewer`, 2026-05-13): verdict PROCEED-WITH-CONDITIONS → 6 이슈 PLAN.md 반영 후 PROCEED
+
+## Append-only edits
+
+> Status 변경 또는 superseded 시점에만 본 섹션을 갱신함. Decision 본문 수정 금지.

--- a/docs/requirements/RTM.md
+++ b/docs/requirements/RTM.md
@@ -32,6 +32,7 @@
 |---|---|---|---|---|---|---|
 | FR-00 | (예시) 세션 생성 API | #0 | `src/05-features/sessions/api/session.routes.ts` | `__tests__/sessions/create.test.ts` | — | Draft |
 | DR-G | Session Aggregate DDD/BDD/TDD Pilot | `.plans/PRD.md` DR-G + `.plans/G-mind-signal-ddd-bdd-tdd/` | `src/06-entities/sessions/{domain,repository,types}` + `src/05-features/sessions/services/pair-subject.service.ts` | `session.aggregate.test.ts` (8) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (3) = 21 | feat/G-ddd-bdd-tdd-pilot | Done (ADR-006 Accepted) |
+| DR-G-PR-A7 | Clock Port at Session Pairing Seam — A-7 race 차단 + A-6 soft seam 동반 해소 | 이슈 #52 + `.plans/I-pr-a7-clock-port/` + `.plans/H-deep-module-poc/RESULT.md` | `src/07-shared/clock/{clock,system-clock,fixed-clock,index}.ts` 신규 + `src/06-entities/sessions/domain/session.aggregate.ts` (pair/isExpired Date 인자) + `src/05-features/sessions/services/pair-subject.service.ts` (constructor required + now 1회 관찰) | `clock.test.ts` (4) + `session.aggregate.test.ts` (9, +boundary) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (8, +S4 A/B/C +S5 ×2) = 31 | feat/52-clock-port-race-fix | Done (ADR-007 Accepted) |
 
 ---
 

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -16,7 +16,11 @@
 import { Types } from 'mongoose';
 import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import { FixedClock } from '@07-shared/clock';
 import { PairSubjectService } from '../services/pair-subject.service';
+
+/** BDD 시나리오 결정성용 고정 시각 — ADR-007 정합 */
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
 
 /**
  * 테스트 환경 헬퍼 — SessionRepository를 in-memory Map으로 모킹함.
@@ -62,13 +66,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'TOK001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() + 60_000),
+          expiresAt: new Date(TEST_NOW.getTime() + 60_000),
         });
         await repo.saveNew(session);
 
         // When — subject bob (userId)이 pairingToken 'TOK001'로 합류 요청을 보냄
         const userId = new Types.ObjectId().toString();
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
         const result = await service.execute({
           pairingToken: 'TOK001',
           userId,
@@ -109,13 +113,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'EXP001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() - 1000), // 1초 전에 만료됨
+          expiresAt: new Date(TEST_NOW.getTime() - 1000), // TEST_NOW 기준 1초 전 만료
         });
         await repo.saveNew(expiredSession);
 
         // When — subject가 만료된 토큰으로 합류 시도함
         const userId = new Types.ObjectId().toString();
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
         // Then — AppError 401 throw
         let captured: AppError | null = null;
@@ -151,12 +155,12 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'PRD001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() + 60_000),
+          expiresAt: new Date(TEST_NOW.getTime() + 60_000),
         });
         await repo.saveNew(session);
 
         // 첫 번째 페어링 성공
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
         await service.execute({
           pairingToken: 'PRD001',
           userId: firstUserId,

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -192,3 +192,173 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
     );
   });
 });
+
+/**
+ * 시나리오 4·5 (Scenario 4: Clock seam race A-7 / Scenario 5: Single observed now)
+ *
+ * Phase H deep-module-poc PAAR Step 5 tdd-spec §2.4 + §2.5 정합.
+ * ADR-007 Clock port 도입 후 race 차단 + 결정성 입증 — `red→green evidence`.
+ * 본 시나리오 4 Context C는 race trigger 시점에서도 AppError 400 wrapping + 영속 PAIRED 불변
+ * 임을 입증하여 InvalidStatusTransitionError 외부 raw 노출이 차단됨을 확정함.
+ */
+
+/** 매번 fresh aggregate + repo 시드 헬퍼 (plan-review I-4 — Scenario 5 state 오염 차단) */
+const makeStubRepoWithCreatedSession = async (params: {
+  pairingToken: string;
+  expiresAt: Date;
+}) => {
+  const repo = makeInMemoryRepo();
+  const aggregate = SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: new Types.ObjectId().toString(),
+    subjectIndex: 1,
+    pairingToken: params.pairingToken,
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: params.expiresAt,
+  });
+  await repo.saveNew(aggregate);
+  return { repo, aggregate };
+};
+
+describe('Feature: Clock seam race 차단 (A-7) + single observed now (ADR-007)', () => {
+  describe('Scenario 4 — Clock seam race (Context A/B/C)', () => {
+    test('Context A: FixedClock T-1ms + status=CREATED → paired (결정적)', async () => {
+      const T = new Date('2026-05-13T11:00:00.000Z');
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-BND-A',
+        expiresAt: T,
+      });
+      const clock = new FixedClock(new Date(T.getTime() - 1));
+
+      const service = new PairSubjectService(repo, clock);
+      const userId = new Types.ObjectId().toString();
+      const result = await service.execute({
+        pairingToken: 'TOK-BND-A',
+        userId,
+      });
+
+      expect(result.session.status).toBe('PAIRED');
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('PAIRED');
+      expect(reloaded!.userId).toBe(userId);
+    });
+
+    test('Context B: FixedClock T+1ms + status=CREATED → AppError 401 + 영속 EXPIRED', async () => {
+      const T = new Date('2026-05-13T11:00:00.000Z');
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-BND-B',
+        expiresAt: T,
+      });
+      const clock = new FixedClock(new Date(T.getTime() + 1));
+
+      const service = new PairSubjectService(repo, clock);
+
+      let captured: AppError | null = null;
+      try {
+        await service.execute({
+          pairingToken: 'TOK-BND-B',
+          userId: new Types.ObjectId().toString(),
+        });
+      } catch (err) {
+        captured = err as AppError;
+      }
+
+      expect(captured).toBeInstanceOf(AppError);
+      expect(captured!.statusCode).toBe(401);
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('EXPIRED');
+    });
+
+    test(
+      'Context C (A-7 race trigger): status=PAIRED + FixedClock T-1ms + expiresAt=T → ' +
+        'AppError 400 + 영속 PAIRED 불변 + InvalidStatusTransitionError 외부 노출 0건',
+      async () => {
+        const T = new Date('2026-05-13T11:00:00.000Z');
+        const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+          pairingToken: 'TOK-BND-C',
+          expiresAt: T,
+        });
+
+        // 사전 페어링 — PAIRED 상태로 전이 (이전 user 박제)
+        const previousUserId = new Types.ObjectId().toString();
+        aggregate.pair(previousUserId, new Date(T.getTime() - 1000));
+        await repo.save(aggregate);
+        expect(aggregate.status).toBe('PAIRED');
+
+        // Approach A 미적용 상태에선 race trigger 시점 (T-1ms boundary).
+        // Approach A 적용 후 같은 now가 pair() 내부 isExpired와 catch 분기 isExpired에 전달되어
+        // race 차단 + AppError 400 wrapping 유지함.
+        const clock = new FixedClock(new Date(T.getTime() - 1));
+        const service = new PairSubjectService(repo, clock);
+
+        let captured: AppError | null = null;
+        try {
+          await service.execute({
+            pairingToken: 'TOK-BND-C',
+            userId: new Types.ObjectId().toString(),
+          });
+        } catch (err) {
+          captured = err as AppError;
+        }
+
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(400);
+        expect(captured!.message).toContain('현재 세션 상태(PAIRED)에서는');
+
+        const reloaded = await repo.findById(aggregate.id);
+        expect(reloaded!.status).toBe('PAIRED'); // 영속 불변
+        expect(reloaded!.userId).toBe(previousUserId); // 덮어쓰기 0
+      }
+    );
+  });
+
+  describe('Scenario 5 — Single observed now', () => {
+    test('wall clock 진행과 무관하게 FixedClock 결과 결정적 (N=5 반복, 매번 fresh seed)', async () => {
+      const T0 = new Date('2026-05-13T12:00:00.000Z');
+      const clock = new FixedClock(T0);
+
+      // plan-review I-4 정합 — 매번 fresh repo + fresh aggregate (state 오염 차단)
+      for (let i = 0; i < 5; i++) {
+        const token = `TOK-SON-${i}`;
+        const { repo } = await makeStubRepoWithCreatedSession({
+          pairingToken: token,
+          expiresAt: new Date(T0.getTime() + 1), // boundary 직전
+        });
+        const service = new PairSubjectService(repo, clock);
+        const result = await service.execute({
+          pairingToken: token,
+          userId: new Types.ObjectId().toString(),
+        });
+        expect(result.session.status).toBe('PAIRED'); // 5회 모두 동일
+      }
+    });
+
+    test('boundary 직후 FixedClock 주입 시 결정적 expired (boundary 반대 케이스)', async () => {
+      const T0 = new Date('2026-05-13T12:00:00.000Z');
+      const expiresAt = T0;
+      const clock = new FixedClock(new Date(T0.getTime() + 1)); // boundary 직후
+
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-SON-AFTER',
+        expiresAt,
+      });
+      const service = new PairSubjectService(repo, clock);
+
+      let captured: AppError | null = null;
+      try {
+        await service.execute({
+          pairingToken: 'TOK-SON-AFTER',
+          userId: new Types.ObjectId().toString(),
+        });
+      } catch (err) {
+        captured = err as AppError;
+      }
+
+      expect(captured).toBeInstanceOf(AppError);
+      expect(captured!.statusCode).toBe(401);
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('EXPIRED');
+    });
+  });
+});

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -93,6 +93,14 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         expect(result.event.subjectIndex).toBe(1);
         expect(result.event.mode).toBe('SEQUENTIAL');
         expect(typeof result.event.occurredAt).toBe('string');
+
+        // drainRecordedEvents observable (tdd-spec §2.1 #6 정합 — codex review R2-1)
+        const firstDrain = service.drainRecordedEvents();
+        expect(firstDrain).toHaveLength(1);
+        expect(firstDrain[0].type).toBe('SessionPaired');
+        expect(firstDrain[0].userId).toBe(userId);
+        // 두 번째 drain은 빈 배열 (buffer 비움 동작 검증)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });
@@ -134,6 +142,9 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         // 세션 status가 EXPIRED로 영속됨
         const reloaded = await repo.findById(expiredSession.id);
         expect(reloaded!.status).toBe('EXPIRED');
+
+        // 만료 흐름은 event 발화 0건 (tdd-spec §2.2 #3 — codex review R2-1)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });
@@ -168,6 +179,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         const afterFirst = await repo.findById(session.id);
         expect(afterFirst!.status).toBe('PAIRED');
         expect(afterFirst!.userId).toBe(firstUserId);
+        const firstPairedAt = afterFirst!.pairedAt;
+        expect(firstPairedAt).not.toBeNull();
+
+        // 첫 페어링 event는 buffer drain 후 retry 시 새 event 발화 0건 검증 준비
+        const firstDrain = service.drainRecordedEvents();
+        expect(firstDrain).toHaveLength(1);
+        expect(firstDrain[0].userId).toBe(firstUserId);
 
         // When — 두 번째 subject가 같은 토큰으로 합류 시도함
         const secondUserId = new Types.ObjectId().toString();
@@ -188,6 +206,10 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         const afterSecond = await repo.findById(session.id);
         expect(afterSecond!.status).toBe('PAIRED');
         expect(afterSecond!.userId).toBe(firstUserId); // 첫 페어링 그대로 유지됨
+        // pairedAt unchanged (tdd-spec §2.3 #2 — codex review R2-1)
+        expect(afterSecond!.pairedAt!.getTime()).toBe(firstPairedAt!.getTime());
+        // retry 흐름은 새 event 발화 0건 (tdd-spec §2.3 #3)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -8,7 +8,10 @@
 import { Types } from 'mongoose';
 import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import { FixedClock } from '@07-shared/clock';
 import { PairSubjectService } from './pair-subject.service';
+
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
 
 const makeAggregate = (
   override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
@@ -20,7 +23,7 @@ const makeAggregate = (
     pairingToken: 'TOK001',
     operatorId: new Types.ObjectId().toString(),
     mode: 'SEQUENTIAL',
-    expiresAt: new Date(Date.now() + 60_000),
+    expiresAt: new Date(TEST_NOW.getTime() + 60_000),
     ...override,
   });
 };
@@ -44,7 +47,7 @@ describe('PairSubjectService', () => {
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(aggregate);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
     const result = await service.execute({
       pairingToken: 'TOK001',
       userId,
@@ -68,13 +71,13 @@ describe('PairSubjectService', () => {
 
   test('2. 만료 토큰 → AppError 401 throw + 세션 status EXPIRED 영속', async () => {
     const expired = makeAggregate({
-      expiresAt: new Date(Date.now() - 1000), // 이미 만료됨
+      expiresAt: new Date(TEST_NOW.getTime() - 1000), // TEST_NOW 기준 1초 전 만료
     });
     const userId = new Types.ObjectId().toString();
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(expired);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -92,14 +95,14 @@ describe('PairSubjectService', () => {
 
   test('3. 이미 PAIRED 상태 토큰 → AppError 400 throw', async () => {
     const aggregate = makeAggregate();
-    aggregate.pair(new Types.ObjectId().toString()); // 사전 페어링 완료
+    aggregate.pair(new Types.ObjectId().toString(), TEST_NOW); // 사전 페어링 완료 (plan-review I-2: Date 인자 추가)
     expect(aggregate.status).toBe('PAIRED');
 
     const userId = new Types.ObjectId().toString();
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(aggregate);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -119,7 +122,7 @@ describe('PairSubjectService', () => {
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(null);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -135,7 +138,7 @@ describe('PairSubjectService', () => {
 
   test('보조: userId 형식 부정합 → AppError 400 throw + repo 호출 0건', async () => {
     const repo = makeRepoMock();
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -27,6 +27,7 @@ import {
 } from '@06-entities/sessions';
 import type { SessionPairedEvent } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import type { Clock } from '@07-shared/clock';
 
 /** PairSubjectService.execute() 입력 인자 */
 export interface PairSubjectInput {
@@ -42,10 +43,16 @@ export interface PairSubjectResult {
 
 export class PairSubjectService {
   private readonly repo: SessionRepository;
+  private readonly clock: Clock;
   private recordedEvents: SessionPairedEvent[] = [];
 
-  constructor(repo?: SessionRepository) {
-    this.repo = repo ?? new SessionRepository();
+  /**
+   * @param repo SessionRepository 어댑터 — 영속화 경유함 (required, A-6 soft seam 해소)
+   * @param clock Clock port — 한 execute() 호출 내 시간 결정성 보장 (ADR-007)
+   */
+  constructor(repo: SessionRepository, clock: Clock) {
+    this.repo = repo;
+    this.clock = clock;
   }
 
   /**
@@ -67,13 +74,17 @@ export class PairSubjectService {
       throw new AppError('존재하지 않거나 유효하지 않은 토큰입니다', 404);
     }
 
+    // 2.5. Clock 1회 관찰 — 본 호출의 모든 시간 판단에 동일 Date snapshot 사용함 (ADR-007)
+    const now = this.clock.now();
+
     // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제
     try {
-      aggregate.pair(input.userId);
+      aggregate.pair(input.userId, now);
     } catch (err) {
       if (err instanceof InvalidStatusTransitionError) {
         // 만료 시 EXPIRED 영속화 + 401 throw (기존 pairing.service.ts L101-105 정합)
-        if (aggregate.isExpired()) {
+        // race 차단 — 동일 `now`를 isExpired에 전달하여 pair() 내부 판단과 결정성 유지함
+        if (aggregate.isExpired(now)) {
           aggregate.expire();
           await this.repo.save(aggregate);
           throw new AppError(
@@ -94,11 +105,12 @@ export class PairSubjectService {
     await this.repo.save(aggregate);
 
     // 5. 도메인 이벤트 메모리 기록 (LD-12 listener 통합은 후속 controller 통합 PR로 분리함)
+    // event.occurredAt도 동일 `now`를 사용함 — 한 호출 = 한 timestamp 결정성
     const event: SessionPairedEvent = {
       type: 'SessionPaired',
       sessionId: aggregate.id,
       userId: input.userId,
-      occurredAt: new Date().toISOString(),
+      occurredAt: now.toISOString(),
       groupId: aggregate.groupId,
       subjectIndex: aggregate.subjectIndex,
       mode: aggregate.mode,

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -11,6 +11,9 @@ import {
   InvalidStatusTransitionError,
 } from './errors';
 
+/** ADR-007 정합 — wall clock 의존 제거, 결정성 보장 */
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
+
 describe('SessionAggregate', () => {
   const baseParams = (
     override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
@@ -21,7 +24,7 @@ describe('SessionAggregate', () => {
     pairingToken: 'TOK001',
     operatorId: 'operator-1',
     mode: 'SEQUENTIAL' as const,
-    expiresAt: new Date(Date.now() + 60_000), // 1분 뒤 만료
+    expiresAt: new Date(TEST_NOW.getTime() + 60_000), // TEST_NOW 기준 1분 뒤 만료
     ...override,
   });
 
@@ -56,26 +59,23 @@ describe('SessionAggregate', () => {
   });
 
   describe('pair()', () => {
-    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩', () => {
+    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩 + pairedAt = now (참조 동등성)', () => {
       const aggregate = SessionAggregate.create(baseParams());
       const userId = 'user-bob';
-      const before = Date.now();
-      aggregate.pair(userId);
-      const after = Date.now();
+      const now = TEST_NOW;
+      aggregate.pair(userId, now);
 
       expect(aggregate.status).toBe('PAIRED');
       expect(aggregate.userId).toBe(userId);
-      expect(aggregate.pairedAt).not.toBeNull();
-      const pairedTime = aggregate.pairedAt!.getTime();
-      expect(pairedTime).toBeGreaterThanOrEqual(before);
-      expect(pairedTime).toBeLessThanOrEqual(after);
+      // ADR-007 정합 — _pairedAt이 주입된 now와 동일 객체 (참조 동등성)
+      expect(aggregate.pairedAt).toBe(now);
     });
 
-    test('5. 실패 — isExpired() === true → InvalidStatusTransitionError', () => {
-      const aggregate = SessionAggregate.create(
-        baseParams({ expiresAt: new Date(Date.now() - 1000) }) // 이미 만료됨
-      );
-      expect(() => aggregate.pair('user-bob')).toThrow(
+    test('5. 실패 — isExpired(now) === true → InvalidStatusTransitionError', () => {
+      const expiresAt = new Date('2026-05-13T10:00:00.000Z');
+      const now = new Date(expiresAt.getTime() + 1000); // 1초 후 (만료됨)
+      const aggregate = SessionAggregate.create(baseParams({ expiresAt }));
+      expect(() => aggregate.pair('user-bob', now)).toThrow(
         InvalidStatusTransitionError
       );
       // 상태는 그대로 CREATED (만료 처리는 별도 expire() 호출 책임)
@@ -84,8 +84,9 @@ describe('SessionAggregate', () => {
 
     test('6. 실패 — status === PAIRED에서 재호출 → InvalidStatusTransitionError', () => {
       const aggregate = SessionAggregate.create(baseParams());
-      aggregate.pair('user-bob');
-      expect(() => aggregate.pair('user-charlie')).toThrow(
+      const now = TEST_NOW;
+      aggregate.pair('user-bob', now);
+      expect(() => aggregate.pair('user-charlie', now)).toThrow(
         InvalidStatusTransitionError
       );
       // userId는 첫 페어링 그대로 유지됨
@@ -104,9 +105,26 @@ describe('SessionAggregate', () => {
 
     test('8. cancel() happy — PAIRED에서 CANCELLED 전이', () => {
       const aggregate = SessionAggregate.create(baseParams());
-      aggregate.pair('user-bob');
+      const now = TEST_NOW;
+      aggregate.pair('user-bob', now);
       aggregate.cancel('ManualEarly');
       expect(aggregate.status).toBe('CANCELLED');
+    });
+
+    test('9. isExpired(now) — boundary 비교 (ADR-007 정합)', () => {
+      const expiresAt = new Date('2026-05-13T10:00:00.000Z');
+      const aggregate = SessionAggregate.create(baseParams({ expiresAt }));
+
+      // boundary 직전 — 미만료
+      const beforeBoundary = new Date(expiresAt.getTime() - 1);
+      expect(aggregate.isExpired(beforeBoundary)).toBe(false);
+
+      // boundary 정확 — expiresAt === now 시점은 미만료 (strict less than)
+      expect(aggregate.isExpired(expiresAt)).toBe(false);
+
+      // boundary 직후 — 만료
+      const afterBoundary = new Date(expiresAt.getTime() + 1);
+      expect(aggregate.isExpired(afterBoundary)).toBe(true);
     });
   });
 });

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -108,10 +108,16 @@ export class SessionAggregate {
   /**
    * 피실험자를 세션에 연결함 — CREATED → PAIRED 전이.
    *
+   * 호출자는 `now` Date를 1회 관찰하여 본 메서드 + `isExpired` + event timestamp에
+   * 동일 Date를 전달함. ADR-007 정합 — race condition 차단을 위해 한 호출 단위 내
+   * 시간 결정성 유지함.
+   *
+   * @param userId 페어링할 피실험자 ID
+   * @param now 호출자가 1회 관찰한 현재 시각
    * @throws InvalidStatusTransitionError 만료(isExpired) 또는 status !== 'CREATED'
    */
-  pair(userId: string): void {
-    if (this.isExpired()) {
+  pair(userId: string, now: Date): void {
+    if (this.isExpired(now)) {
       throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
     }
     if (this._status !== 'CREATED') {
@@ -119,7 +125,7 @@ export class SessionAggregate {
     }
     this._status = 'PAIRED';
     this._userId = userId;
-    this._pairedAt = new Date();
+    this._pairedAt = now;
   }
 
   /** PAIRED → MEASURING — 본 단계 시연 외, 메서드 골조만 */
@@ -158,9 +164,14 @@ export class SessionAggregate {
     this._status = 'CANCELLED';
   }
 
-  /** 만료 여부 — expiresAt < 현재 시각 */
-  isExpired(): boolean {
-    return this._expiresAt.getTime() < Date.now();
+  /**
+   * 만료 여부 — expiresAt < 주입된 시각.
+   *
+   * 호출자가 1회 관찰한 `now`를 전달함. SA가 자체 `Date.now()`를 호출하지 않으므로
+   * 호출 단위 내 시간 결정성 보장 + test에서 FixedClock 주입으로 분기 결정적 재현 가능.
+   */
+  isExpired(now: Date): boolean {
+    return this._expiresAt.getTime() < now.getTime();
   }
 
   // ===== getters =====

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -120,7 +120,7 @@ describe('SessionRepository (통합 — Mongoose Model mock)', () => {
   test('3. save 상태 전이 영속 (CREATED → PAIRED)', async () => {
     const aggregate = makeAggregate();
     const userId = new Types.ObjectId().toString();
-    aggregate.pair(userId);
+    aggregate.pair(userId, new Date()); // ADR-007 정합 — Date 인자 전달
 
     SessionMock.findByIdAndUpdate.mockResolvedValueOnce(makeDocLike(aggregate));
     await repo.save(aggregate);

--- a/src/07-shared/clock/clock.test.ts
+++ b/src/07-shared/clock/clock.test.ts
@@ -1,0 +1,33 @@
+import { SystemClock, FixedClock } from './index';
+
+describe('SystemClock', () => {
+  it('호출 결과가 valid Date 인스턴스임', () => {
+    const result = new SystemClock().now();
+    expect(result).toBeInstanceOf(Date);
+    expect(Number.isNaN(result.getTime())).toBe(false);
+  });
+
+  it('호출 직전 wall clock 이상의 시각 반환함', () => {
+    const before = Date.now();
+    const result = new SystemClock().now();
+    expect(result.getTime()).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('FixedClock', () => {
+  const fixed = new Date('2026-05-13T10:00:00.000Z');
+
+  it('생성자 주입 Date를 N회 호출에서 동일 객체로 반환함 (참조 동등성)', () => {
+    const clock = new FixedClock(fixed);
+    expect(clock.now()).toBe(fixed);
+    expect(clock.now()).toBe(fixed);
+    expect(clock.now().toISOString()).toBe('2026-05-13T10:00:00.000Z');
+  });
+
+  it('invalid Date 주입 시 TypeError throw — plan-review I-5', () => {
+    expect(() => new FixedClock(new Date('invalid'))).toThrow(TypeError);
+    expect(() => new FixedClock(new Date('invalid'))).toThrow(
+      'FixedClock requires a valid Date'
+    );
+  });
+});

--- a/src/07-shared/clock/clock.ts
+++ b/src/07-shared/clock/clock.ts
@@ -1,0 +1,13 @@
+/**
+ * Clock port — 시간 관찰 seam.
+ *
+ * SessionAggregate.isExpired/pair 및 PairSubjectService.execute가 직접 `Date.now()` /
+ * `new Date()`를 호출하지 않고 본 인터페이스를 통해 시간을 관찰함. 한 `execute()` 호출
+ * 단위 내 시간 결정성 보장 + test에서 FixedClock 주입을 통해 시간 분기 결정적 재현 가능.
+ *
+ * 출처: ADR-007 (Phase H deep-module-poc A-7 race 후속, 이슈 #52).
+ */
+export interface Clock {
+  /** 현재 시각을 Date 객체로 반환함 */
+  now(): Date;
+}

--- a/src/07-shared/clock/fixed-clock.ts
+++ b/src/07-shared/clock/fixed-clock.ts
@@ -1,0 +1,20 @@
+import type { Clock } from './clock';
+
+/**
+ * Test adapter — 생성자 주입 Date를 호출마다 동일하게 반환함.
+ *
+ * Scenario 4 (Clock seam race) + Scenario 5 (single observed now) 결정성 보장에 필수임.
+ * invalid Date 주입 시 TypeError를 즉시 throw하여 호출부 `toISOString()` 시점 RangeError
+ * 전파를 차단함.
+ */
+export class FixedClock implements Clock {
+  constructor(private readonly fixed: Date) {
+    if (Number.isNaN(fixed.getTime())) {
+      throw new TypeError('FixedClock requires a valid Date');
+    }
+  }
+
+  now(): Date {
+    return this.fixed;
+  }
+}

--- a/src/07-shared/clock/index.ts
+++ b/src/07-shared/clock/index.ts
@@ -1,0 +1,3 @@
+export type { Clock } from './clock';
+export { SystemClock } from './system-clock';
+export { FixedClock } from './fixed-clock';

--- a/src/07-shared/clock/system-clock.ts
+++ b/src/07-shared/clock/system-clock.ts
@@ -1,0 +1,13 @@
+import type { Clock } from './clock';
+
+/**
+ * Production adapter — wall clock 기반 Date 반환함.
+ *
+ * 호출 시점 시각을 `new Date()`로 반환하므로 호출 간 시각이 진행함.
+ * test에서는 본 클래스를 사용하지 말 것 — FixedClock으로 결정성 확보 필요.
+ */
+export class SystemClock implements Clock {
+  now(): Date {
+    return new Date();
+  }
+}


### PR DESCRIPTION
## Summary

Phase H deep-module-poc(2026-05-13 GO)에서 발견된 **A-7 Clock race condition**을 차단하고, 부수적으로 **A-6 PS constructor optional default soft seam**을 동반 해소.

- **Approach A** (Method param + Date 전달) 채택 — `SessionAggregate.pair(userId, now: Date)` / `isExpired(now: Date)` 시그니처 + `PairSubjectService`가 `execute()` 진입 시 `clock.now()` 1회 관찰 후 동일 Date를 SA + event timestamp에 전달
- 한 호출 = 한 Date snapshot **인터페이스 강제**로 race를 production code 차원에서 영구 차단
- `Clock` port 신규(`src/07-shared/clock/`) — `SystemClock` (production) + `FixedClock` (test)
- ADR-007 Accepted (Phase G ADR-006 후속)
- closes #52

## Race trigger (수정 전 시퀀스)

| 시점 | 코드 | 결과 |
|---|---|---|
| T-1ms | `session.aggregate.ts:163` 1차 `isExpired()` | `Date.now()` = T-1ms < expiresAt = T → **false** |
| T-1ms | SA L117 `_status !== 'CREATED'` (PAIRED) | `InvalidStatusTransitionError` throw |
| T+1ms | `pair-subject.service.ts:76` 2차 `isExpired()` 재호출 | `Date.now()` = T+1ms ≥ T → **true** (시간 진행) |
| T+1ms | PS L77 `expire()` → SA L143 `_status !== 'CREATED'` | **새 `InvalidStatusTransitionError` raw 외부 노출** |

Approach A 적용 후: 같은 `now`를 catch 분기 `isExpired(now)`에 전달 → false 유지 → status 분기로 빠짐 → `AppError(400)` wrapping.

## TDD red → green evidence

- **red**: Phase G `ee559da` 코드 트레이스 + codex 5.5 r2 thread `019e1f19-f5b3-7150-90b7-e71bd3066b23` 강한 인정 + plan-review Round 1 W2 (`feature-dev:code-reviewer` Opus)
- **green**: 신규 BDD 시나리오 5건 PASS — Scenario 4 Context A/B/C + Scenario 5 N=5 + boundary 반대

## Cross-LLM review

### plan-review Round 1 (Claude Opus 4.7, `feature-dev:code-reviewer`)
- verdict **PROCEED-WITH-CONDITIONS** → 6 이슈(High 2 / Medium 2 / Low 2) 모두 PLAN.md 반영
- High 2건(I-1 `session.repository.test.ts` L123, I-2 PS test L95) — build 차단 회피
- I-3 통합 결정 — T2 + T3+T4를 단일 commit으로 (build green 유지)

### codex 5.5 review (thread `019e1f96-4b57-70b2-abf4-8195ad56fc23`)
- verdict **PROCEED-WITH-CONDITIONS** → 3 이슈(Medium 1 / Low 2) 처리 완료
  - **R2-1** (Medium) → commit `9830bf0` BDD observable 보강 (drain + pairedAt parity)
  - **R2-2** (Low) → BDD fixture `SEQUENTIAL`/`A1B2C3D4`는 Phase G 시연 컨텍스트 정합 유지, tdd-spec §2.1의 `DUAL`/`GRP-S1`은 PS unit test 매핑으로 명시
  - **R2-3** (Low) → CHECKLIST.md typo fix
- **우회 부재 검증 5/5 PASS** (V3-1~V3-6)
  - `jest.useFakeTimers` / `setSystemTime` / `MockDate` 26 testcase 전체 0건
  - SA/PS/Clock 내부 메서드 호출 횟수 검증 0건 (observable outcome 정합 — DEEPENING.md L36)
  - Context C 실제 race trigger input(PAIRED + FixedClock T-1ms + expiresAt=T) 사용 확인
  - Scenario 5 매 iteration fresh seed
  - `new PairSubjectService` 호출 13건 전수 2인자 확인 (A-6 caller 무중단)

## 6 atomic commit

| SHA | Type | Scope |
|---|---|---|
| `c90a219` | feat(shared) | Clock port + SystemClock + FixedClock adapters |
| `44aabda` | refactor(sessions) | inject Clock at SessionAggregate + PairSubjectService seam |
| `dca0303` | test(sessions) | add Clock seam race scenarios (A-7 red→green evidence) |
| `9db9d59` | docs(adr) | add ADR-007 + RTM DR-G-PR-A7 row |
| `f86d774` | chore(verify) | npm run verify GREEN with regression 0 |
| `9830bf0` | test(sessions) | tighten BDD observables (codex R2-1) |

## verify 6단계 GREEN

| 단계 | 결과 |
|---|---|
| format:check | ✅ PASS |
| typecheck | ✅ PASS |
| depcruise | ✅ PASS (R-DDD-1/2 위반 0건) |
| lint --max-warnings 0 | ✅ PASS |
| jest | ✅ **31 suites / 298 tests PASS / 0 FAIL** |
| build (tsc + tsc-alias) | ✅ EXIT 0 |

## 회귀 0 검증

- Phase G 21 test → 본 PR 후 sessions+clock 영역 73 PASS
- BDD 3 시나리오 거동 불변(paired / expired / retry-after-paired)
- `pairing.service.ts` 수정 0건 (Phase G G9 의무 유지)
- depcruise 06-entities → 07-shared 방향 정합

## Test plan
- [x] `npm run verify` 6단계 GREEN
- [x] BDD 시나리오 5건 신규 PASS (4 Context A/B/C + 5 N=5 + boundary 반대)
- [x] plan-review Round 1 6 이슈 PLAN.md 반영
- [x] codex 5.5 review 3 이슈 처리
- [ ] CI green (본 PR 검증 대기)
- [ ] 머지 후 dev 브랜치 verify GREEN 재확인

## References
- 이슈 #52 (본 PR closes)
- Phase H GO: `Team-project/.plans/H-deep-module-poc/RESULT.md`
- ADR-006 (Phase G 후속) → ADR-007 (본 PR)
- vendor skill: `improve-codebase-architecture` — LANGUAGE.md §Locality + DEEPENING.md §Seam discipline + L29 "Two adapters means a real one"
- DISCUSS/PLAN/CHECKLIST: `Team-project/.plans/I-pr-a7-clock-port/` (git 외부)

## 후속 PR 후보
- **PR-A1** (controller wiring) — production composition root 정식 결정
- **PR-A8** (fromDocument invariant locality) — SA invariant 분담 ADR
- **chore PR** (Phase H untracked 산출물 7 PAAR + mermaid + skills vendor)

Co-authored-by: gs07103 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 세션 페어링의 시간 처리 일관성이 개선되어 동시 작업 환경에서의 안정성이 향상되었습니다. 여러 페어링 요청이 동시에 발생하는 상황에서도 세션 상태가 정확하게 처리되며, 이전의 타이밍 관련 오류들이 해소되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->