### PR TITLE
fix(measurement): unref dual-2pc flush interval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md
 # Project planning (local only)
 .plans/
 context/
+
+# AI 에이전트 문서 (마인드 시그널 한정 — 본인만 사용, 팀 공유 안 함)
+# Why: 마인드 시그널은 이 패턴 적용을 본인 학습용으로 유지하고 다른 프로젝트에 templating할 예정.
+# 다른 모델 세션이 자동으로 추적 시도하지 않도록 .git/info/exclude 대신 .gitignore에 명시.
+AGENTS.md
+CLAUDE.md
+.agents/

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -83,6 +83,8 @@ async function subscribeWithAligner(groupId: string): Promise<void> {
   const intervalId = setInterval(() => {
     timestampAlignerRegistry.flush(groupId);
   }, 100);
+  // process 종료 시 flush 타이머가 Jest/Node를 block하지 않도록 unref 적용함
+  intervalId.unref();
   groupFlushIntervals.set(groupId, intervalId);
 }
 


### PR DESCRIPTION
## Summary

- DUAL_2PC `subscribeWithAligner` 내부 100ms flush `setInterval`이 `.unref()` 누락으로 `jest --detectOpenHandles` 실행 시 worker가 영구 hang.
- `dual-2pc-trigger.service.ts` staleLockTimer/gcTimer 동일 패턴으로 `intervalId.unref()` 1줄 추가.
- 부산물: `package-lock.json` node engines 항목을 main `cd37381`(`>=20.10.0`)과 sync (별도 chore commit).

## Diagnosis

Call chain (code-review-graph 검증):
```
measurement.service.dual2pc.runtime.test.ts
  → startMeasurementService → startDualMeasurement → subscribeWithAligner
        → setInterval(flush, 100)  ← unref 없음, 테스트 cleanup 경로 X
```
- `unsubscribeGroupChannels`의 유일한 caller는 `stopMeasurementService` (production HTTP route).
- 테스트는 `start` 후 `stop`을 호출하지 않으므로 production cleanup 미진입 → interval 영구 alive → worker hang.

Production 영향 0 — 운영 시 socket.io/redis 등 다른 핸들이 process alive 유지.

## Verification

```
npm test -- --detectOpenHandles
# Before: Tests: 319 passed, "A worker process has failed to exit gracefully" + hang
# After:  Tests: 319 passed, no warnings, exit 0 (37.2s)
```

## Test plan

- [ ] CI green (lint / typecheck / depcruise / test / build)
- [ ] `npm test -- --detectOpenHandles` 로컬 재현 — exit 0 + 경고 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 프로세스 종료 시 타이머가 실행을 블로킹하지 않도록 개선했습니다.

* **Chores**
  * AI 에이전트 관련 문서를 버전 관리에서 제외하도록 설정했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/57)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->