### PR TITLE
chore: archive Phase H deep-module-poc artifacts (vendor skill + 4 PAAR)

### DIFF
--- a/.claude/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.claude/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.claude/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.claude/skills/improve-codebase-architecture/_local-addendum.md
+++ b/.claude/skills/improve-codebase-architecture/_local-addendum.md
@@ -1,0 +1,85 @@
+# Local Addendum — Mind Signal H-deep-module-poc 적용 노트
+
+> 작성일: 2026-05-13
+> 대상: `improve-codebase-architecture` skill의 Mind Signal 컨텍스트 변형 박제
+> 원본 4 파일 (SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN.md)은 byte-identical 유지 — 본 addendum은 PoC 적용 변형만 다룸
+
+---
+
+## 1. HANDOFF tentative 임계값 폐기 — "depth = behavior / interface lines, threshold 2.0"
+
+`.plans/H-deep-module-poc/HANDOFF.md` §5 Step 2와 §7 미결 사항에 박제된 잠정 공식:
+
+```
+depth = behavior_size / public_interface_size — 임계값 2.0 잠정
+```
+
+**이 공식은 본 PoC에서 사용하지 않음.** 근거: `LANGUAGE.md` §"Rejected framings" 1번 항목.
+
+> "Depth as ratio of implementation-lines to interface-lines (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead."
+
+Matt Pocock 본인이 명시적으로 거부한 측정. 임계값 2.0을 적용하면 PoC가 끼워맞추기 위험(`feedback_no_fabricated_evidence` 위반)에 노출됨.
+
+## 2. 대체 측정 — 정성 평가 3축
+
+원문 SKILL.md + LANGUAGE.md + DEEPENING.md에서 직접 인용 가능한 측정 도구:
+
+### 2.1 Deletion test (SKILL.md §Glossary, LANGUAGE.md §Principles)
+> "Imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep."
+
+3 클래스 각각에 대해 적용:
+- 결과 = "complexity vanishes" → shallow
+- 결과 = "complexity reappears across N callers" → deep
+
+### 2.2 Interface complexity ≈ implementation complexity (LANGUAGE.md §Depth)
+> "Shallow when the interface is nearly as complex as the implementation."
+
+정량 ratio 대신 정성 비교 — public method 수 / invariant 수 / error mode 수와 implementation 분기 수 / 외부 호출 수의 대략적 정합 평가.
+
+### 2.3 Dependency 4 categories (DEEPENING.md §Dependency categories)
+1. **In-process** — pure computation, in-memory state, no I/O
+2. **Local-substitutable** — PGLite, in-memory FS 등 local stand-in 보유
+3. **Remote but owned** — Ports & Adapters, port + 2 adapter
+4. **True external** — Stripe/Twilio 같은 third-party
+
+각 클래스의 외부 의존을 4 카테고리로 분류 → adapter 후보 판별.
+
+## 3. Seam discipline (DEEPENING.md + LANGUAGE.md)
+
+> "One adapter means a hypothetical seam. Two adapters means a real one."
+
+PoC Pass 기준 B (adapter 후보 ≥ 3)는 본 원칙과 정합:
+- 후보 = 2 adapter 이상 정당화 가능한 seam만 카운트
+- 단일 adapter 인디렉션은 후보에서 제외
+
+## 4. CONTEXT.md 부재 처리
+
+SKILL.md §2는 CONTEXT.md vocabulary 사용을 요구. mind-signal-backend는 별도 CONTEXT.md 미보유.
+
+**대체**:
+- 도메인 어휘는 `mind-signal-backend/CLAUDE.md` §8 Domain Terms (Operator/Subject/Phase 1/Group/EmotivMetrics 등) 사용
+- ADR 영역은 `docs/architecture/decisions/ADR-006` (Phase G) 참조
+
+## 5. Pass 기준 매핑
+
+| Pass 기준 | 적용 측정 도구 (원문 위치) |
+|---|---|
+| A ≥ 2 구조 문제 | Deletion test (SKILL §Glossary) + interface≈impl 정성 비교 (LANGUAGE §Depth) |
+| B ≥ 3 adapter 후보 | Dependency 4 categories (DEEPENING §1~4) + Two-adapter rule (DEEPENING §Seam discipline) |
+| C ≥ 1 cross-LLM delta | 두 LLM이 동일 LANGUAGE.md 7 terms grounding |
+| D 회귀 0 | read-only 유지 (src/** 수정 0) |
+
+## 6. 다음 단계 ↔ 원문 매핑
+
+| 본 PoC 단계 | 원문 SKILL.md Process |
+|---|---|
+| Step 2 depth + adapter 후보 | Process §1 Explore |
+| Step 3 mermaid + 후보 정리 | Process §2 Present candidates |
+| Step 4a-c cross-LLM 검토 | Process §3 Grilling loop |
+| Step 5 TDD 명세 | INTERFACE-DESIGN §2 "design twice" (3+ alt interface) — PoC에서는 1 후보만, 별도 PR로 다중 alt 작성 |
+
+## 7. 출처
+
+- 원본 4 파일 (`SKILL.md`, `LANGUAGE.md`, `DEEPENING.md`, `INTERFACE-DESIGN.md`) — `mattpocock/skills@main:skills/engineering/improve-codebase-architecture/`
+- HANDOFF 박제된 5번째 파일 REFERENCE.md는 실재하지 않음 (2026-05-13 확인 — repo에는 4 파일만 존재)
+- SHA256 byte-identical 검증 결과는 `.plans/H-deep-module-poc/HANDOFF.md` 후속 박제 예정

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,17 @@ DIFF-backend.md
 
 # 기타
 
+# Phase H deep-module-poc 산출물 중 박제 제외 (Abandonment-Cost-Scoring-Rubric 4점 이하)
+# 시각화 자료는 이슈/PR 본문에 mermaid code fence로 박제
+docs/architecture/*.mmd
+docs/architecture/*.svg
+docs/architecture/puppeteer-config.json
+
+# Phase H PAAR 중 단독 가치 낮음 (다른 PAAR에 흡수됨, codex r1 → r2 흡수, slice → depth 흡수)
+docs/reports/paar-2026-05-13-deep-module-poc-slice.md
+docs/reports/paar-2026-05-13-deep-module-poc-mermaid.md
+docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md
+
 # Project planning (local only)
 .plans/
 context/

--- a/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md
@@ -1,0 +1,219 @@
+# PAAR — Phase G slice (deep-module PoC Step 4b — Claude 4-Lens 반박)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 4b (Claude 4-Lens 반박)
+> 선행: `paar-2026-05-13-deep-module-poc-codex-r1.md` (Step 4a — codex 5.5 1차)
+> 다음: Step 4c — codex 5.5 2차 재응답
+> 검토 단위: codex r1 응답 (Q1 / Q2 / Q3) 각 항목별 4-Lens 적용 + Claude 단독 발견
+
+---
+
+## 0. 4-Lens 정의 (DISCUSS.md / HANDOFF.md §6 박제 정합)
+
+| Lens | 적용 질문 | 통과 조건 |
+|---|---|---|
+| Lens 1 — Contract | codex 응답이 인용한 Matt Pocock 원리 (LANGUAGE.md 7 terms)가 실제 코드에 적용 가능한가? | 인용 원리가 mermaid + 코드 양쪽 정합 |
+| Lens 2 — Reality | codex 응답이 mermaid 외 정보를 환각으로 추가하지 않았나? | 모든 가설이 코드 read로 검증됨 |
+| Lens 3 — Completeness | codex가 놓친 shallow / seam / 후보가 있는가? | Claude 단독 후보 ≥ 1건 |
+| Lens 4 — Runtime Contract | codex 제안이 Phase G BDD 3 시나리오 invariant를 깨뜨리는가? | invariant 보존 + 회귀 0 정합 |
+
+---
+
+## 1. Lens 1 — Contract (codex 인용 원리 정합성)
+
+### 1.1 Q1 PS shallow 의심 — 4 원리 동시 인용
+- codex: Depth + Deletion test + Locality + Adapter/Seam
+- **검증**:
+  - Depth: PS interface 2개 (`execute`, `drainRecordedEvents`) vs implementation 5단계 흐름 (L58-109) → 정성 비교상 Depth 후보 정합 ✅
+  - Deletion test: PS 제거 시 책임 분산 가설 — PS L65, L72, L78, L94, L106 5개 호출 지점 모두 caller(controller 또는 BDD test)로 흩어질 → 정합 ✅
+  - Locality: 페어링 invariant + 만료 처리 + 이벤트 기록 3개 책임이 PS에 집중 → "change concentrates at one place" 정합 ✅
+  - Adapter/Seam: D-3 hypothetical seam 직접 인용 → 정합 ✅
+- **결론**: 4 원리 모두 LANGUAGE.md 정합 인용 ✅
+
+### 1.2 Q2 §2.4 D-4 value-object 권고 — 인용 원리 위치 검토
+- codex 권고: `SessionId` / `ObjectIdParser` value-object
+- 인용 위치: codex는 "INTERFACE-DESIGN.md §design twice" 명시 인용 없음. 일반 DDD value-object 개념으로만 제시.
+- **반박**: 본 권고는 LANGUAGE.md 7 terms 영역이 아닌 INTERFACE-DESIGN.md §"design twice" 또는 DDD value-object 영역. **Pass 기준 B (adapter 후보 ≥ 3)에서는 D-4를 후보에서 제외**하는 것이 codex 응답의 함의 (codex 본인이 "adapter 누락이라고 단정하지 않음" 명시).
+- **결론**: codex 응답 자체는 정합하나, B 기준 매칭에서 D-4를 제외하는 것이 더 정확 — paar-depth §4 사전 인벤토리도 D-4를 별도 port 불필요로 박제했으므로 정합 ✅
+
+### 1.3 Lens 1 통과 ✅
+
+---
+
+## 2. Lens 2 — Reality (codex 환각 검증)
+
+### 2.1 Q1 SA "isExpired interface가 시간 제어를 드러내지 못함"
+- **코드 검증**: `session.aggregate.ts:162-164`
+  ```typescript
+  isExpired(): boolean {
+    return this._expiresAt.getTime() < Date.now();
+  }
+  ```
+- **결론**: codex 가설 정합 ✅
+  - no-arg 메서드 + 내부 `Date.now()` 호출 = caller가 시간 제어 불가
+  - 테스트 시 `jest.useFakeTimers` 또는 시스템 시간 조작 외 대안 없음 (port 부재)
+
+### 2.2 Q2 §2.4 D-4 ObjectId.isValid
+- **코드 검증**: `pair-subject.service.ts:60`
+  ```typescript
+  if (!Types.ObjectId.isValid(input.userId)) {
+    throw new AppError('유효하지 않은 사용자 ID 형식입니다', 400);
+  }
+  ```
+- **결론**: codex 가설 정합 ✅
+  - `import { Types } from 'mongoose'` (L22) — feature service가 persistence library에 직접 의존
+  - codex 권고대로 `SessionId` value-object 도입 시 persistence concern 격리 가능
+
+### 2.3 Q1 PS "구현 책임이 SR, SA, D2, D3, D4로 넓게 퍼져있다"
+- **코드 검증**: PS L60 (D-4) + L65 (SR.findByPairingToken) + L72 (SA.pair) + L76 (SA.isExpired 간접 D-2) + L77 (SA.expire) + L78 (SR.save) + L94 (SR.save) + L101 (`new Date()` 직접 D-2) + L106 (recordedEvents A-3 우회)
+- **결론**: codex 가설 정합 ✅ — 5 의존 노드 모두 PS 본문에서 호출 확인
+
+### 2.4 Lens 2 통과 ✅ — 환각 0건
+
+---
+
+## 3. Lens 3 — Completeness (codex가 놓친 Claude 단독 후보)
+
+### 3.1 🆕 SA `cancel(_reason: CancelReason)` 파라미터 미사용
+- **코드 위치**: `session.aggregate.ts:150-159`
+  ```typescript
+  cancel(_reason: CancelReason): void {
+    if (
+      this._status === 'COMPLETED' ||
+      this._status === 'EXPIRED' ||
+      this._status === 'CANCELLED'
+    ) {
+      throw new InvalidStatusTransitionError(this._status, 'CANCELLED');
+    }
+    this._status = 'CANCELLED';
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §"the interface is the test surface" — Interface가 caller에게 `reason: CancelReason`을 받지만 implementation에서 폐기 (underscore prefix `_reason`). 즉 **"Interface that lies"** 패턴.
+- **분류**: Pass A 후보 추가 (A-5로 명명) — `cancel(_reason)`은 미래 확장을 위한 Sentinel signature이나 본 단계에서는 dead parameter
+
+### 3.2 🆕 PS constructor `repo?: SessionRepository` optional default
+- **코드 위치**: `pair-subject.service.ts:47-49`
+  ```typescript
+  constructor(repo?: SessionRepository) {
+    this.repo = repo ?? new SessionRepository();
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Seam + DEEPENING.md §Seam discipline — Constructor injection이 optional default fallback을 갖는다는 것은 **caller에게 "주입 안 해도 동작"이라고 신호**. Two-adapter rule 정합 (prod = `new SessionRepository()` / test = jest.mock)이지만, default fallback 자체가 seam을 약화시킴.
+- **분류**: Pass A 후보 추가 (A-6) — adapter at seam이 "soft seam" (defaultable)
+- **참고**: INTERFACE-DESIGN.md §"design twice"에서 권고할 수 있는 영역 (required injection vs optional fallback)
+
+### 3.3 🆕 PS L72-91 try-catch + `isExpired()` 재호출 — Clock race
+- **코드 위치**: `pair-subject.service.ts:72-83`
+  ```typescript
+  try {
+    aggregate.pair(input.userId);
+  } catch (err) {
+    if (err instanceof InvalidStatusTransitionError) {
+      if (aggregate.isExpired()) {  // L76 — pair()에서 isExpired 호출 후 재호출
+        aggregate.expire();
+        await this.repo.save(aggregate);
+        throw new AppError(...401);
+      }
+      // ...
+    }
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Locality — `aggregate.pair()` 내부에서 `isExpired()` 1차 호출 (L114, throws InvalidStatusTransitionError), catch 후 PS L76에서 `isExpired()` 2차 호출. **두 시점 사이 시간 흐름** → Clock race 가능. Clock seam이 hypothetical인 직접 증거이자, Two-adapter rule 적용 시 fixedClock으로 race 제거 가능.
+- **분류**: Pass A 후보 추가 (A-7) — Clock seam 부재의 직접 증거 (codex Q1 §1.2 SA 의심을 강화)
+
+### 3.4 🆕 SA `fromDocument` invariant 검증 부재 vs `create` invariant 강제
+- **코드 위치**:
+  - `create()` L69-77: `pairingToken === ''` 또는 `subjectIndex < 1` 시 `InvariantViolationError` throw
+  - `fromDocument()` L93-106: invariant 검증 0건. DB 도큐먼트를 그대로 신뢰
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Locality + §Depth — invariant 강제 책임이 `create` 한 곳에만 locality가 있고, `fromDocument`는 우회 통로. 즉 DB에 invariant 위반 데이터가 있으면 SA가 통과시켜 buggy aggregate 반환 가능.
+- **분류**: Pass A 후보 추가 (A-8) — invariant locality 균열. mermaid에 표현되지 않은 코드 내부 책임 분포.
+
+### 3.5 Lens 3 통과 ✅ — Claude 단독 후보 4건 (A-5/A-6/A-7/A-8)
+
+---
+
+## 4. Lens 4 — Runtime Contract (Phase G BDD 3 시나리오 invariant)
+
+### 4.1 BDD 3 시나리오 (Q1 LOCK, paar-2026-05-13-deep-module-poc-slice.md 박제)
+1. CREATED + valid token → PAIRED + SessionPaired event 1건
+2. CREATED + expired token → EXPIRED + AppError 401
+3. PAIRED + retry → AppError 400 (전이 불가)
+
+### 4.2 codex 권고 vs BDD 시나리오 invariant 영향
+| codex 권고 | invariant 영향 | 평가 |
+|---|---|---|
+| Q3 PS 1순위 TDD | 시나리오 추가일 뿐 — 기존 3 시나리오 보존 | ✅ 정합 |
+| Δ-3 A-2 연결도 시정 (SA → A-2, PS → A-2, A-2 → D-2) | src 수정 필요 — 본 PoC는 권고만 박제, 실제 수정 X | ✅ 회귀 0 |
+| Δ-4 A-3 → A-5 재명명 + 연결도 | src 수정 필요 — 본 PoC는 권고만 박제 | ✅ 회귀 0 |
+| Δ-5 D-4 value-object 도입 | SessionId 도입 시 SA `pair(userId: string)` 시그니처 변경 필요 — BDD 시나리오 수정 필요 가능 | 🟡 **다음 PR 결정 영역**, 본 PoC 회귀 0 정합 |
+
+### 4.3 Claude 단독 후보 vs BDD 시나리오 invariant 영향
+| 후보 | invariant 영향 | 평가 |
+|---|---|---|
+| A-5 `cancel(_reason)` dead param | 시나리오 #1/#2/#3 모두 cancel 미호출 — 영향 0 | ✅ 무관 |
+| A-6 PS constructor optional repo | BDD test에서 `new PairSubjectService(mockRepo)` 명시 주입 가능 — 영향 0 | ✅ 무관 |
+| A-7 Clock race | 시나리오 #2 expired token — Clock seam 도입 시 시나리오 더 결정적이 됨 (개선) | ✅ 정합 |
+| A-8 fromDocument invariant 부재 | 시나리오 #1 시작점이 fromDocument 경로 (DB → aggregate) — 현재 DB 데이터 유효성 가정. invariant 추가 시 시나리오 강화 | ✅ 정합 |
+
+### 4.4 Lens 4 통과 ✅ — invariant 위반 0건, 회귀 0 유지
+
+---
+
+## 5. 4-Lens 종합 + Pass 기준 갱신 매칭
+
+### 5.1 Lens 종합
+| Lens | 결론 |
+|---|---|
+| Lens 1 Contract | ✅ codex 인용 원리 모두 LANGUAGE.md 정합 (D-4 value-object는 INTERFACE-DESIGN 영역으로 이동) |
+| Lens 2 Reality | ✅ codex 응답 환각 0건 — isExpired no-arg + ObjectId.isValid 직접 의존 + 5 의존 노드 모두 코드 정합 |
+| Lens 3 Completeness | ✅ Claude 단독 후보 4건 (A-5/A-6/A-7/A-8) — mermaid에 표현되지 않은 코드 내부 책임 분포 |
+| Lens 4 Runtime Contract | ✅ Phase G BDD 3 시나리오 invariant 보존, 회귀 0 정합 |
+
+### 5.2 Pass 기준 갱신 매칭
+| 기준 | 사전 인벤토리 | codex r1 발견 | Claude 단독 추가 | Step 4b 잠정 결과 |
+|---|---|---|---|---|
+| A ≥ 2 구조 문제 | 4 (A-1~A-4) | 4 (PS shallow + SA clock + D-3 hypothetical + SA interface 약함) | 4 (A-5~A-8) | **총 8 후보, 매칭 6건 (A-1/A-2/A-3 부분/A-4)** ✅ |
+| B ≥ 3 adapter 후보 | 3 (D-1/D-2/D-3 → A-1/A-2/A-3) | 3 매칭 + 연결도 시정 권고 + Δ-1 localSubstitutable 분리 | 0 추가 | **3건 모두 매칭** ✅ |
+| C ≥ 1 cross-LLM delta | 측정 불가 | 5 신규 (Δ-1~Δ-5) | 4 신규 (A-5~A-8) | **총 9 delta** ✅ |
+| D 회귀 0 | 충족 | src 수정 0 | src 수정 0 (read-only) | **충족** ✅ |
+
+### 5.3 잠정 GO 신호 (Step 4c codex 2차 후 최종 확정)
+- A/B/C/D 4 기준 모두 잠정 충족
+- 끼워맞추기 없음 — Claude 단독 후보 4건은 mermaid + 코드 read로 객관 검증 가능
+- Step 4c에서 codex가 4-Lens 반박을 받아들이는지 + 추가 발견 있는지 확인 필요
+
+---
+
+## 6. Step 4c 진입 — codex 2차 prompt 가이드
+
+### 6.1 전달 내용
+1. codex r1 응답 (codex 자체 thread `019e1f11-50e0-7001-b4ce-2b7791d6b407` 보존)
+2. 본 4-Lens 반박 요약 4건:
+   - Lens 1 §1.2 — D-4 value-object 권고는 INTERFACE-DESIGN 영역 (B 기준에서 제외)
+   - Lens 2 — codex 환각 0건 (isExpired no-arg + ObjectId.isValid 검증)
+   - Lens 3 — Claude 단독 4건 (A-5 cancel dead param / A-6 optional repo / A-7 isExpired race / A-8 fromDocument invariant 부재)
+   - Lens 4 — invariant 보존, 회귀 0 정합
+3. 4 추가 후보에 대한 codex 인정/거부 + 추가 발견 요청
+
+### 6.2 codex 2차 질문
+- Q1' — Claude 단독 4건 (A-5/A-6/A-7/A-8) 각각에 대한 인정/거부 + 근거
+- Q2' — 본 4-Lens 반박 중 거부할 항목? (예: D-4 value-object를 B 기준에서 제외 vs 포함 논쟁)
+- Q3' — Step 5 TDD 시나리오 명세 작성 시, A-5~A-8 중 어느 후보까지 포함할지 (PoC scope vs full scope)
+
+### 6.3 산출물
+- `paar-2026-05-13-deep-module-poc-codex-r2.md`
+
+---
+
+## 7. 산출물 인덱스
+
+| 종류 | 경로 |
+|---|---|
+| 본 PAAR | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| codex r1 | `paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| 검증한 코드 | `src/06-entities/sessions/domain/session.aggregate.ts` (L150-159, L162-164, L93-106) + `src/05-features/sessions/services/pair-subject.service.ts` (L47-49, L60, L72-83) |
+| mermaid | `docs/architecture/deep-module-mermaid.{mmd, svg}` |

--- a/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md
@@ -1,0 +1,182 @@
+# PAAR — Phase G slice (deep-module PoC Step 4c — codex 5.5 2차 재응답)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 4c (codex 5.5 2차)
+> 선행: `paar-2026-05-13-deep-module-poc-claude-rebuttal.md` (Step 4b — Claude 4-Lens 반박)
+> 다음: Step 5 — TDD 시나리오 명세 추출
+> codex r2 thread: `019e1f19-f5b3-7150-90b7-e71bd3066b23`
+> 모델: gpt-5.5 / sandbox: read-only / cwd: `mind-signal-backend`
+
+---
+
+## 0. 호출 메타
+
+- 호출 도구: `mcp__codex__codex` (별 thread — r1 thread 컨텍스트 미상속, r1 결론을 prompt에 재인용)
+- prompt 길이: 약 7.8KB (r1 요약 + Claude 4-Lens 반박 4건 + Q1'/Q2'/Q3' 3 질문)
+- 응답 길이: 약 5.4KB
+
+---
+
+## 1. Q1' — Claude 단독 4건 인정/거부
+
+### 1.1 A-5 `cancel(_reason)` — **부분 인정**
+- LANGUAGE.md "Interface = caller가 올바르게 쓰기 위해 알아야 하는 모든 것" 및 "the interface is the test surface" 기준 정합
+- 강도 중간 이하 — "shallow module"보다 **거짓 interface / 미완성 domain invariant**에 가까움
+- 수정 방향: `reason` 제거 또는 aggregate 상태에 보존 또는 cancellation event에 포함
+- **Step 5 1순위 TDD 후보는 아님**
+
+### 1.2 A-6 PS constructor `repo?` optional default — **부분 인정**
+- DEEPENING.md "One adapter means a hypothetical seam. Two adapters means a real one" + "Internal seams vs external seams" 정합
+- 강도 — **composition root 부재 / soft seam**으로 분류
+- 약화 요소: `constructor(repo?: SessionRepository)`가 테스트용 stand-in을 실제로 받을 수 있음
+- 핵심 문제: PS가 `new SessionRepository()`까지 알아서 concrete persistence를 생성하는 점
+- **A-1 repository seam을 정리할 때 같이 다룰 부속 후보**
+
+### 1.3 A-7 PS try-catch + `isExpired()` 재호출 Clock race — **강하게 인정**
+- LANGUAGE.md §Locality "change, bugs, knowledge, verification concentrate at one place" 위반
+- DEEPENING.md "the interface is the test surface" — 고정 clock 없이 결정적 테스트 불가
+- **codex 추가 발견**: PAIRED 상태에서 첫 `isExpired()` false → catch 두 번째 `isExpired()` true 시:
+  - service가 expired branch 진입 → `aggregate.expire()` 호출
+  - 그러나 `expire()` L142-147은 status !== 'CREATED' 시 `InvalidStatusTransitionError` throw
+  - **결과: 다른 transition error 새로 발생 가능** — try-catch 외부로 새어나가는 실제 버그 트리거 가능성
+- **결정: 강한 인정** — r1의 SA Clock seam 의심을 PS runtime flow에서 강화하는 직접 증거
+
+### 1.4 A-8 SA `fromDocument` invariant 검증 부재 — **인정, invariant locality 후보로 분류**
+- LANGUAGE.md §Locality + §Depth — `create()` 경로와 `fromDocument()` 경로 invariant 규칙 비대칭
+- "Interface includes invariants" 정의 위반
+- **codex 추가 발견**: repository `toAggregate()`가 `doc.subjectIndex ?? 0`으로 hydrate → schema nullable이 aggregate 내부 invalid 값(0)으로 진입 가능. **A-8 위반의 실제 우회 통로 직접 증거**
+- 약화 요소: hydration factory가 DB를 신뢰하는 전략은 흔함. schema/repository가 invariant 일부 담당 가능
+- 그러나 이 코드에서는 schema가 `subjectIndex` min을 강제하지 않고 null 허용 → `fromDocument()` 무검증이 **실제 우회 통로**
+- **결정: 인정** — adapter 후보가 아닌 **aggregate invariant locality 후보**
+
+---
+
+## 2. Q2' — 4-Lens 반박 거부할 항목
+
+### 2.1 결론: 거부할 핵심 항목 없음
+- Lens 1 §1.2 "D-4 ObjectId.isValid는 adapter 후보 ≥ 3 기준에서 제외" 분류 **정확**
+- `Types.ObjectId.isValid`는 외부 라이브러리 호출이나 DEEPENING.md Ports & Adapters 대상 "remote but owned" 또는 "true external service" 성격 약함
+- deterministic in-process validation 영역. "One adapter means a hypothetical seam" 기준 별도 port 근거 부족
+
+### 2.2 codex 추가 발견 — D-4 value-object 명명 정교화
+- D-4는 value-object / parser module 후보. INTERFACE-DESIGN.md "Design It Twice" 영역
+- **개선된 명명 권고**: `UserIdValidatorPort`보다 `UserIdParserPort` 또는 `SubjectIdCodecPort`가 더 깊은 interface
+  - 이유: 단순 boolean validation보다 "parse 성공 시 domain-safe id 반환, 실패 시 error mode 고정"이 더 깊은 interface
+- **현재 PoC 기준**: B 기준 adapter count 제외, INTERFACE-DESIGN 후속 PR 영역
+
+---
+
+## 3. Q3' — Step 5 scope 선택
+
+### 3.1 결정: **옵션 B — PS 1순위 + SA Clock seam (A-7) 추가**
+- 옵션 A는 r1 핵심 결론 보존하나, A-7을 놓침 (가장 강하게 추가된 후보)
+- 옵션 C는 PoC 가치 대비 넓음. A-5/A-6/A-8은 adapter/deepening보다 interface cleanup 또는 invariant 설계 논의에 가까움
+- 검증성 PoC는 **"가장 강한 executable specification 후보"에 집중**하는 편이 적절
+
+### 3.2 Step 5 권고 시나리오 5건
+
+1. **PS happy path** — valid userId + valid token + CREATED + not expired → pair, save, event recorded
+2. **PS expired path** — CREATED but expired → expire, save, AppError 401
+3. **PS retry-after-paired** — already PAIRED → AppError 400, no expire mutation
+4. **Clock seam race** (A-7) — pair 실패 후 재호출된 `isExpired()`가 다른 판단을 만들 수 있음을 고정 clock으로 명세
+5. **Single observed now** (선택) — pair use case는 하나의 clock snapshot으로 만료 판단을 수행해야 함 (observable outcome 중심)
+
+### 3.3 명세 작성 원칙 (codex 권고)
+- LANGUAGE.md "the interface is the test surface" + DEEPENING.md "Tests assert on observable outcomes through the interface"
+- 내부 `Date.now()` 호출 횟수보다 **observable outcome 중심**으로 명세화
+
+---
+
+## 4. codex r2 추가 한계 (codex 자가 박제)
+
+1. `CancelReason`의 실제 product requirement 미확인 → A-5는 "현재 구현 기준 interface lie"로만 판단
+2. `fromDocument()`가 legacy DB 복구를 의도적으로 허용하는 설계인지 ADR / 도메인 문서 미확인 → A-8 최종 severity 가설
+
+---
+
+## 5. Pass 기준 최종 매칭 (Step 4a + 4b + 4c 종합)
+
+### 5.1 A 기준 ≥ 2 구조 문제
+
+| 후보 | 사전 박제 출처 | codex r1 | Claude 반박 | codex r2 | 최종 결정 |
+|---|---|---|---|---|---|
+| A-1 PS hypothetical seam (importers_of=0) | paar-depth §5 | ✅ 강 매칭 | ✅ Lens 1/2 검증 | (재확인 없음) | **확정** |
+| A-2 SA Clock seam 부재 | paar-depth §5 | ✅ 강 매칭 (Q1 SA) | ✅ Lens 2 isExpired no-arg 검증 | (재확인 없음) | **확정** |
+| A-3 SA interface 표면 비대 (10 getters + 7-arg) | paar-depth §5 | 🟡 부분 ("Depth 명백 안 함") | (Claude 미반박) | (재확인 없음) | **부분 매칭** |
+| A-4 PS event 경로 분기 (recordedEvents vs pairingListeners) | paar-depth §5 | ✅ 강 매칭 (Q1 D-3 + Q2 A-5 재명명) | ✅ Lens 4 회귀 0 정합 | (재확인 없음) | **확정** |
+| A-5 SA `cancel(_reason)` Interface that lies | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | 🟡 부분 인정 ("interface lie" 인정, severity 중간) | **부분 매칭** |
+| A-6 PS constructor `repo?` soft seam | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | 🟡 부분 인정 ("composition root 부재") | **부분 매칭** |
+| A-7 PS try-catch isExpired Clock race | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | ✅ **강한 인정** + 실제 버그 트리거 발견 | **확정** + 강화 |
+| A-8 SA fromDocument invariant 부재 | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | ✅ 인정 + toAggregate ?? 0 우회 통로 발견 | **확정** + 강화 |
+
+**Pass A 충족**: 확정 5건 (A-1/A-2/A-4/A-7/A-8) + 부분 매칭 3건 (A-3/A-5/A-6) = **총 8 후보, 확정만 5건 ≥ 2** ✅
+
+### 5.2 B 기준 ≥ 3 adapter 후보
+
+| 후보 | codex r1 | Claude 반박 (Lens 1) | codex r2 | 최종 결정 |
+|---|---|---|---|---|
+| D-1 → A-1 Repository (real seam) | ✅ Two-adapter rule 통과 + Δ-1 classDef 분리 권고 | 정합 | (재확인 없음) | **확정** |
+| D-2 → A-2 Clock (hypothetical → 승격) | ✅ Δ-2 category 구분 + Δ-3 연결도 시정 권고 | 정합 | A-7 강한 인정으로 강화 | **확정** |
+| D-3 → A-3 EventBus (hypothetical → A-5 재명명) | ✅ Δ-4 재명명 권고 | 정합 | (재확인 없음) | **확정** |
+| D-4 → adapter 후보 | 🟡 "단정하지 않음" | ✅ B 기준 제외 권고 (INTERFACE-DESIGN 영역) | ✅ Lens 1 분류 인정 + UserIdParserPort 명명 권고 (B에서는 제외) | **B 기준 제외 확정** |
+
+**Pass B 충족**: 3건 모두 확정 (D-1/D-2/D-3) + D-4는 value-object/parser 영역으로 분류 = **3 ≥ 3** ✅
+
+### 5.3 C 기준 ≥ 1 cross-LLM delta
+
+| Delta | 출처 | 검증 결과 |
+|---|---|---|
+| Δ-1 D-1 classDef localSubstitutable 분리 | codex r1 | (Claude 미반박) |
+| Δ-2 D-2 category embedded vs pure 구분 | codex r1 | (Claude 미반박) |
+| Δ-3 A-2 연결도 시정 (SA→A2, PS→A2, A2→D2) | codex r1 | (Claude 미반박) |
+| Δ-4 A-3 → A-5 PairingEventBusPort 재명명 | codex r1 | (Claude 미반박) |
+| Δ-5 D-4 value-object 후보 (SessionId/ObjectIdParser) | codex r1 | Lens 1 §1.2 분류 정합 + r2 명명 정교화 (UserIdParserPort / SubjectIdCodecPort) |
+| Δ-6 A-5 cancel(_reason) Interface that lies | Claude Step 4b | r2 부분 인정 |
+| Δ-7 A-6 PS constructor soft seam | Claude Step 4b | r2 부분 인정 (composition root 부재) |
+| Δ-8 A-7 PS Clock race 실제 버그 트리거 | Claude Step 4b + codex r2 강화 | r2 강한 인정 + PAIRED→재호출 시 expire() InvalidStatusTransitionError 새 발생 가능 |
+| Δ-9 A-8 toAggregate ?? 0 invariant 우회 통로 | codex r2 추가 발견 | (Claude Step 4b A-8을 강화) |
+
+**Pass C 충족**: **9 delta** (Claude/codex 양방향) ≥ 1 ✅
+
+### 5.4 D 기준 회귀 0
+- Step 4a / 4b / 4c 모두 src/** 수정 0 (read-only)
+- 신규 산출물: PAAR 보고서 3건 (r1 / rebuttal / r2) + mermaid 2건은 Step 3에서 이미 박제됨
+- **충족** ✅
+
+---
+
+## 6. Step 5 진입 — TDD 시나리오 명세 가이드
+
+### 6.1 codex 권고 5 시나리오 (Q3' 옵션 B 결정)
+1. PS happy path
+2. PS expired path
+3. PS retry-after-paired
+4. Clock seam race (A-7)
+5. Single observed now (선택)
+
+### 6.2 명세 작성 원칙
+- LANGUAGE.md "the interface is the test surface"
+- DEEPENING.md "Tests assert on observable outcomes through the interface"
+- 내부 `Date.now()` 호출 횟수보다 observable outcome 중심
+- spec 파일 작성 X — 명세만 박제
+
+### 6.3 산출물
+- `paar-2026-05-13-deep-module-poc-tdd-spec.md`
+- 각 시나리오: Given (preconditions) / When (interface call) / Then (observable outcomes)
+- Adapter port suggestion (A-7 Clock port 한정) 첨부
+
+---
+
+## 7. 산출물 인덱스 (Step 4 완료)
+
+| 단계 | 경로 |
+|---|---|
+| Step 4a | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| Step 4b | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| Step 4c (본 PAAR) | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md` |
+
+### 7.1 GO/NO-GO 잠정 신호
+- A/B/C/D 모두 충족
+- codex r1 발견 + Claude 반박 + codex r2 추가 발견 양방향 cross-LLM delta 9건
+- 끼워맞추기 없음 — 모든 후보가 코드 read 또는 mermaid 직접 인용으로 객관 검증
+- **잠정 GO** — Step 5/6 완수 후 RESULT.md에서 최종 확정

--- a/docs/reports/paar-2026-05-13-deep-module-poc-depth.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-depth.md
@@ -1,0 +1,146 @@
+# PAAR — Phase G slice (deep-module PoC Step 2 — depth + adapter 후보)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 2 (정성 depth 평가 + dependency 분류)
+> 선행: `paar-2026-05-13-deep-module-poc-slice.md` (Step 1 그래프 baseline 35 노드)
+> 측정 도구: vendored `mattpocock/improve-codebase-architecture` skill (byte-identical SHA256, `_local-addendum.md` 임시 공식 폐기 박제)
+
+---
+
+## 0. 측정 도구 변경 — HANDOFF 임시 공식 폐기 박제
+
+`.plans/H-deep-module-poc/HANDOFF.md` §5 Step 2 잠정 공식
+`depth = behavior_size / public_interface_size, 임계값 2.0`은 **본 PoC에서 사용하지 않음**.
+
+근거: `mind-signal-backend/.claude/skills/improve-codebase-architecture/LANGUAGE.md` §"Rejected framings" 1번 — Matt Pocock이 명시적으로 거부 ("Depth as ratio of implementation-lines to interface-lines — rewards padding the implementation"). 끼워맞추기 방지(`feedback_no_fabricated_evidence`)에도 부합하므로 정성 평가 3축으로 변경:
+
+1. **Deletion test** — 삭제 시 complexity 분산 여부 (SKILL.md §Glossary)
+2. **Interface ≈ Implementation 정성 비교** (LANGUAGE.md §Depth)
+3. **Dependency 4 categories + Two-adapter rule** (DEEPENING.md §1~4, §Seam discipline)
+
+벤더링 검증 (SHA256 byte-identical):
+| 파일 | sha256 |
+|---|---|
+| SKILL.md | `9e9b617b1c70d390e37dbfd1c031c11b3de850e2e3d01c4a2c2888bdb386a247` |
+| LANGUAGE.md | `6feca2140439c54a774749e8367f18350899ff69c777144ed2248cd4407949fa` |
+| DEEPENING.md | `9577485f4fc32c0267639a9151bb41c8af0f8f6086e4bf8b84d5b236e30604e9` |
+| INTERFACE-DESIGN.md | `678c3e34f1339015053212b3316bf0b676c70aa251050a0613667d4e755fb35e` |
+
+HANDOFF §8 박제된 5번째 문서 `REFERENCE.md`는 실재 안 함 (2026-05-13 GitHub API 확인 — repo에 4 파일만 존재). 메모리 `reference_mattpocock_improve_codebase_architecture.md`의 "5 URL" 박제도 4 URL로 정정 필요.
+
+## 1. Slice scope 재확인 (Step 1 baseline 유지)
+
+| 클래스 | 파일 | LOC | public 메서드 | private 메서드 |
+|---|---|---|---|---|
+| SessionAggregate | `src/06-entities/sessions/domain/session.aggregate.ts` | 197 | create / fromDocument / pair / markMeasuring / complete / expire / cancel / isExpired + 10 getters | constructor |
+| SessionRepository | `src/06-entities/sessions/repository/session.repository.ts` | 101 | findById / findByPairingToken / save / saveNew | toAggregate / toDocumentFields / toObjectId |
+| PairSubjectService | `src/05-features/sessions/services/pair-subject.service.ts` | 117 | execute / drainRecordedEvents | (없음) |
+
+graph slice (Step 1) 35 노드 baseline 유지. 회귀 0 (read-only).
+
+## 2. 추가 graph 호출 결과 (sequential, detail_level=minimal)
+
+| # | pattern | target | result_count | 핵심 발견 |
+|---|---|---|---|---|
+| 1 | callers_of | SessionAggregate | ambiguous (5 candidates) | Class node 직접 매칭 부재 — 호출은 SessionRepository.findById/findByPairingToken/save 3건이 주 |
+| 2 | file_summary | session.aggregate.ts | 21 | 본문 Class 1 + Function 4 + 16 추가 노드 (테스트 가능성) |
+| 3 | imports_of | pair-subject.service.ts | **4** | 본문 read와 일치 (`Types`, `SessionRepository/Aggregate/InvalidStatusTransitionError`, `SessionPairedEvent`, `AppError`) |
+| 4 | importers_of | pair-subject.service.ts | **0** | 🔴 **dead path** — 어떤 src 파일도 PairSubjectService를 import 하지 않음 |
+| 5 | tests_for | pair-subject.service.ts | 0 | graph indexing 한계 (실제 test 파일 2개 존재: `pair-subject.service.test.ts` + `__tests__/pair-subject.bdd.test.ts`) |
+
+도구 안정성: 5회 순차 호출 전부 정상 응답 (Step 1 noted 병렬+standard internal error 없음).
+
+## 3. Deletion test + dependency category — 클래스별 정성 평가
+
+### 3.1 SessionAggregate
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | "complexity reappears across N callers" — 5 status transition rule + 6 invariant error가 caller(Repository, Service, 잠재 controller)로 흩어짐 → **DEEP** |
+| Interface ≈ Implementation | Interface가 비대 (7-arg factory, 10 getters, 6 transition methods, 5 status enum, 4 cancel reason). Implementation은 transition rule + invariant 강제. 정성적으로 interface 표면이 implementation 깊이를 상회 — "the interface is the test surface" 원칙상 caller가 너무 많이 알아야 함. **Depth는 있으나 interface 슬림화 여지 있음** |
+| Dependency category | 1 (In-process) — Mongoose/Redis/Socket.io 의존 0건 (file header 박제). 단 `Date.now()` (L163) + 암묵 `new Date()` (L122) **clock embed** 존재 |
+| 결론 | DEEP (5 transition + 6 invariant locality) 단 **clock seam 미존재** + **interface 표면 비대** 2건 friction |
+
+### 3.2 SessionRepository
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | "complexity reappears" — 삭제 시 Mongoose 호출 + Aggregate↔Document 변환이 PairSubjectService + 향후 controller로 흩어짐 → **DEEP (adapter seam 정합)** |
+| Interface ≈ Implementation | Interface 4 method, plain types. Implementation = 변환 3 private helper + Mongoose 호출. 정성 비교 적절 비율. **Step 1 의심 "1:1 비율 shallow"는 정정 — 본 정성 평가에서는 shallow 아님** |
+| Dependency category | **2 (Local-substitutable)** — Mongoose `Session` Model. test stand-in: `mongodb-memory-server` 도입 가능 (TD-G-2 후속). 현재 prod = Atlas/Heroku, test = `jest.mock` |
+| 결론 | DEEP — strangler 패턴 adapter at seam 정상 동작 |
+
+### 3.3 PairSubjectService
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | **현 시점 "complexity vanishes"** — importers_of=0이므로 삭제 시 src/** 영향 0건. 단 BDD 테스트(__tests__/pair-subject.bdd.test.ts)에서만 호출 → 테스트가 유일 caller. 즉 "tests-only module" 상태 |
+| Interface ≈ Implementation | Interface 2 method (execute + drainRecordedEvents). Implementation 5-step flow + 3 AppError 분기 + 1 listener 통합 보류 NOTE. 정성 비교 깊이 있음. **Interface 자체는 슬림** |
+| Dependency category | 1 (In-process, validation) + Repository 간접 (DB는 Repository가 흡수) + clock embed (L101 `new Date().toISOString()`) |
+| 결론 | **🟠 currently hypothetical seam, not yet real seam** — controller wiring (TD-G-3) 미완. 본 단계에서 deep 단정 불가. 일단 "deepenable 후보"로 분류 |
+
+## 4. 외부 의존 식별 (Pass 기준 B 사전 인벤토리)
+
+| # | 의존 | 위치 | category (DEEPENING.md) | 현재 처리 | 잠재 adapter |
+|---|---|---|---|---|---|
+| D-1 | MongoDB (Mongoose Session Model) | session.repository.ts L11-14, L22, L32, L42, L48 | 2 Local-substitutable | Repository 어댑터 (single) | + mongodb-memory-server in-memory (TD-G-2) → real seam ✅ |
+| D-2 | Clock (Date.now / new Date) | session.aggregate.ts L122, L163 / pair-subject.service.ts L101 | 1 In-process embedded | 직접 호출 (테스트 시 `jest.useFakeTimers`로 우회) | + injected clock port (production = systemClock, test = fixedClock) ✅ |
+| D-3 | Event listener fire | (현재 미존재 — `drainRecordedEvents` buffer만, pairingListeners 통합 보류) | 3 Remote but owned (잠재 Redis/Socket.io 향한 port) | recordedEvents 메모리 buffer | + production = pairingListeners fire (TD-G-1), test = buffer drain → real seam ✅ |
+| D-4 | Mongoose Types.ObjectId.isValid | pair-subject.service.ts L60 | 1 In-process | 정적 함수 (pure) | 별도 port 불필요 |
+
+**adapter 후보 ≥ 3건 잠정 충족** (D-1 / D-2 / D-3). Pass 기준 B는 codex 2라운드에서 cross-LLM이 동일 결론에 도달하면 정식 통과.
+
+## 5. 구조 문제 사전 인벤토리 (Pass 기준 A 사전 후보)
+
+| # | 문제 유형 | 위치 | 원리 위반 | 적용 측정 도구 |
+|---|---|---|---|---|
+| A-1 | hypothetical seam not real | pair-subject.service.ts (importers_of=0) | LANGUAGE.md §Principles "Two adapters means a real one" — 현재 0 adapter caller | importers_of graph |
+| A-2 | clock seam 부재 | session.aggregate.ts L163, pair-subject.service.ts L101 | DEEPENING.md §1 "In-process" 카테고리지만 testability 저해 — embedded clock | source read |
+| A-3 | interface 표면 비대 | session.aggregate.ts (10 getters + 6 transitions + 7-arg factory) | LANGUAGE.md §Depth "interface is the test surface" — caller가 학습해야 할 양이 많음 | source read |
+| A-4 | event 처리 경로 분기 | pair-subject.service.ts L96-106 vs 기존 pairingListeners (TD-G-1 보류) | LANGUAGE.md §Locality "change concentrates at one place" — 2 경로 공존 | source read + file header 박제 |
+
+**구조 문제 ≥ 2건 잠정 충족** (4건 후보). Pass 기준 A는 Step 4a codex 1차에서 mermaid만 보고 동일 결론에 도달할 수 있는지 검증.
+
+## 6. Step 1 가설 정정
+
+- Step 1 박제 "SessionRepository shallow 후보 (interface 3 : behaviour 3 = 1:1 비율)" → **정정**. LANGUAGE.md "Rejected framings"에서 line-ratio depth 거부 → 본 클래스는 정성 평가상 deep (변환 책임 locality 충족). 단 Step 1 의심 자체는 "ratio 추론은 끼워맞추기 위험"이라는 메타 교훈.
+
+## 7. Step 3 사전 결정 — mermaid 색상/모양 규약
+
+HANDOFF §7 미결 사항 해소:
+
+| 노드 종류 | 모양 | 색상 | 의미 |
+|---|---|---|---|
+| Class (deep) | 사각형 + 두꺼운 실선 | 파랑 | locality 충족 |
+| Class (shallow/hypothetical) | 사각형 + 점선 | 회색 | importer 미연결 또는 interface≈impl |
+| Adapter (real) | 마름모 + 실선 | 초록 | 2 adapter 정당화 |
+| Adapter (hypothetical) | 마름모 + 점선 | 노랑 | 1 adapter (잠재 seam) |
+| External dep | 원 | 빨강 | clock/DB/network/event |
+| Test-only path | 화살표 점선 | 회색 | importers_of=0인 path |
+
+## 8. Pass 기준 현재 진행
+
+| 기준 | 사전 인벤토리 | 정식 통과 조건 | 현재 상태 |
+|---|---|---|---|
+| A ≥ 2 구조 문제 (cross-LLM이 mermaid만 보고 발견) | 4 후보 (A-1~A-4) | Step 4a-c codex 응답 + Claude 반박 | 🟡 사전 충족, codex 검증 대기 |
+| B ≥ 3 adapter 후보 | 3 (D-1/D-2/D-3) | Step 4c codex 2라운드 동일 결론 | 🟡 사전 충족, codex 검증 대기 |
+| C ≥ 1 cross-LLM delta | 측정 불가 | Step 4b/4c 비교 | ⏳ 대기 |
+| D 회귀 0 | src/** 수정 0 | 본 단계까지 유지 | ✅ 충족 |
+
+## 9. 다음 단계 (Step 3)
+
+1. `docs/architecture/deep-module-mermaid.mmd` 작성 — §7 규약 적용
+2. mermaid-svg-renderer 스킬로 SVG
+3. 자가검증 1줄 — `graph_node_count (Step 1 baseline 35) == mermaid_node_count`
+4. 산출물: `docs/architecture/deep-module-mermaid.{mmd, svg}`
+
+## 10. 도구 사용 누적
+
+| 도구 | 호출 수 | 결과 |
+|---|---|---|
+| Bash (gh api) | 3 | repo tree + skills/ + engineering/ 디렉토리 확인 |
+| Bash (curl raw.githubusercontent) | 1 | 4 파일 byte-identical download |
+| Read (skill 원본) | 4 | SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN 직접 분석 |
+| Read (mind-signal src) | 3 | SessionAggregate/Repository/PairSubjectService 본문 |
+| query_graph_tool (sequential minimal) | 5 | callers/file_summary/imports/importers/tests |
+| 총 graph 호출 | 5 (Step 1의 3개 + Step 2의 5개 합계 8) | internal error 0건 (도구 안정성 규칙 준수 입증) |

--- a/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md
@@ -1,0 +1,353 @@
+# PAAR — Phase G slice (deep-module PoC Step 5 — TDD 시나리오 명세)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 5 (TDD 시나리오 명세 추출 only)
+> 선행: `paar-2026-05-13-deep-module-poc-codex-r2.md` (Step 4c — codex r2 option B 결정)
+> 다음: Step 6 — RESULT.md 측정 + GO/NO-GO
+> 본 산출물: 명세 문서 1건. **production code / test code / resource config 변경 0건**. 회귀 0 유지.
+> 작성 원칙: LANGUAGE.md L38 "the interface is the test surface" + DEEPENING.md L36 "Tests assert on observable outcomes through the interface, not internal state"
+
+---
+
+## 0. §10 검증 체크리스트 통과 보고 (HANDOFF rev.4 §10 박제 정합)
+
+> 본 표는 HANDOFF rev.4 §10 "체크리스트 통과 보고 양식" 정합. 다음 세션 재실행 시 같은 양식으로 재박제.
+
+| 항목 | 결과 | 검증 도구 / 근거 |
+|---|---|---|
+| #1 external-source | Pass | Glob `mind-signal-backend/.claude/skills/improve-codebase-architecture/*.md` → 5 파일 실재 (SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN + `_local-addendum.md`) |
+| #2 source-quote | Pass | Grep 원문 검증: "the interface is the test surface" LANGUAGE.md L38 + DEEPENING.md L35 + SKILL.md L26 / "Rejected framings" LANGUAGE.md L49 / "Two adapters means a real one" LANGUAGE.md L39 + DEEPENING.md L29 / "Tests assert on observable outcomes through the interface" DEEPENING.md L36 / "Locality" LANGUAGE.md L31 + L47 |
+| #3 ad-hoc-formula | Pass | 본 spec Pass/Fail 기준에 line ratio / threshold 2.0 / graph_node_count == mermaid_node_count 사용 0건. §1 정성 평가 3축(deletion test + Interface≈Implementation + Dependency category)만 사용 |
+| #4 code-location | Pass | Read 직접 검증: `session.aggregate.ts` L69-90 create / L93-106 fromDocument / L113-123 pair / L142-147 expire / L150-159 cancel / L162-164 isExpired / `pair-subject.service.ts` L47-49 constructor / L58-109 execute / L60 ObjectId.isValid / L65 findByPairingToken / L72-83 try-catch + isExpired 재호출 / L97-105 event 객체 / `session.repository.ts` L62 `doc.subjectIndex ?? 0` 우회 통로 |
+| #5 principle-mapping | Pass | 본 spec 시나리오 4·5 = LANGUAGE.md §Locality + §Depth + DEEPENING.md §Seam discipline 직접 인용. 후보별 4단계 표 (§3 deferred) 동반 |
+| #6 graph-mermaid-unit | Pass | 본 spec 본문에 graph count vs mermaid count 자가검증 산식 0건. paar-mermaid §자가검증 = 분류별 inventory matching (계량적 1:1 아님) |
+| #7 llm-consensus | Pass | A-7 Clock race 강한 인정 근거 = codex r2 §1.3 + Claude rebuttal §3.3 + 코드 read L72-83 + L113-123 + L162-164 직접 인용. 합의 단독 0건 |
+| #8 stale-session-state | Pass | Glob `**/base44*` 0건 (3 프로젝트 docs/configs) + `Team-project/.claude/settings.json` Grep "UserPromptSubmit\|Stop" 0건 (PostToolUse + SessionStart 2개만 잔존) |
+| #9 observable-outcome | Pass | 본 spec §2 5 시나리오 모두 5요소(Given / When / Then / observable outcome / non-goal) 명시. 내부 Date.now() 호출 횟수 명세 0건 |
+| #10 deferred-candidate | Pass | A-5/A-6/A-8 §3 별도 섹션으로 분리. §1 spec scope / §5 Pass 기준 / §4 adapter 권고에 포함 0건 |
+
+10항목 모두 Pass — Step 5 명세 본문 진입.
+
+---
+
+## 1. Spec scope (codex r2 §3.2 option B)
+
+### 1.1 1순위 — PairSubjectService (PS)
+- **근거 3축** (paar-depth §3.3 + Step 4a codex r1 Q1):
+  1. **Deletion test** — PS 제거 시 5-step flow(L58-109) + 3 AppError 분기가 caller(controller / BDD test)로 흩어짐. "complexity reappears across N callers" (LANGUAGE.md L37) 정합
+  2. **Interface ≈ Implementation** — 인터페이스 2 메서드(execute / drainRecordedEvents)는 슬림. 5단계 흐름 + 3 분기는 그 뒤로 숨음. depth 후보 정합 (LANGUAGE.md L19)
+  3. **Dependency category 3종** (DEEPENING.md §1~4 분류) — D-1 MongoDB(Repository 어댑터 경유) / D-2 Clock(embedded) / D-4 ObjectId.isValid(in-process). PS는 3 카테고리 모두 경유하는 **응용 서비스 단일 hot path**
+
+### 1.2 추가 — A-7 Clock seam race
+- **근거**: codex r2 §1.3 강한 인정. PS `pair-subject.service.ts` L72-83 try-catch 후 `aggregate.isExpired()` 재호출 시점에 첫 호출(SA L114)과 다른 시간 판단 가능성 + PAIRED 상태에서 재호출 시 `expire()` (SA L142-147)가 새 `InvalidStatusTransitionError` 발생 가능
+- **시나리오 4**(Clock seam race) + **시나리오 5**(single observed now)로 명세화
+
+### 1.3 명세화 원칙 (LANGUAGE.md L38 + DEEPENING.md L36)
+1. **The interface is the test surface** — Test가 검증하는 대상은 PS의 `execute()` 메서드와 `drainRecordedEvents()` + 영속화 후 `SessionRepository.findByPairingToken()` 관찰 결과. SA 내부 transition rule이나 `aggregate.pair()` 호출 자체를 검증 대상에 두지 않음
+2. **Tests assert on observable outcomes through the interface, not internal state** — Then 절은 외부에서 관찰 가능한 결과(thrown AppError / 영속 상태 / drainRecordedEvents 반환값)만 검증. 내부 `Date.now()` 호출 횟수 / `aggregate.expire()` 호출 횟수는 non-goal
+
+### 1.4 회귀 0 박제
+- `mind-signal-backend/src/**` 수정 0건
+- 본 PAAR 1건 추가 (`docs/reports/`)
+- Phase G 11 commit(`feat/G-ddd-bdd-tdd-pilot`) untouched
+- Clock port 실제 구현 / `SA.isExpired()` 시그니처 변경 / `PS.constructor` 수정 0건 — 모두 후속 PR 영역
+
+---
+
+## 2. 5 시나리오 명세 (Given / When / Then / observable outcome / non-goal)
+
+### 2.1 Scenario 1 — PS happy path
+
+- **Given (preconditions)**:
+  - SessionRepository stand-in이 1 도큐먼트로 seed됨: `pairingToken = "TOK-VALID-S1"`, `status = 'CREATED'`, `expiresAt > now`, `groupId = "GRP-S1"`, `subjectIndex = 1`, `experimentMode = 'DUAL'`, `userId = null`, `pairedAt = null`, `creatorId = <operator ObjectId>`
+  - 24자 hex `userId` 입력 (`Types.ObjectId.isValid` 통과)
+  - 본 시나리오에서 Clock 관찰 시점 T0는 단조 증가하는 시스템 클럭의 한 순간 (시나리오 5에서 단일 snapshot 의무로 강화)
+- **When (interface call)**:
+  - `new PairSubjectService(stubRepo).execute({ pairingToken: "TOK-VALID-S1", userId: <24hex> })`
+- **Then (observable outcomes)**:
+  1. `Result.session.status === 'PAIRED'`
+  2. `Result.session.userId === <24hex>`
+  3. `Result.session.pairedAt instanceof Date` (non-null)
+  4. `Result.event` 객체 shape (PS L97-105 정합):
+     - `type === 'SessionPaired'`
+     - `sessionId === <seed session._id>`
+     - `userId === <24hex>`
+     - `occurredAt` is ISO 8601 string
+     - `groupId === "GRP-S1"`
+     - `subjectIndex === 1`
+     - `mode === 'DUAL'`
+  5. 영속화 검증: subsequent `stubRepo.findByPairingToken("TOK-VALID-S1")` returns aggregate with `status === 'PAIRED'` and `userId === <24hex>`
+  6. `service.drainRecordedEvents()` 첫 호출 시 `[Result.event]` 길이 1, 두 번째 호출 시 빈 배열(buffer 비움 검증 — PS L112-115 정합)
+- **Non-goal**:
+  - 내부 `Date.now()` 호출 횟수
+  - `stubRepo.save()` 호출 횟수
+  - `aggregate.pair()` 호출 빈도
+  - 기존 `pairingListeners` (외부 Set, LD-12) 발화 — pair-subject.service.ts L14-19 NOTE 정합으로 본 흐름에서는 발화하지 않음을 명시 (검증 대상 외)
+
+### 2.2 Scenario 2 — PS expired path (AppError 401)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-EXP-S2"`, `status = 'CREATED'`, `expiresAt < now` (확실히 만료된 시점)
+  - 유효 `userId` 24-hex
+- **When**:
+  - `service.execute({ pairingToken: "TOK-EXP-S2", userId: <24hex> })`
+- **Then**:
+  1. `AppError` thrown — `statusCode === 401` and `message === '페어링 토큰이 만료되었습니다. 다시 시도해주세요.'` (PS L79-82 정합)
+  2. 영속화 검증: subsequent `stubRepo.findByPairingToken("TOK-EXP-S2")` returns aggregate with `status === 'EXPIRED'` (PS L77-78 `expire() + save()` 정합 — observable through repository)
+  3. `service.drainRecordedEvents()` returns empty array
+- **Non-goal**:
+  - `aggregate.expire()` 직접 호출 횟수
+  - `aggregate.isExpired()` 호출 횟수
+  - try-catch 분기 내부 sequence
+
+### 2.3 Scenario 3 — PS retry-after-paired (AppError 400)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-PRD-S3"`, `status = 'PAIRED'`, `userId = <previous-user-24hex>`, `pairedAt = <prior Date>`, `expiresAt > now` (만료 전이지만 이미 PAIRED)
+  - 신규 `userId` 24-hex (`previous-user`와 다름)
+- **When**:
+  - `service.execute({ pairingToken: "TOK-PRD-S3", userId: <new-24hex> })`
+- **Then**:
+  1. `AppError` thrown — `statusCode === 400` and `message === '현재 세션 상태(PAIRED)에서는 페어링할 수 없습니다.'` (PS L84-88 정합)
+  2. **영속 상태 불변 검증**: subsequent `stubRepo.findByPairingToken("TOK-PRD-S3")` returns aggregate with `status === 'PAIRED'` (변경 0), `userId === <previous-user-24hex>` (덮어쓰기 0), `pairedAt` unchanged
+  3. `service.drainRecordedEvents()` returns empty array
+- **Non-goal**:
+  - catch 분기 내부 isExpired() 호출 자체
+  - PS가 `aggregate.expire()`를 호출하지 않았다는 사실의 직접 검증 (영속 상태 PAIRED 불변으로 간접 보장됨)
+
+### 2.4 Scenario 4 — Clock seam race (A-7) — 결정성 명세
+
+> 본 시나리오는 **A-7 Clock seam race**(codex r2 §1.3 강한 인정 + Claude rebuttal §3.3 Lens 3 박제)의 observable 표현. 실제 Clock port 구현은 후속 PR 영역(§4.3). 본 명세는 "Clock port가 도입되면 어떻게 결정성이 보장되어야 하는가"를 정의함.
+
+- **가정 (port hypothesis)**:
+  - 가설적 `Clock` 포트가 PS에 주입됨 (§4.1 시그니처). `SA.isExpired()`는 주입된 clock을 통해 시간을 관찰. 한 `execute()` 호출 내에서 모든 시간 관찰은 결정적이어야 함
+
+- **Given**:
+  - 동일 sessionDoc 2개 context로 seed (각각 다른 pairingToken): `pairingToken = "TOK-BND-A"`, `"TOK-BND-B"`, 두 도큐먼트 모두 `status = 'CREATED'`, `expiresAt = T`, 유효 `userId` 24-hex
+  - **Context A**: FixedClock at `T - 1ms` 주입
+  - **Context B**: FixedClock at `T + 1ms` 주입
+
+- **When**:
+  - 각 context별로 `service.execute({ pairingToken, userId })` 1회 호출
+
+- **Then (cross-context observable)**:
+  1. **Context A** — Scenario 1 결과와 동일: `Result.session.status === 'PAIRED'`, 영속 PAIRED, event recorded
+  2. **Context B** — Scenario 2 결과와 동일: `AppError(401)` thrown, 영속 EXPIRED, drain empty
+  3. **결정성**: 동일 context를 N회 반복 실행 시 N개의 결과가 모두 동일 (no flakiness, no race)
+
+- **Within-call observable invariant (race 부재 강제)**:
+  - `execute()` 한 번의 호출 안에서 `SA.pair()` 내부 `isExpired()` 첫 판단 (`SA.aggregate.ts:114`) + PS catch 분기 `aggregate.isExpired()` 재호출 (`pair-subject.service.ts:76`)가 **동일 clock snapshot**을 본다
+  - 즉 Context A에서 `pair()`는 false를 받지만 catch 분기 isExpired()가 true를 받는 race가 **존재할 수 없어야 함**
+  - 검증 방법: Context A에서 paired 결과 + Context B에서 expired 결과 + 두 context 모두 N회 반복 시 동일 결과가 유지되는지
+
+- **A-7 버그 트리거 명세 (codex r2 §1.3 추가 발견 박제)**:
+  - 현재 구현(embedded clock) 가설적 race: PAIRED 상태에서 catch 분기 진입 후 isExpired() true 반환 → `aggregate.expire()` 호출(PS L77) → SA L143 `status !== 'CREATED'` 조건으로 `InvalidStatusTransitionError` **새로** throw → AppError(401)이 아닌 raw transition error가 PS 외부로 새어나갈 가능성
+  - **Then 강화 명세**: Context C — FixedClock at `T - 1ms`, status=PAIRED(이미 PAIRED)로 seed → 결과는 Scenario 3 (AppError 400 + 영속 PAIRED 불변)이어야 함. `InvalidStatusTransitionError`가 외부로 새어나오지 않음을 검증
+
+- **Non-goal**:
+  - 실제 `Clock` 포트 구현 (§4.3 후속 PR)
+  - 내부 `Date.now()` 호출 횟수
+  - `pair()`와 catch 분기가 동일 변수 vs 동일 함수 재호출인지 (implementation detail)
+  - SA.aggregate.ts L122 `this._pairedAt = new Date()`의 clock 정합 (별도 후속 — 시나리오 1의 pairedAt observable만 검증, 정확한 값 일치는 시나리오 5에서 강화)
+
+### 2.5 Scenario 5 — Single observed now (선택, observable 강화)
+
+> 시나리오 4의 within-call observable invariant를 직접 명세화. Clock seam 도입 시 "한 번의 execute()는 한 번의 시간 관찰"이라는 결정성을 인터페이스 수준에서 보장.
+
+- **가정**:
+  - PS는 `execute()` 시작 시점에 clock을 1회 관찰하여 그 snapshot T0를 흐름 전체에 사용 (구현 방법은 자유 — 포트 호출 1회 vs 첫 관찰 결과 캐싱 vs 다른 방식. 검증 대상은 결과의 결정성)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-SON-S5"`, `status = 'CREATED'`, `expiresAt = T0 + δ` (δ는 매우 작은 양수 — boundary 직전)
+  - FixedClock at `T0` 주입
+  - 실제 wall-clock이 execute() 호출 중에 `T0 + 2δ`로 진행됨 (실제 시간 흐름과 주입 clock 분리)
+
+- **When**:
+  - `service.execute({ pairingToken: "TOK-SON-S5", userId: <24hex> })`
+
+- **Then (observable invariant)**:
+  1. 결과는 **주입된 FixedClock의 T0**가 expiresAt 미만이므로 **paired** (Scenario 1 outcome)
+  2. wall-clock이 execute() 종료 시점에 `T0 + 100ms`이든 `T0 + 5초`이든 결과는 **동일**
+  3. 동일 FixedClock + 동일 seed로 N회 반복 시 N개 결과 모두 paired
+
+- **상대 시나리오 (boundary 반대)**:
+  - 같은 seed에 FixedClock at `T0 + 2δ`(boundary 직후) 주입 시 → expired (Scenario 2 outcome). 두 경계 사이의 차이가 결정적임을 보장
+
+- **Non-goal**:
+  - Clock port API 형태(`now(): Date` vs `nowMs(): number` 등 design decision) — 후속 PR
+  - 내부 clock 관찰 횟수 — 결과의 결정성만 검증
+
+---
+
+## 3. 보류 후보 (Step 5 비포함 — 후속 PR)
+
+> 본 §은 HANDOFF rev.4 §0 표 "Step 5 포함 / 보류 결정" 정합. A-5 / A-6 / A-8은 각각 별도 PR 후보로 보류. 본 spec scope(§1) / Pass 기준(§5) / adapter 권고(§4)에 포함 0건.
+
+### 3.1 A-5 — `SessionAggregate.cancel(_reason: CancelReason)` Interface that lies
+
+- **위치**: `session.aggregate.ts:150-159`
+- **현 구현**: 메서드 시그니처는 `reason: CancelReason`을 받지만 implementation은 `_reason` (underscore prefix)으로 폐기. 상태 전이만 수행
+- **원리 위반**: LANGUAGE.md L11-13 §Interface — "Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, ..." → 시그니처가 caller에게 `reason`이 의미 있는 입력이라는 신호를 보내지만 실제로는 폐기. **거짓 인터페이스**
+- **codex r2 §1.1 인정 강도**: 부분 — "shallow module"보다 **거짓 interface / 미완성 domain invariant**에 가까움
+- **Step 5 비포함 사유**:
+  - 본 PoC scope는 페어링 흐름(CREATED → PAIRED) 1줄 — `cancel()`은 별도 hot path
+  - cancel 의미론 결정(reason 보존 vs 폐기 vs cancellation event 발화)은 도메인 차원 의사결정 필요
+- **후속 PR 후보**:
+  - **PR-A5-cleanup-interface**: reason을 도메인 의도에 맞게 처리 (3 옵션 중 택일 — aggregate state 보존 / cancellation event payload / 인터페이스에서 제거)
+  - 영향 범위: SA L150-159 + `CancelReason` type + 잠재 `cancel()` caller(현재 importers_of=0 추정, 별도 검증 필요)
+
+### 3.2 A-6 — `PairSubjectService` constructor `repo?: SessionRepository` soft seam
+
+- **위치**: `pair-subject.service.ts:47-49`
+- **현 구현**: `constructor(repo?: SessionRepository) { this.repo = repo ?? new SessionRepository(); }` — Repository 미주입 시 concrete `SessionRepository`를 직접 생성
+- **원리 위반**: DEEPENING.md §Seam discipline (L27-32) — composition root 부재. caller가 `new PairSubjectService()` 만으로 동작한다고 신호 받음 → adapter at seam이 "soft seam"(defaultable)으로 약화
+- **codex r2 §1.2 인정 강도**: 부분 — A-1 repository seam 정리 시 함께 다룰 부속 후보
+- **Step 5 비포함 사유**:
+  - 시나리오 1~5는 모두 명시 주입(`new PairSubjectService(stubRepo)`)을 사용하므로 본 명세 자체는 default fallback 동작을 호출하지 않음. 즉 보류해도 시나리오 검증 가능
+  - A-1 (PS importers_of=0 → real seam 승격)이 controller wiring PR에서 해결될 때 함께 default 제거가 자연스러움
+- **후속 PR 후보**:
+  - **PR-A6-required-injection**: A-1 controller wiring PR에 포함. `constructor(repo: SessionRepository)` (required) + composition root에서 단일 인스턴스화
+  - 영향 범위: PS L47-49 + BDD test 2건(이미 명시 주입이므로 무중단) + controller wiring PR 신규
+
+### 3.3 A-8 — `SessionAggregate.fromDocument` invariant 부재 + `toAggregate(doc.subjectIndex ?? 0)` 우회 통로
+
+- **위치**:
+  - `session.aggregate.ts:93-106` — `fromDocument()`가 `create()` (L69-77)의 invariant 검증(`pairingToken !== ''`, `subjectIndex >= 1`)을 우회
+  - `session.repository.ts:62` — `toAggregate()`가 `doc.subjectIndex ?? 0` 으로 nullable을 0으로 hydrate
+  - `session.schema.ts:45-48` — schema에서 `subjectIndex` `default: null` 허용, `min: 1` 강제 없음
+- **원리 위반**: LANGUAGE.md L31-32 §Locality — invariant 강제 책임이 `create()` 한 곳에 locality가 있어야 하나 `fromDocument()`가 비대칭 우회 통로. DB → aggregate hydration 시 invariant 위반 값(`subjectIndex = 0`)이 통과 가능
+- **codex r2 §1.4 + Δ-9 추가 발견**: `toAggregate ?? 0`이 invariant 우회 통로의 직접 증거
+- **Step 5 비포함 사유**:
+  - invariant locality 설계 결정은 다음 3 옵션 중 선택 필요 — (a) `fromDocument()`에 invariant 강제 추가 / (b) schema가 invariant 일부 담당 (`min: 1`, `required: true`) / (c) repository가 hydration 시 invariant 검증
+  - 어느 옵션이든 schema migration 또는 정합성 점검 스크립트가 필요할 수 있음 (legacy 도큐먼트의 `subjectIndex = null` 처리)
+- **후속 PR 후보**:
+  - **PR-A8-invariant-locality**: 3 옵션 중 ADR 결정 후 구현. ADR-006(Phase G)와 별도 ADR-007 후보
+  - 영향 범위: SA L93-106 + SR L62 + session.schema.ts L45-48 + 잠재 legacy 데이터 보정
+
+---
+
+## 4. Adapter port 권고 (A-7 Clock port 한정)
+
+> 본 §은 시나리오 4 / 5의 가설적 Clock port를 명세화. **본 spec에서 실제 구현은 0건** — 시그니처와 정당화만 박제. 구현은 후속 PR (TD-G-Clock 또는 별도 phase).
+
+### 4.1 Clock port 시그니처 (제안 — 후속 PR에서 확정)
+
+```
+// 의사 코드 — production code 아님, 시나리오 명세의 가설 표현
+interface Clock {
+  now(): Date;   // 또는 nowMs(): number — Design It Twice 영역
+}
+
+class SystemClock implements Clock {
+  now(): Date { return new Date(); }
+}
+
+class FixedClock implements Clock {
+  constructor(private readonly fixed: Date) {}
+  now(): Date { return this.fixed; }
+}
+```
+
+### 4.2 Two-adapter rule 정당화 (DEEPENING.md L29)
+
+- **Production adapter**: `SystemClock` — `new Date()` / `Date.now()` 캡슐화
+- **Test adapter**: `FixedClock` — 시나리오 4/5에서 결정성 보장에 필수
+- **DEEPENING.md L29 "Two adapters means a real one"**: 두 어댑터 모두 정당. test stand-in이 단순 mock이 아닌 의미 있는 substitution
+
+### 4.3 본 spec 범위 한계 박제
+
+- Clock port 실제 구현 / `SA.isExpired()` 시그니처 변경(현재 no-arg → `isExpired(clock: Clock)` 또는 생성자 주입) / PS의 clock 단일 관찰(시나리오 5 강화) — **모두 후속 PR** (예: TD-G-Clock-port)
+- 본 spec은 "Clock seam이 어떤 결정성을 보장해야 하는가"의 observable 정의만 박제
+- 후속 PR ADR 후보: ADR-008 "Clock port at SA isExpired() seam" — 시그니처 결정(method param vs constructor inject) + production 단일 SystemClock 인스턴스 위치(composition root vs SA static)
+
+### 4.4 A-7 race trigger 후속 검증 의무
+
+- 시나리오 4 §"A-7 버그 트리거 명세"의 Context C(PAIRED 상태 + boundary clock)가 현재 코드에서 실제로 `InvalidStatusTransitionError`를 raw 노출하는지는 후속 PR에서 **재현 test 1건 + 수정**으로 입증/반증 필요
+- 본 spec에서는 "그럴 가능성이 있다 (codex r2 §1.3 박제)" + "Clock port 도입 시 결정적으로 차단" 까지만 명세
+
+---
+
+## 5. Pass 기준 매칭 (Step 5 한정)
+
+| 기준 | 조건 | 결과 | 근거 |
+|---|---|---|---|
+| **A** | Step 4 산출물의 주요 후보(A-1 / A-2 / A-4 / A-7 confirmed)가 Step 5 명세 범위에 정확히 반영 | ✅ Pass | A-1(PS center, §1.1 3축) + A-2/A-7(Clock seam, 시나리오 4 + 5) + A-4(event recorded, 시나리오 1 Then 4) 모두 시나리오 본문 또는 spec scope에 반영 |
+| **B** | 신규 박제 정보는 원문 Read 검증 또는 명확한 보류 표시 보유 | ✅ Pass | 본 spec 본문 모든 원리 인용 = §0 §10 #2 검증 통과 라인 번호. A-5/A-6/A-8 보류 후보는 §3 별도 섹션 |
+| **C** | 임시 공식 / 추론 / cross-LLM 주장만으로 확정 0건 | ✅ Pass | 본 spec Pass/Fail 기준에 line ratio / threshold / count equality 0건. A-7 confirmed는 코드 read(L72-83 + L113-123 + L162-164) + r2 §1.3 + Claude rebuttal §3.3 3중 근거 |
+| **D** | Step 5 산출물이 다음 구현 세션에서 바로 TDD 입력으로 사용 가능할 만큼 구체적 | ✅ Pass | 각 시나리오 Given/When/Then/observable outcome/non-goal 5요소 + AppError statusCode/message 한국어 원문 + repository seed 필드 명시 + 24-hex userId 형식 명시 |
+
+**Step 5 완료 조건 충족** (HANDOFF rev.4 §4.1 7항목):
+- [✅] `paar-2026-05-13-deep-module-poc-tdd-spec.md` 명세 작성 완료
+- [✅] 5 시나리오(PS happy / PS expired / PS retry-after-paired / Clock seam race A-7 / single observed now)가 PS 중심 옵션 B에 맞게 정리
+- [✅] A-7 Clock seam race가 observable outcome 기반 시나리오로 포함 (Given / When / Then / observable outcome / non-goal)
+- [✅] A-5 / A-6 / A-8은 후속 후보로 보류 사유 명시 (§3)
+- [✅] 명세가 LANGUAGE.md "the interface is the test surface" + DEEPENING.md "Tests assert on observable outcomes" 원칙 정합
+- [✅] production code / test code / resource config 변경 0건
+- [✅] 회귀 0 유지
+
+---
+
+## 6. 다음 단계 (Step 6 — RESULT.md + GO/NO-GO)
+
+### 6.1 측정해야 할 항목
+- A 기준 ≥ 2 구조 문제 — 확정 5건(A-1/A-2/A-4/A-7/A-8) + 부분 매칭 3건(A-3/A-5/A-6) = 잠정 충족
+- B 기준 ≥ 3 adapter 후보 — D-1/D-2/D-3 확정 + D-4는 INTERFACE-DESIGN 영역 = 잠정 충족
+- C 기준 ≥ 1 cross-LLM delta — 9 delta (Δ-1~Δ-9) = 잠정 충족
+- D 기준 회귀 0 — src/** 수정 0 = 충족
+
+### 6.2 산출물
+- `.plans/H-deep-module-poc/RESULT.md` (8~15줄)
+- `STATE.md` Phase H 갱신 (또는 신규 생성 — 본 세션 STATE.md 미존재 확인됨)
+- 메모리: `project_phase_h_done.md` 또는 `_no_go.md`
+- 옵시디언 task amend (`/obsidian-record` 의무, [[feedback-use-obsidian-skill]] + [[feedback-obsidian-record-amend-too]])
+
+### 6.3 GO 신호 (Step 6에서 최종 확정)
+- A/B/C/D 4 기준 모두 잠정 충족
+- 끼워맞추기 없음 ([[feedback-no-fabricated-evidence]])
+- §10 검증 체크리스트 10/10 Pass
+- 본 spec이 다음 구현 세션에서 TDD 입력으로 사용 가능
+
+### 6.4 NO-GO 시 처리 (방어 절차)
+- Step 6 측정에서 임의의 Pass 기준이 객관 근거 없이 충족되었다는 사실이 드러나면 RESULT.md에 `NO-GO: <항목명>` 박제
+- 워크플로우 폐기 또는 도구 교체 결정 + 원인 분석
+- 메모리: `project_phase_h_no_go.md`
+
+---
+
+## 7. 산출물 인덱스 (Step 5 완료 기준)
+
+| 종류 | 경로 |
+|---|---|
+| 본 PAAR (Step 5) | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md` |
+| Step 1 PAAR | `paar-2026-05-13-deep-module-poc-slice.md` |
+| Step 2 PAAR | `paar-2026-05-13-deep-module-poc-depth.md` |
+| Step 3 PAAR | `paar-2026-05-13-deep-module-poc-mermaid.md` |
+| Step 4a PAAR (codex r1) | `paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| Step 4b PAAR (Claude rebuttal) | `paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| Step 4c PAAR (codex r2) | `paar-2026-05-13-deep-module-poc-codex-r2.md` |
+| mermaid source | `docs/architecture/deep-module-mermaid.mmd` |
+| mermaid SVG | `docs/architecture/deep-module-mermaid.svg` |
+| 본 PoC HANDOFF (rev.4) | `Team-project/.plans/H-deep-module-poc/HANDOFF.md` |
+| vendor 스킬 | `mind-signal-backend/.claude/skills/improve-codebase-architecture/{SKILL,LANGUAGE,DEEPENING,INTERFACE-DESIGN}.md` + `_local-addendum.md` |
+
+---
+
+## 8. 회귀 0 박제
+
+- `mind-signal-backend/src/**` 수정 0건 (본 세션 Read only)
+- `mind-signal-backend/__tests__/**` 수정 0건
+- resource config / package.json / tsconfig.json 수정 0건
+- Phase G 11 commit (`feat/G-ddd-bdd-tdd-pilot`) untouched
+- `Team-project/.claude/settings.json` hooks(PostToolUse + SessionStart) 상태 유지 — UserPromptSubmit / Stop 부재 (§10 #8 Pass 정합)
+- 본 PAAR 1건만 신규 (`docs/reports/`)
+
+---
+
+## 9. 출처 / 참조 메모리
+
+- LANGUAGE.md L11-13 §Interface / L18-19 §Depth / L31-32 §Locality / L37-39 §Principles / L49-53 §Rejected framings
+- DEEPENING.md L27-32 §Seam discipline / L35-36 §The interface is the test surface
+- SKILL.md L15-26 §Glossary + §Deletion test + §The interface is the test surface
+- INTERFACE-DESIGN.md §Design It Twice (D-4 value-object 후보 영역, B 기준 제외)
+- 본 PoC 박제 위반 사례 4건(§10 §"본 세션 박제 위반 사례"): REFERENCE.md 5번째 파일 / depth ratio 2.0 / SR 1:1 ratio shallow / graph count == mermaid count
+- 메모리: [[reference-mattpocock-improve-codebase-architecture]] / [[feedback-no-fabricated-evidence]] / [[feedback-websearch-unverified-persist-ban]] / [[feedback-codex-model-default]] / [[feedback-obsidian-handoff-required-fields]] / [[feedback-use-obsidian-skill]] / [[feedback-obsidian-record-amend-too]] / [[feedback-external-doc-natural-language-5w1h]] / [[feedback-code-review-graph-parallel-standard-error]] / [[project-phase-h-deep-module-poc-step1]]


### PR DESCRIPTION
## Summary

Phase H deep-module-poc(2026-05-13 GO) + Phase I PR-A7 (PR #53 머지 완료) 후속 chore. Phase H의 분석 산출물 중 [Abandonment-Cost-Scoring-Rubric](https://github.com/) 5+ 점수만 박제, 4점 이하는 .gitignore로 차단.

본 PR은 src/** 수정 0건 — 회귀 위험 0, build-and-test 영향 0.

## 박제 내역 (5 entry, 9 파일)

### vendor skill (5 파일)
mattpocock/skills 4 byte-identical + 1 local addendum. ADR-006(Phase G) + ADR-007(Phase I) 인용 baseline.

- `.claude/skills/improve-codebase-architecture/SKILL.md`
- `.claude/skills/improve-codebase-architecture/LANGUAGE.md`
- `.claude/skills/improve-codebase-architecture/DEEPENING.md`
- `.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md`
- `.claude/skills/improve-codebase-architecture/_local-addendum.md`

`.gitignore !.claude/skills/**` Negation으로 추적 가능.

### Phase H PAAR (4 파일)
| 파일 | 점수 | 박제 사유 |
|---|---:|---|
| `paar-...-tdd-spec.md` | **7** | test의 source of truth. BDD 8건 1:1 매핑, ADR-007 인용 |
| `paar-...-codex-r2.md` | **6** | 이슈 #52 + ADR-007 + plan-review W2 인용. A-7 강한 인정 + PR-A8 baseline |
| `paar-...-claude-rebuttal.md` | **6** | Claude thread 영속화 미지원. ADR-007 + W2 인용 |
| `paar-...-depth.md` | **5** | 정성 3축. ADR-007 references |

## .gitignore 차단 (6 파일, 4점 이하)

| 파일 | 점수 | 차단 사유 |
|---|---:|---|
| `docs/architecture/*.mmd` | 3 | 시각화 보조. 이슈/PR 본문 mermaid code fence로 박제 |
| `docs/architecture/*.svg` | 3 | 동일 |
| `docs/architecture/puppeteer-config.json` | 3 | mermaid 렌더 부수 설정 |
| `paar-...-slice.md` | 3 | code-review-graph MCP로 재생산 가능, depth.md에 흡수 |
| `paar-...-mermaid.md` | 3 | 보조 시각화, codex-r2에 분석 흡수 |
| `paar-...-codex-r1.md` | 4 | codex thread MCP 서버 보존, r2가 r1 흡수 |

wildcard 패턴(`*.mmd`/`*.svg`)으로 미래 시각화 자료 자동 차단. PAAR 보고서는 `paar-*.md` 자동 추적 + 박제 제외 3건만 명시 차단 — 매번 unignore 추가 부담 0.

## 3 atomic commit

| SHA | Type | Description |
|---|---|---|
| `deeec21` | chore(skills) | vendor improve-codebase-architecture skill (5 files) |
| `1963b72` | docs(reports) | Phase H PAAR 4 high-value reports |
| `c1ffbe1` | chore(gitignore) | exclude Phase H low-value artifacts |

## 회귀 0

- src/** 수정 0건
- package.json / tsconfig.json / .dependency-cruiser.cjs 수정 0건
- verify 6단계 영향 0 (`.claude/skills/` + `docs/`는 jest/tsc 대상 외)

## Test plan
- [ ] CI green (build-and-test, commitlint, CodeRabbit)
- [ ] 머지 후 dev 브랜치에서 `git status` clean (Phase H untracked 11 files 모두 박제 또는 차단)

## References

- Phase H GO: `.plans/H-deep-module-poc/RESULT.md`
- Phase I PR-A7: PR #53 (merge commit `be180311`)
- 평가 기준: Abandonment-Cost-Scoring-Rubric (옵시디언 위키 `Guide/Abandonment-Cost-Scoring-Rubric.md`)
- 선행 ADR: ADR-006 (Phase G), ADR-007 (Phase I)

Co-authored-by: gs07103 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 아키텍처 개선 스킬 가이드 문서 추가 (용어 정의, 워크플로우, 인터페이스 설계 방법론 포함)
  * 코드베이스 구조화 및 모듈 심화 관련 내부 기술 문서 추가
  * 증명 개념(PoC) 평가 및 테스트 시나리오 명세 보고서 추가

* **Chores**
  * 빌드 산출물 무시 항목 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/54)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->