### PR TITLE
fix(engine): add audit logging to maybeTriggerDualAssignGroup

### DIFF
--- a/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
@@ -307,10 +307,17 @@ describe('dualTriggerService — Phase 17.6', () => {
       freshModule.dualTriggerService,
       'triggerAssignGroup'
     );
+    // TS-7 (J phase amend): success path silent log 검증용 spy
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
     await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('grp-006');
 
     expect(triggerSpy).toHaveBeenCalledWith('grp-006', expect.any(Array));
+    // TS-7: success path는 [2PC-trigger-skip] log emit 없음
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('[2PC-trigger-skip]')
+    );
+    consoleSpy.mockRestore();
   });
 
   // ============================================================
@@ -470,5 +477,267 @@ describe('dualTriggerService — Phase 17.6', () => {
     expect(result1).toBe(true);
     // 2회차: 이미 등록됨 → false (idempotent)
     expect(result2).toBe(false);
+  });
+
+  // ============================================================
+  // TS-1 ~ TS-6: maybeTriggerDualAssignGroup audit logging (J phase)
+  //   6 silent return reason 분기별 log emit + trigger 미호출 검증함
+  // ============================================================
+
+  it('TS-1: sessions 빈 배열 → log emit reason=no_sessions + trigger 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: { find: jest.fn().mockResolvedValue([]) },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-empty');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=no_sessions')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('groupId=g-empty')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('sessionCount=0')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-2: BTI mode → log emit reason=mode_not_dual_2pc + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-bti',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'BTI',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-bti');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=mode_not_dual_2pc')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mode=BTI')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-3: subject1 미페어링 → log emit reason=subject1_not_paired + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-s1',
+            subjectIndex: 1,
+            status: 'CREATED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-s1',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    freshModule.operatorJoinedGroups.add('g-s1');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-s1');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=subject1_not_paired')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=false')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('operatorJoined=true')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    // cleanup — Set leak 방어 (plan-review R-02)
+    freshModule.operatorJoinedGroups.delete('g-s1');
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-4: subject2 미페어링 → log emit reason=subject2_not_paired + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-s2',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-s2',
+            subjectIndex: 2,
+            status: 'CREATED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    freshModule.operatorJoinedGroups.add('g-s2');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-s2');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=subject2_not_paired')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=false')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    freshModule.operatorJoinedGroups.delete('g-s2');
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-5: operator 미참여 → log emit reason=operator_not_joined + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-op',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-op',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    // operatorJoinedGroups에 add 안 함 → operatorJoined=false 강제
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-op');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=operator_not_joined')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('operatorJoined=false')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-6: pending=1 (한쪽만 등록) → reason=pending_count_mismatch + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@07-shared/config/config', () => ({
+      config: { dataEngine: { secretKey: 'valid-secret' } },
+    }));
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-pc1',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-pc1',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const freshRegistryModule = await import('./engine-registry.service');
+    // subject 1만 등록 → pending.length = 1 → collectPendingSubjects 빈 배열 반환
+    freshRegistryModule.engineRegistryService.registerPending(
+      1,
+      'http://de-1.ngrok-free.dev',
+      'valid-secret'
+    );
+    freshModule.operatorJoinedGroups.add('g-pc1');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-pc1');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=pending_count_mismatch')
+    );
+    // pendingCount 값까지 검증 (plan-review R-01/R-03)
+    // collectPendingSubjects line 421 `pending.length < 2 ? []` → subjects.length=0
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pendingCount=0')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    // cleanup — registry + Set 양쪽 (unregisterPending: subjectIndex, url, secret)
+    freshRegistryModule.engineRegistryService.unregisterPending(
+      1,
+      'http://de-1.ngrok-free.dev',
+      'valid-secret'
+    );
+    freshModule.operatorJoinedGroups.delete('g-pc1');
+    consoleSpy.mockRestore();
   });
 });

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.ts
@@ -433,10 +433,26 @@ export const dualTriggerService: DualTriggerService = {
   async maybeTriggerDualAssignGroup(groupId) {
     // Mongoose Session 조회 — 3-condition AND 체크 (LD-1)
     const sessions = await Session.find({ groupId });
-    if (sessions.length === 0) return;
+    if (sessions.length === 0) {
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=no_sessions ` +
+          `sessionCount=0 mode=n/a subject1Paired=n/a subject2Paired=n/a ` +
+          `operatorJoined=n/a pendingCount=n/a`
+      );
+      return;
+    }
 
     const mode = sessions[0].experimentMode;
-    if (mode !== 'DUAL_2PC') return; // DUAL_2PC 모드가 아니면 skip
+    if (mode !== 'DUAL_2PC') {
+      // DUAL_2PC 모드가 아니면 skip
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=mode_not_dual_2pc ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=n/a subject2Paired=n/a operatorJoined=n/a ` +
+          `pendingCount=n/a`
+      );
+      return;
+    }
 
     const subject1Paired = sessions.some(
       (s) => s.subjectIndex === 1 && s.status === 'PAIRED'
@@ -446,12 +462,37 @@ export const dualTriggerService: DualTriggerService = {
     );
     const operatorJoined = operatorJoinedGroups.has(groupId);
 
-    // 3조건 AND 체크 (LD-1)
-    if (!subject1Paired || !subject2Paired || !operatorJoined) return;
+    // 3조건 AND 체크 (LD-1) — silent return reason 3분기 식별함
+    if (!subject1Paired || !subject2Paired || !operatorJoined) {
+      const reason = !subject1Paired
+        ? 'subject1_not_paired'
+        : !subject2Paired
+          ? 'subject2_not_paired'
+          : 'operator_not_joined';
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=${reason} ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=${subject1Paired} ` +
+          `subject2Paired=${subject2Paired} ` +
+          `operatorJoined=${operatorJoined} pendingCount=n/a`
+      );
+      return;
+    }
 
     // pending DE 정보 조회 (LD-13)
     const subjects = await dualTriggerService.collectPendingSubjects(groupId);
-    if (subjects.length !== 2) return;
+    if (subjects.length !== 2) {
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} ` +
+          `reason=pending_count_mismatch ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=${subject1Paired} ` +
+          `subject2Paired=${subject2Paired} ` +
+          `operatorJoined=${operatorJoined} ` +
+          `pendingCount=${subjects.length}`
+      );
+      return;
+    }
 
     await dualTriggerService.triggerAssignGroup(groupId, subjects);
   },


### PR DESCRIPTION
## 배경

학교 시험 DUAL_2PC 페어링 실시간 전송 실패 사고 (`.plans/_diagnostics/2026-05-13-school-pairing-2pc-failure/HANDOFF.md`)의 silent return 원인 식별을 위한 hotfix. 5/26 교수면담 전 차단 의무.

`maybeTriggerDualAssignGroup` 4 silent return 분기 (line 433-457)에 audit log를 추가하여 다음 시연 시 분기 reason을 즉시 식별 가능하도록 보강. 6 distinct reason 키를 emit.

## 변경 사항

- **production**: `dual-2pc-trigger.service.ts` — 4 silent return 직전 `console.log('[2PC-trigger-skip] ...')` emit. line 450 3-way OR을 ternary로 reason 식별 (`subject1_not_paired` / `subject2_not_paired` / `operator_not_joined`). **분기 구조 0 변경** (행위 동등성 보장)
- **test**: `dual-2pc-trigger.service.test.ts` — 6 신규 BDD 시나리오 (TS-1~6) + T-BE-6 success path silent log assertion amend (TS-7)

```
 .../services/dual-2pc-trigger.service.test.ts | 269 ++++++++++++++++++
 .../engine/services/dual-2pc-trigger.service.ts | 51 +++-
 2 files changed, 315 insertions(+), 5 deletions(-)
```

## 6 silent return reason 키

| Reason | 조건 |
|---|---|
| `no_sessions` | `Session.find({groupId})` 결과 = `[]` |
| `mode_not_dual_2pc` | `experimentMode !== 'DUAL_2PC'` |
| `subject1_not_paired` | 3-way OR 분기 — subject1 미페어링 |
| `subject2_not_paired` | 3-way OR 분기 — subject2 미페어링 |
| `operator_not_joined` | 3-way OR 분기 — operator 미참여 |
| `pending_count_mismatch` | `collectPendingSubjects.length !== 2` |

## 테스트 결과

| 항목 | 결과 |
|---|---|
| TS-1~6 신규 BDD 시나리오 | ✅ 6/6 PASS |
| TS-7 (T-BE-6 amend) success path silent log | ✅ PASS |
| T-BE-1~12 회귀 baseline | ✅ 12/12 PASS |
| 전체 dual-2pc-trigger.service.test.ts | ✅ 18/18 PASS |
| `npm run verify` 6단계 (304 tests) | ✅ GREEN (format/typecheck/depcruise/lint/test/build) |

## 회귀 시뮬레이션 — Pass-Only 트랩 회피 입증

[[feedback_bdd_tdd_not_pass_only]] 가드 2 의무 수행:

| 항목 | 내용 |
|---|---|
| 변경 위치 | `dual-2pc-trigger.service.ts` line 450 영역 ternary |
| 변경 내용 | `const reason = !subject1Paired ? 'subject1_not_paired' : ...` → `const reason = 'no_sessions';` 상수 |
| 예상 결과 | TS-3/4/5 FAIL (reason 키 매칭 깨짐) |
| 실제 결과 | ✅ 3 failed, 15 skipped, 18 total (TS-3/4/5 명확히 FAIL) |
| 복구 후 | ✅ 18/18 PASS 재확인 |

**결론**: BDD 시나리오 TS-3/4/5가 production 1줄 변경에 정확히 반응 — `expect.stringContaining('reason=X')` assertion이 실제 외부 관찰 가능한 행위 (log reason 키)를 검증. trivial/tautological 테스트 아님.

## 영향도

- 신규 endpoint 0 / 신규 dependency 0 / FSD 경계 무위반
- 회귀 0건 — T-BE-1~12 baseline 유지
- 동작 변경 0 — 순수 observability 추가 (silent return 동작 보존)

## Refs

- `.plans/_diagnostics/2026-05-13-school-pairing-2pc-failure/HANDOFF.md` (사고 진단)
- `.plans/J-dual-2pc-audit-logging/{DISCUSS,PLAN,CHECKLIST}.md` (워크플로우 산출물)
- plan-review Round 1 결과: Critical 0 / High 2 / Medium 4 → 6 정정 후 PROCEED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 이중 트랜잭션 처리 시나리오에 대한 감시 로깅 테스트 확대 (6개의 새로운 테스트 케이스 추가)
  * 조건별 조기 반환 경로 검증 강화

* **Bug Fixes**
  * 이중 트랜잭션 처리 중 조기 반환 시 상세 로그 정보 추가로 디버깅 가능성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/55)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->