### PR TITLE
feat(sessions): add admin force-pair endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,8 @@ ASK_USER=mks004@neurosignal.kr
 # ======================
 DUAL_2PC_TIMESTAMP_TOLERANCE_MS=200
 DUAL_2PC_REGISTRATION_TIMEOUT_MS=60000
+
+# ======================
+# K phase 강제 페어링 admin allowlist (콤마 구분, 자동 lowercase normalize)
+# ======================
+ADMIN_EMAILS=

--- a/src/05-features/sessions/api/session.controller.ts
+++ b/src/05-features/sessions/api/session.controller.ts
@@ -6,6 +6,7 @@ import {
 import { submitConsentProcess } from '@05-features/sessions/services/submit-consent.service';
 import { createOperatorInviteToken } from '@05-features/sessions/services/invite-operator.service';
 import { joinAsOperator } from '@05-features/sessions/services/join-operator.service';
+import { adminPairDeviceProcess } from '@05-features/sessions/services/admin-pair.service';
 import { AppError } from '@07-shared/errors';
 import {
   pairDeviceSchema,
@@ -129,6 +130,36 @@ export const pairDevice = async (
       status: 'success',
       data: session,
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * [Controller] 관리자 강제 페어링 처리함.
+ *
+ * @throws AppError 401 — admin/타겟 user 미존재
+ * @throws AppError 403 — 관리자 권한 없음
+ * @throws AppError 404 — target email DB 미존재
+ */
+export const adminPairDevice = async (
+  req: AuthedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { pairingToken } = req.params;
+    // validate middleware가 body를 adminPairSchema로 parse 후 교체함
+    const { email } = req.body as { email: string };
+
+    if (!req.user || !req.user.id) {
+      throw new AppError('인증이 필요한 서비스입니다.', 401);
+    }
+    const adminId = req.user.id;
+
+    const session = await adminPairDeviceProcess(pairingToken, email, adminId);
+
+    res.status(200).json({ status: 'success', data: session });
   } catch (error) {
     next(error);
   }

--- a/src/05-features/sessions/api/session.routes.adminpair.test.ts
+++ b/src/05-features/sessions/api/session.routes.adminpair.test.ts
@@ -1,0 +1,149 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { Types } from 'mongoose';
+
+// env는 모듈 로딩 전에 설정 — config.ts 초기 평가에 영향
+process.env.JWT_SECRET_KEY = 'test-secret';
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.ADMIN_EMAILS = 'admin-test@example.com';
+
+// hoist-safe — factory 내부는 리터럴만 사용
+jest.mock('@06-entities/users/model/user.schema', () => {
+  const ChainedQuery = (resolveValue: unknown) => ({
+    lean: jest.fn().mockResolvedValue(resolveValue),
+  });
+  return {
+    __esModule: true,
+    default: {
+      findById: jest.fn((id: string) => {
+        if (id === 'ADMIN_ID_LITERAL') {
+          return ChainedQuery({ email: 'admin-test@example.com' });
+        }
+        if (id === 'NON_ADMIN_ID_LITERAL') {
+          return ChainedQuery({ email: 'normal@user.com' });
+        }
+        return ChainedQuery(null);
+      }),
+      findOne: jest.fn((filter: { email: string }) => {
+        if (filter.email === 'target@example.com') {
+          return {
+            lean: jest.fn().mockResolvedValue({
+              _id: new Types.ObjectId('507f191e810c19729de860ea'),
+            }),
+          };
+        }
+        return { lean: jest.fn().mockResolvedValue(null) };
+      }),
+    },
+  };
+});
+
+jest.mock('@05-features/sessions/services/pairing.service', () => ({
+  pairDeviceProcess: jest.fn().mockResolvedValue({
+    _id: 'sess-int-1',
+    groupId: 'g-int',
+    subjectIndex: 1,
+    status: 'PAIRED',
+  }),
+  addPairingCompleteListener: jest.fn(),
+  pairingListeners: new Set(),
+}));
+
+import sessionRoutes from './session.routes';
+import { AppError } from '@07-shared/errors';
+
+// bare Express app — mongoose connect 없음, app.ts side-effect 회피
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/sessions', sessionRoutes);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof AppError) {
+      return res.status(err.statusCode).json({
+        status: err.statusCode >= 500 ? 'error' : 'fail',
+        message: err.message,
+      });
+    }
+    return res.status(500).json({ status: 'error', message: 'internal' });
+  });
+  return app;
+};
+
+const makeToken = (userId: string) =>
+  jwt.sign({ id: userId }, 'test-secret', { expiresIn: '1h' });
+
+describe('POST /api/sessions/:pairingToken/admin-pair (integration)', () => {
+  const app = buildApp();
+
+  // I-1
+  it('I-1: Happy path — admin JWT + valid target email → 200 + session', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'success',
+      data: expect.objectContaining({ _id: 'sess-int-1' }),
+    });
+  });
+
+  // I-2
+  it('I-2: non-admin JWT → 403', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('NON_ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('관리자'),
+    });
+  });
+
+  // I-3
+  it('I-3: JWT missing → 401', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(401);
+  });
+
+  // I-4 — route 미등록 404 vs service 404 구분
+  it('I-4: target email 미존재 → 404 + service-level 메시지', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'missing@example.com' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('대상 사용자'),
+    });
+  });
+
+  // I-5 — Zod strict mass-assignment 방어
+  it('I-5: body에 추가 필드 → 400', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com', isAdmin: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  // I-6 — email normalize (대소문자/공백)
+  it('I-6: body email 대소문자/공백 → normalize 후 200', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: '  TARGET@example.com  ' });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/05-features/sessions/api/session.routes.ts
+++ b/src/05-features/sessions/api/session.routes.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import * as sessionsController from './session.controller';
 import { authenticate, validate } from '@07-shared/middlewares'; // 인증 및 Zod body 검증 미들웨어
+import { requireAdmin } from '../middlewares/require-admin.middleware'; // K phase admin gate
 import { createSessionSchema } from './session.schema'; // 세션 생성 스키마
+import { adminPairSchema } from '../dto/session.dto'; // K phase 강제 페어링 body 스키마
 
 const router = Router();
 
@@ -206,6 +208,15 @@ router.post(
  */
 
 router.post('/:pairingToken/pair', authenticate, sessionsController.pairDevice);
+
+// K phase 관리자 강제 페어링 — chain: authenticate → requireAdmin → validate → controller
+router.post(
+  '/:pairingToken/admin-pair',
+  authenticate,
+  requireAdmin,
+  validate(adminPairSchema),
+  sessionsController.adminPairDevice
+);
 
 /**
  * @openapi

--- a/src/05-features/sessions/dto/session.dto.ts
+++ b/src/05-features/sessions/dto/session.dto.ts
@@ -21,3 +21,13 @@ export const submitConsentSchema = z.object({
 });
 
 export type SubmitConsentDto = z.infer<typeof submitConsentSchema>;
+
+// 강제 페어링 body 검증 — Zod strict() mass-assignment 방어함
+// .trim() 적용으로 normalize 시나리오가 schema 차원에서 차단되지 않게 처리함
+export const adminPairSchema = z
+  .object({
+    email: z.string().trim().email('유효한 이메일 형식이어야 합니다.'),
+  })
+  .strict();
+
+export type AdminPairDto = z.infer<typeof adminPairSchema>;

--- a/src/05-features/sessions/middlewares/require-admin.middleware.test.ts
+++ b/src/05-features/sessions/middlewares/require-admin.middleware.test.ts
@@ -1,0 +1,80 @@
+import { Response, NextFunction } from 'express';
+
+jest.mock('@07-shared/config/config', () => ({
+  config: { adminEmails: ['admin@example.com'] },
+}));
+
+const mockFindById = jest.fn();
+jest.mock('@06-entities/users/model/user.schema', () => ({
+  __esModule: true,
+  default: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+import { requireAdmin } from './require-admin.middleware';
+import { AppError } from '@07-shared/errors';
+
+const makeReq = (userId?: string) =>
+  ({
+    user: userId ? { id: userId } : undefined,
+  }) as Parameters<typeof requireAdmin>[0];
+
+const res = {} as Response;
+
+describe('requireAdmin middleware', () => {
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindById.mockReset();
+    next = jest.fn();
+  });
+
+  // M-1
+  it('M-1: admin email allowlist 통과 → next() 호출됨', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'admin@example.com' }),
+    });
+    await requireAdmin(makeReq('admin-id'), res, next as NextFunction);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  // M-2
+  it('M-2: req.user.id 누락 → 401', async () => {
+    await requireAdmin(makeReq(undefined), res, next as NextFunction);
+    expect(next).toHaveBeenCalledWith(expect.any(AppError));
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(401);
+  });
+
+  // M-3
+  it('M-3: DB stale (findById 결과 null) → 401', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue(null),
+    });
+    await requireAdmin(makeReq('stale-id'), res, next as NextFunction);
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(401);
+  });
+
+  // M-4
+  it('M-4: user email이 allowlist 미포함 → 403', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'normal@user.com' }),
+    });
+    await requireAdmin(makeReq('user-id'), res, next as NextFunction);
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(403);
+  });
+
+  // M-5
+  it('M-5: findById 호출 시 projection {email:1} 적용됨', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'admin@example.com' }),
+    });
+    await requireAdmin(makeReq('admin-id'), res, next as NextFunction);
+    expect(mockFindById).toHaveBeenCalledWith('admin-id', { email: 1 });
+  });
+});

--- a/src/05-features/sessions/middlewares/require-admin.middleware.ts
+++ b/src/05-features/sessions/middlewares/require-admin.middleware.ts
@@ -1,0 +1,37 @@
+import { Response, NextFunction } from 'express';
+import { config } from '@07-shared/config/config';
+import { AppError } from '@07-shared/errors';
+import { AuthedRequest } from '@07-shared/types';
+import User from '@06-entities/users/model/user.schema';
+
+/**
+ * 관리자 권한 검증 미들웨어 — authenticate 이후에 chain됨.
+ *
+ * @param req - AuthedRequest (req.user.id JWT payload 주입 후)
+ * @param _res - 응답 객체 미사용
+ * @param next - 다음 미들웨어 호출 함수
+ * @throws AppError 401 — req.user.id 누락 또는 DB stale
+ * @throws AppError 403 — user.email이 ADMIN_EMAILS 미포함
+ */
+export const requireAdmin = async (
+  req: AuthedRequest,
+  _res: Response,
+  next: NextFunction
+) => {
+  try {
+    if (!req.user?.id) {
+      return next(new AppError('인증이 필요합니다.', 401));
+    }
+    // projection {email:1}로 PII 최소화 + lean()으로 hydrated overhead 제거함
+    const user = await User.findById(req.user.id, { email: 1 }).lean();
+    if (!user) {
+      return next(new AppError('사용자를 찾을 수 없습니다.', 401));
+    }
+    if (!config.adminEmails.includes(user.email)) {
+      return next(new AppError('관리자 권한이 필요합니다.', 403));
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/05-features/sessions/services/admin-pair.service.test.ts
+++ b/src/05-features/sessions/services/admin-pair.service.test.ts
@@ -1,0 +1,128 @@
+import { Types } from 'mongoose';
+
+const mockFindOne = jest.fn();
+const mockPairDeviceProcess = jest.fn();
+
+jest.mock('@06-entities/users/model/user.schema', () => ({
+  __esModule: true,
+  default: { findOne: (...args: unknown[]) => mockFindOne(...args) },
+}));
+jest.mock('./pairing.service', () => ({
+  pairDeviceProcess: (...args: unknown[]) => mockPairDeviceProcess(...args),
+}));
+
+import { adminPairDeviceProcess } from './admin-pair.service';
+
+// .lean() chain helper — Mongoose Query stub
+const leanReturning = (value: unknown) => ({
+  lean: jest.fn().mockResolvedValue(value),
+});
+
+const ADMIN_ID = new Types.ObjectId().toString();
+const TARGET_ID = new Types.ObjectId();
+const TARGET_ID_STR = TARGET_ID.toString();
+
+describe('adminPairDeviceProcess', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // AS-1
+  it('AS-1: target email 정상 → pairDeviceProcess 호출 + success log emit', async () => {
+    mockFindOne.mockReturnValue(leanReturning({ _id: TARGET_ID }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-1',
+      groupId: 'g-1',
+      subjectIndex: 1,
+    });
+
+    const result = await adminPairDeviceProcess(
+      'token-x',
+      'user@example.com',
+      ADMIN_ID
+    );
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      { email: 'user@example.com' },
+      { _id: 1 }
+    );
+    expect(mockPairDeviceProcess).toHaveBeenCalledWith(
+      'token-x',
+      TARGET_ID_STR
+    );
+    expect(result._id).toBe('sess-1');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[admin-force-pair] outcome=success')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`adminId=${ADMIN_ID}`)
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`targetUserId=${TARGET_ID_STR}`)
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('isSelf=false')
+    );
+  });
+
+  // AS-2
+  it('AS-2: target email 미존재 → 404 + failure log emit', async () => {
+    mockFindOne.mockReturnValue(leanReturning(null));
+
+    await expect(
+      adminPairDeviceProcess('token-x', 'missing@example.com', ADMIN_ID)
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[admin-force-pair] outcome=failure')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=target_user_not_found')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('targetEmail=missing@example.com')
+    );
+    expect(mockPairDeviceProcess).not.toHaveBeenCalled();
+  });
+
+  // AS-3
+  it('AS-3: isSelf=true (admin이 자기 자신 강제 페어링)', async () => {
+    const sameAsAdmin = new Types.ObjectId(ADMIN_ID);
+    mockFindOne.mockReturnValue(leanReturning({ _id: sameAsAdmin }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-2',
+      groupId: 'g-2',
+      subjectIndex: 1,
+    });
+
+    await adminPairDeviceProcess('token-y', 'admin@example.com', ADMIN_ID);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('isSelf=true')
+    );
+  });
+
+  // AS-4
+  it('AS-4: email normalize (대소문자 + 공백) — DB lookup은 normalized 값', async () => {
+    mockFindOne.mockReturnValue(leanReturning({ _id: TARGET_ID }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-3',
+      groupId: 'g-3',
+      subjectIndex: 1,
+    });
+
+    await adminPairDeviceProcess('token-z', '  Admin@Example.COM  ', ADMIN_ID);
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      { email: 'admin@example.com' },
+      { _id: 1 }
+    );
+  });
+});

--- a/src/05-features/sessions/services/admin-pair.service.ts
+++ b/src/05-features/sessions/services/admin-pair.service.ts
@@ -1,0 +1,48 @@
+import { AppError } from '@07-shared/errors';
+import User from '@06-entities/users/model/user.schema';
+import { pairDeviceProcess } from './pairing.service';
+
+/**
+ * 관리자가 사용자 email로 강제 페어링 처리함.
+ *
+ * 기존 pairDeviceProcess 재사용으로 pairing listener fire + DUAL_2PC trigger
+ * audit log (J phase) 자동 정합 유지.
+ *
+ * @param pairingToken - 세션 페어링 토큰
+ * @param targetEmail - 페어링 대상 user의 email (normalize 후 lookup함)
+ * @param adminId - 호출자 admin user의 _id (audit log 박제용)
+ * @returns 페어링 완료된 Session document
+ * @throws AppError 404 — target email DB 미존재
+ * @throws AppError - pairDeviceProcess 기존 throw 전파 (401/400 등)
+ */
+export const adminPairDeviceProcess = async (
+  pairingToken: string,
+  targetEmail: string,
+  adminId: string
+) => {
+  const normalized = targetEmail.trim().toLowerCase();
+  const targetUser = await User.findOne(
+    { email: normalized },
+    { _id: 1 }
+  ).lean();
+  if (!targetUser) {
+    console.log(
+      `[admin-force-pair] outcome=failure reason=target_user_not_found ` +
+        `adminId=${adminId} targetEmail=${normalized}`
+    );
+    throw new AppError('대상 사용자를 찾을 수 없습니다.', 404);
+  }
+
+  // lean() 도 ObjectId 반환함 — toString() 안전
+  const targetUserId = targetUser._id.toString();
+  const session = await pairDeviceProcess(pairingToken, targetUserId);
+
+  console.log(
+    `[admin-force-pair] outcome=success adminId=${adminId} ` +
+      `targetUserId=${targetUserId} ` +
+      `isSelf=${adminId === targetUserId} ` +
+      `sessionId=${session._id} groupId=${session.groupId} ` +
+      `subjectIndex=${session.subjectIndex}`
+  );
+  return session;
+};

--- a/src/07-shared/config/config.ts
+++ b/src/07-shared/config/config.ts
@@ -26,6 +26,19 @@ if (nodeEnv !== 'test') {
   });
 }
 
+// 3.5 강제 페어링 admin allowlist — env ADMIN_EMAILS 콤마 구분, lowercase normalize함
+const adminEmails: readonly string[] = (process.env.ADMIN_EMAILS ?? '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+// production 환경에서 ADMIN_EMAILS 누락 시 startup fail-fast 처리함
+if (nodeEnv === 'production' && adminEmails.length === 0) {
+  throw new Error(
+    'Critical Error: ADMIN_EMAILS 환경변수가 production에서 설정되지 않았습니다.'
+  );
+}
+
 // 4. 설정 객체 내보내기
 export const config = {
   env: nodeEnv,
@@ -66,6 +79,8 @@ export const config = {
   kakaoClientId: process.env.KAKAO_CLIENT_ID,
   kakaoClientSecret: process.env.KAKAO_CLIENT_SECRET,
   kakaoRedirectUri: process.env.KAKAO_REDIRECT_URI,
+  // K phase 강제 페어링 admin allowlist — lowercase normalize됨
+  adminEmails,
   // Phase 16 DUAL_2PC 타임스탬프 정렬 설정 (optional — 기본값 사용 가능)
   dualPc: {
     // plan-review M-4: 편도 50ms + NTP skew 50ms = 200ms 기본값


### PR DESCRIPTION
## 배경

K phase 강제 페어링 BE endpoint 추가. 5/26 시연 시 QR 카메라 페어링 실패에 대한 admin(팀장 단독 운영) 우회 경로 제공.

`ADMIN_EMAILS` env allowlist + DB lookup middleware로 보호. 기존 `pairDeviceProcess` 재사용으로 [J phase audit log](https://github.com/KWONSEOK02/mind-signal-backend/pull/55)와 자동 정합.

## 변경 사항

- **middleware**: `require-admin` (`05-features/sessions/middlewares/`) — JWT authenticate 후 DB lookup으로 email allowlist 확인 (FSD 정합 — codex C1)
- **service**: `adminPairDeviceProcess(token, email, adminId)` — server-side `trim().toLowerCase()` normalize + `[admin-force-pair] outcome=success|failure ...` audit log
- **endpoint**: `POST /api/sessions/:pairingToken/admin-pair` body `{ email }` (Zod `.strict().trim()`)
- **config**: `ADMIN_EMAILS` env + production startup fail-fast
- **test**: 15 신규 (M-1~5 / AS-1~4 / I-1~6) + 회귀 시뮬레이션 PASS

```
 .env.example                                                          |   5 +
 src/05-features/sessions/api/session.controller.ts                    |  31 ++
 src/05-features/sessions/api/session.routes.ts                        |  11 +
 src/05-features/sessions/api/session.routes.adminpair.test.ts         | 149 ++++
 src/05-features/sessions/dto/session.dto.ts                           |  10 +
 src/05-features/sessions/middlewares/require-admin.middleware.ts      |  35 ++
 src/05-features/sessions/middlewares/require-admin.middleware.test.ts |  79 ++
 src/05-features/sessions/services/admin-pair.service.ts               |  51 ++
 src/05-features/sessions/services/admin-pair.service.test.ts          | 127 +++
 src/07-shared/config/config.ts                                        |  15 +
 10 files changed, 514 insertions(+)
```

## 미들웨어 chain

`authenticate → requireAdmin → validate(adminPairSchema) → adminPairDevice controller`

## 응답 코드

| 상황 | 응답 |
|---|---|
| Happy path | 200 + `{ status: 'success', data: <Session> }` |
| JWT 누락/invalid | 401 (authenticate) |
| req.user.id DB stale | 401 (requireAdmin) |
| user.email 미allowlist | 403 (requireAdmin) |
| Zod validation 실패 | 400 (validate) |
| target email 미존재 | 404 (admin-pair.service) |
| 만료 토큰 / 잘못된 상태 | 401 / 400 (pairDeviceProcess 기존 동작) |

## 테스트 결과

| 항목 | 결과 |
|---|---|
| M-1~5 require-admin middleware (5건) | ✅ PASS |
| AS-1~4 admin-pair.service (4건) | ✅ PASS |
| I-1~6 integration endpoint (6건) | ✅ PASS |
| 회귀 baseline (304 tests) | ✅ PASS |
| `npm run verify` 6단계 | ✅ GREEN (format/typecheck/depcruise/lint/test/build) |

## 회귀 시뮬레이션 — Pass-Only 트랩 회피 입증

[[feedback_bdd_tdd_not_pass_only]] 가드 2 의무:

| 항목 | 내용 |
|---|---|
| 변경 위치 | `require-admin.middleware.ts` line ~28 |
| 변경 내용 | `if (!config.adminEmails.includes(user.email))` → `if (false)` 임시 변경 (allowlist 무력화) |
| 예상 결과 | M-4 (allowlist 미포함 user → 403) + I-2 (non-admin JWT → 403) FAIL |
| 실제 결과 | ✅ **2 failed, 9 passed, 11 total** (M-4 + I-2 정확히 FAIL) |
| 실제 출력 (I-2) | `Expected: 403` / `Received: 200` (admin gate 미동작으로 happy path 응답) |
| 복구 후 | ✅ 15/15 PASS + verify GREEN 재확인 |

**결론**: BDD 시나리오가 production 1줄 변경에 정확히 반응 — `expect.stringContaining('관리자')` + `expect(res.status).toBe(403)` assertion이 실제 행위(403 응답 + 한국어 message)를 검증.

## codex Round 1+2 PROCEED-WITH-CONDITIONS 정정 반영

codex 5.5 thread `019e21b9` 양 라운드 합산 13 정정 + 7 권장 모두 PLAN.md rev.2 + 실제 구현 반영:
- C1 (FSD): middleware `05-features/sessions/middlewares/` 위치 정합
- C2 (signature): `(token, email, adminId)` 3-arg
- C3 (race): `K-followup-backlog` F-01 분리
- A (self-pair): 허용 + `isSelf=true/false` audit
- B (DB query): 매 요청 + `{ email: 1 }` projection + `.lean()`
- C (prefix): `[admin-force-pair] outcome=...`
- D (normalize): server-side `trim().toLowerCase()`
- E (Zod): `.strict().trim()` mass-assignment 방어
- F (PII): success는 targetUserId, 404만 targetEmail
- G (auto-trigger): DUAL_2PC trigger 자동 발화 유지

Opus `feature-dev:code-reviewer` 독립 cross-review에서 발견한 R-02/R-04/R-07/R-08/R-09 + T10-1~4 / Wave-1 / Risk-1 / A-G-1 모두 반영.

> **Opus R-01 (Zod v4 `.strict()` API break)** 은 false positive 확인 — `node -e` 실측으로 `typeof s.strict === 'function'` 검증 (Zod 4.3.4).

## 후속 TODO 분리 박제 (K-followup-backlog)

본 phase scope 외 5 아이템 별도 박제:
- **F-01**: `pairDeviceProcess` race fix (atomic `findOneAndUpdate`) — admin 1명 단독 운영으로 위험도 0
- **F-02**: target email hash audit (PII 추가 보호)
- **F-03**: requireAdmin 403 security event log
- **F-04**: multi-dyno scale-out (`operatorJoinedGroups` Set) — 별도 ADR 후보
- **F-05**: dev mode 진입 BE audit endpoint (FE phase 후속)

## 운영 후속

- Heroku Config Vars `ADMIN_EMAILS=gwonseok02@gmail.com` 설정 (merge 후)
- FE phase `K-dev-mode-force-pair` 별도 시작 (5-tap entry + 입력 form)
- dev DB `gwonseok02@gmail.com` user 존재 확인됨 (MCP 검증 완료, `_id=69bac04ff41da5cb04573d48`)

## Refs

- `.plans/K-admin-force-pair/{DISCUSS,PLAN,CHECKLIST}.md`
- `.plans/K-followup-backlog/BACKLOG.md` (5 아이템 분리)
- `.plans/_diagnostics/2026-05-13-school-pairing-2pc-failure/HANDOFF.md` (사고 baseline)
- codex thread `019e21b9-8cfa-7561-b330-0a2604f1e353` (Round 1+2 cross-validation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 사용자 디바이스를 강제로 페어링할 수 있는 새로운 관리 기능이 추가되었습니다. 관리자 이메일 기반 권한 검증을 포함하며, 이메일 주소로 대상 사용자를 식별하여 디바이스 페어링 프로세스를 수행할 수 있습니다.

* **테스트**
  * 관리자 페어링 엔드포인트, 권한 검증, 서비스 로직에 대한 종합 테스트 스위트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/56)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->