### PR TITLE
release: sync dev to main (PR #51-#57)

### DIFF
--- a/.claude/skills/improve-codebase-architecture/DEEPENING.md
+++ b/.claude/skills/improve-codebase-architecture/DEEPENING.md
@@ -1,0 +1,37 @@
+# Deepening
+
+How to deepen a cluster of shallow modules safely, given its dependencies. Assumes the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**.
+
+## Dependency categories
+
+When assessing a candidate for deepening, classify its dependencies. The category determines how the deepened module is tested across its seam.
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — merge the modules and test through the new interface directly. No adapter needed.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (PGLite for Postgres, in-memory filesystem). Deepenable if the stand-in exists. The deepened module is tested with the stand-in running in the test suite. The seam is internal; no port at the module's external interface.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a **port** (interface) at the seam. The deep module owns the logic; the transport is injected as an **adapter**. Tests use an in-memory adapter. Production uses an HTTP/gRPC/queue adapter.
+
+Recommendation shape: *"Define a port at the seam, implement an HTTP adapter for production and an in-memory adapter for testing, so the logic sits in one deep module even though it's deployed across a network."*
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. The deepened module takes the external dependency as an injected port; tests provide a mock adapter.
+
+## Seam discipline
+
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a port unless at least two adapters are justified (typically production + test). A single-adapter seam is just indirection.
+- **Internal seams vs external seams.** A deep module can have internal seams (private to its implementation, used by its own tests) as well as the external seam at its interface. Don't expose internal seams through the interface just because tests use them.
+
+## Testing strategy: replace, don't layer
+
+- Old unit tests on shallow modules become waste once tests at the deepened module's interface exist — delete them.
+- Write new tests at the deepened module's interface. The **interface is the test surface**.
+- Tests assert on observable outcomes through the interface, not internal state.
+- Tests should survive internal refactors — they describe behaviour, not implementation. If a test has to change when the implementation changes, it's testing past the interface.

--- a/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
+++ b/.claude/skills/improve-codebase-architecture/INTERFACE-DESIGN.md
@@ -1,0 +1,44 @@
+# Interface Design
+
+When the user wants to explore alternative interfaces for a chosen deepening candidate, use this parallel sub-agent pattern. Based on "Design It Twice" (Ousterhout) — your first idea is unlikely to be the best.
+
+Uses the vocabulary in [LANGUAGE.md](LANGUAGE.md) — **module**, **interface**, **seam**, **adapter**, **leverage**.
+
+## Process
+
+### 1. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would rely on, and which category they fall into (see [DEEPENING.md](DEEPENING.md))
+- A rough illustrative code sketch to ground the constraints — not a proposal, just a way to make the constraints concrete
+
+Show this to the user, then immediately proceed to Step 2. The user reads and thinks while the sub-agents work in parallel.
+
+### 2. Spawn sub-agents
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1–3 entry points max. Maximise leverage per entry point."
+- Agent 2: "Maximise flexibility — support many use cases and extension."
+- Agent 3: "Optimise for the most common caller — make the default case trivial."
+- Agent 4 (if applicable): "Design around ports & adapters for cross-seam dependencies."
+
+Include both [LANGUAGE.md](LANGUAGE.md) vocabulary and CONTEXT.md vocabulary in the brief so each sub-agent names things consistently with the architecture language and the project's domain language.
+
+Each sub-agent outputs:
+
+1. Interface (types, methods, params — plus invariants, ordering, error modes)
+2. Usage example showing how callers use it
+3. What the implementation hides behind the seam
+4. Dependency strategy and adapters (see [DEEPENING.md](DEEPENING.md))
+5. Trade-offs — where leverage is high, where it's thin
+
+### 3. Present and compare
+
+Present designs sequentially so the user can absorb each one, then compare them in prose. Contrast by **depth** (leverage at the interface), **locality** (where change concentrates), and **seam placement**.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not a menu.

--- a/.claude/skills/improve-codebase-architecture/LANGUAGE.md
+++ b/.claude/skills/improve-codebase-architecture/LANGUAGE.md
@@ -1,0 +1,53 @@
+# Language
+
+Shared vocabulary for every suggestion this skill makes. Use these terms exactly — don't substitute "component," "service," "API," or "boundary." Consistent language is the whole point.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"**: overloaded with DDD's bounded context. Say **seam** or **interface**.

--- a/.claude/skills/improve-codebase-architecture/SKILL.md
+++ b/.claude/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: improve-codebase-architecture
+description: Find deepening opportunities in a codebase, informed by the domain language in CONTEXT.md and the decisions in docs/adr/. Use when the user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more testable and AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The aim is testability and AI-navigability.
+
+## Glossary
+
+Use these terms exactly in every suggestion. Consistent language is the point — don't drift into "component," "service," "API," or "boundary." Full definitions in [LANGUAGE.md](LANGUAGE.md).
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know to use the module: types, invariants, error modes, ordering, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface: a lot of behaviour behind a small interface. **Deep** = high leverage. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place. (Use this, not "boundary.")
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (see [LANGUAGE.md](LANGUAGE.md) for the full list):
+
+- **Deletion test**: imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+This skill is _informed_ by the project's domain model. The domain language gives names to good seams; ADRs record decisions the skill should not re-litigate.
+
+## Process
+
+### 1. Explore
+
+Read the project's domain glossary and any ADRs in the area you're touching first.
+
+Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+
+Apply the **deletion test** to anything you suspect is shallow: would deleting it concentrate complexity, or just move it? A "yes, concentrates" is the signal you want.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate:
+
+- **Files** — which files/modules are involved
+- **Problem** — why the current architecture is causing friction
+- **Solution** — plain English description of what would change
+- **Benefits** — explained in terms of locality and leverage, and also in how tests would improve
+
+**Use CONTEXT.md vocabulary for the domain, and [LANGUAGE.md](LANGUAGE.md) vocabulary for the architecture.** If `CONTEXT.md` defines "Order," talk about "the Order intake module" — not "the FooBarHandler," and not "the Order service."
+
+**ADR conflicts**: if a candidate contradicts an existing ADR, only surface it when the friction is real enough to warrant revisiting the ADR. Mark it clearly (e.g. _"contradicts ADR-0007 — but worth reopening because…"_). Don't list every theoretical refactor an ADR forbids.
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. Grilling loop
+
+Once the user picks a candidate, drop into a grilling conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+Side effects happen inline as decisions crystallize:
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
+- **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/.claude/skills/improve-codebase-architecture/_local-addendum.md
+++ b/.claude/skills/improve-codebase-architecture/_local-addendum.md
@@ -1,0 +1,85 @@
+# Local Addendum — Mind Signal H-deep-module-poc 적용 노트
+
+> 작성일: 2026-05-13
+> 대상: `improve-codebase-architecture` skill의 Mind Signal 컨텍스트 변형 박제
+> 원본 4 파일 (SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN.md)은 byte-identical 유지 — 본 addendum은 PoC 적용 변형만 다룸
+
+---
+
+## 1. HANDOFF tentative 임계값 폐기 — "depth = behavior / interface lines, threshold 2.0"
+
+`.plans/H-deep-module-poc/HANDOFF.md` §5 Step 2와 §7 미결 사항에 박제된 잠정 공식:
+
+```
+depth = behavior_size / public_interface_size — 임계값 2.0 잠정
+```
+
+**이 공식은 본 PoC에서 사용하지 않음.** 근거: `LANGUAGE.md` §"Rejected framings" 1번 항목.
+
+> "Depth as ratio of implementation-lines to interface-lines (Ousterhout): rewards padding the implementation. We use depth-as-leverage instead."
+
+Matt Pocock 본인이 명시적으로 거부한 측정. 임계값 2.0을 적용하면 PoC가 끼워맞추기 위험(`feedback_no_fabricated_evidence` 위반)에 노출됨.
+
+## 2. 대체 측정 — 정성 평가 3축
+
+원문 SKILL.md + LANGUAGE.md + DEEPENING.md에서 직접 인용 가능한 측정 도구:
+
+### 2.1 Deletion test (SKILL.md §Glossary, LANGUAGE.md §Principles)
+> "Imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep."
+
+3 클래스 각각에 대해 적용:
+- 결과 = "complexity vanishes" → shallow
+- 결과 = "complexity reappears across N callers" → deep
+
+### 2.2 Interface complexity ≈ implementation complexity (LANGUAGE.md §Depth)
+> "Shallow when the interface is nearly as complex as the implementation."
+
+정량 ratio 대신 정성 비교 — public method 수 / invariant 수 / error mode 수와 implementation 분기 수 / 외부 호출 수의 대략적 정합 평가.
+
+### 2.3 Dependency 4 categories (DEEPENING.md §Dependency categories)
+1. **In-process** — pure computation, in-memory state, no I/O
+2. **Local-substitutable** — PGLite, in-memory FS 등 local stand-in 보유
+3. **Remote but owned** — Ports & Adapters, port + 2 adapter
+4. **True external** — Stripe/Twilio 같은 third-party
+
+각 클래스의 외부 의존을 4 카테고리로 분류 → adapter 후보 판별.
+
+## 3. Seam discipline (DEEPENING.md + LANGUAGE.md)
+
+> "One adapter means a hypothetical seam. Two adapters means a real one."
+
+PoC Pass 기준 B (adapter 후보 ≥ 3)는 본 원칙과 정합:
+- 후보 = 2 adapter 이상 정당화 가능한 seam만 카운트
+- 단일 adapter 인디렉션은 후보에서 제외
+
+## 4. CONTEXT.md 부재 처리
+
+SKILL.md §2는 CONTEXT.md vocabulary 사용을 요구. mind-signal-backend는 별도 CONTEXT.md 미보유.
+
+**대체**:
+- 도메인 어휘는 `mind-signal-backend/CLAUDE.md` §8 Domain Terms (Operator/Subject/Phase 1/Group/EmotivMetrics 등) 사용
+- ADR 영역은 `docs/architecture/decisions/ADR-006` (Phase G) 참조
+
+## 5. Pass 기준 매핑
+
+| Pass 기준 | 적용 측정 도구 (원문 위치) |
+|---|---|
+| A ≥ 2 구조 문제 | Deletion test (SKILL §Glossary) + interface≈impl 정성 비교 (LANGUAGE §Depth) |
+| B ≥ 3 adapter 후보 | Dependency 4 categories (DEEPENING §1~4) + Two-adapter rule (DEEPENING §Seam discipline) |
+| C ≥ 1 cross-LLM delta | 두 LLM이 동일 LANGUAGE.md 7 terms grounding |
+| D 회귀 0 | read-only 유지 (src/** 수정 0) |
+
+## 6. 다음 단계 ↔ 원문 매핑
+
+| 본 PoC 단계 | 원문 SKILL.md Process |
+|---|---|
+| Step 2 depth + adapter 후보 | Process §1 Explore |
+| Step 3 mermaid + 후보 정리 | Process §2 Present candidates |
+| Step 4a-c cross-LLM 검토 | Process §3 Grilling loop |
+| Step 5 TDD 명세 | INTERFACE-DESIGN §2 "design twice" (3+ alt interface) — PoC에서는 1 후보만, 별도 PR로 다중 alt 작성 |
+
+## 7. 출처
+
+- 원본 4 파일 (`SKILL.md`, `LANGUAGE.md`, `DEEPENING.md`, `INTERFACE-DESIGN.md`) — `mattpocock/skills@main:skills/engineering/improve-codebase-architecture/`
+- HANDOFF 박제된 5번째 파일 REFERENCE.md는 실재하지 않음 (2026-05-13 확인 — repo에는 4 파일만 존재)
+- SHA256 byte-identical 검증 결과는 `.plans/H-deep-module-poc/HANDOFF.md` 후속 박제 예정

--- a/.claude/skills/office-hours-ddd-discovery/SKILL.md
+++ b/.claude/skills/office-hours-ddd-discovery/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: office-hours-ddd-discovery
+description: Six forcing questions (Garry Tan gstack v2.0.0, MIT) adapted for DDD bounded context discovery. Use when starting a new bounded context, validating an aggregate boundary, or pivoting domain model.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Grep
+---
+
+# Office Hours × DDD Discovery
+
+> Origin: garrytan/gstack `office-hours/SKILL.md` v2.0.0 (MIT, Copyright 2026 Garry Tan)
+> Adaptation: ecosystem 의존성 제거 (`gbrain` schema, `~/.gstack/`, cross-skill calls). DDD discovery 맥락으로 재구성.
+> License: MIT — see UPSTREAM.md (full text inline)
+> Companion: docs/patterns/ddd-discovery-via-6q.md
+
+## When to invoke
+
+- Starting a **new bounded context** (greenfield aggregate)
+- Validating an **aggregate root boundary** (existing model)
+- Pivoting **domain model** after discovering edge case mismatch
+
+## 6 Forcing Questions (verbatim from gstack/office-hours, MIT — Copyright 2026 Garry Tan)
+
+Ask these questions **ONE AT A TIME** via AskUserQuestion. Push on each one until the answer is specific, evidence-based, and uncomfortable. Comfort means the team hasn't gone deep enough.
+
+**Smart routing based on bounded-context maturity:**
+- Pre-context (greenfield) → Q1, Q2, Q3
+- Has aggregates (model exists) → Q2, Q4, Q5
+- Has paying users (production) → Q4, Q5, Q6
+- Pure infra/CRUD → Q2, Q4 only
+
+### Q1: Demand Reality
+
+**Ask:** "What's the strongest evidence you have that someone actually wants this — not 'is interested,' not 'signed up for a waitlist,' but would be genuinely upset if it disappeared tomorrow?"
+
+**DDD lens**: surface the **Domain Event** that captures the demand signal. "User clicks save" is not a domain event. "Order placed" with monetary commitment is.
+
+**Push until you hear:** Specific behavior. Someone paying. Someone expanding usage. Someone building their workflow around it.
+
+### Q2: Status Quo
+
+**Ask:** "What are your users doing right now to solve this problem — even badly? What does that workaround cost them?"
+
+**DDD lens**: identify the **Anti-Corruption Layer** seam. Existing workarounds (Excel sheets, copy-paste flows) are evidence of where the new bounded context must integrate.
+
+**Push until you hear:** Specific workflow. Hours/dollars wasted. Tools duct-taped together.
+
+### Q3: Desperate Specificity
+
+**Ask:** "Name the actual human who needs this most. What's their title? What gets them promoted? What gets them fired? What keeps them up at night?"
+
+**DDD lens**: this is the **Domain Expert** who must collaborate on Ubiquitous Language. Without a name, there's no UL. "Operations team" is not a domain expert — "Sarah, fulfillment lead at warehouse 3" is.
+
+**Push until you hear:** A name. A role. A specific consequence.
+
+### Q4: Narrowest Wedge
+
+**Ask:** "What's the smallest possible version of this that someone would pay real money for — this week, not after you build the platform?"
+
+**DDD lens**: this defines the **Aggregate root boundary**. The narrowest wedge is the smallest aggregate that delivers value end-to-end. If you can't ship it as a single aggregate transaction, the boundary is wrong.
+
+**Push until you hear:** One feature. One workflow. Something shippable in days.
+
+### Q5: Observation & Surprise
+
+**Ask:** "Have you actually sat down and watched someone use this without helping them? What did they do that surprised you?"
+
+**DDD lens**: this is **Domain Expert collaboration**, not user testing. Caveat: real user-observation also counts, but the primary signal is **expert language drift** — the moment a domain expert uses a term you didn't expect, your UL is incomplete.
+
+**Push until you hear:** A specific surprise. Something that contradicted assumptions.
+
+### Q6: Future-Fit
+
+**Ask:** "If the world looks meaningfully different in 3 years — and it will — does your product become more essential or less?"
+
+**DDD lens**: this is **Strategic subdomain classification** (core / supporting / generic). Future-essential = core domain (invest). Future-irrelevant = generic (buy). Caveat: fit=3 (lower than other questions) — strategic classification is a board-level decision, not a domain modeling decision.
+
+**Push until you hear:** A specific claim about user-world change.
+
+---
+
+## Smart-skip + STOP
+
+- **Smart-skip**: If the user's answers to earlier questions already cover a later question, skip it. Only ask questions whose answers aren't yet clear.
+- **STOP** after each question. Wait for the response before asking the next.
+
+## Hard constraints
+
+- **One question at a time** (gstack 정책 그대로)
+- **No Q advancement without human response** — never simulate the answer
+- **Sequential Thinking MCP usage**: pre-processing only ("which Q is most critical for this stage?"). **Never use ST to substitute for AskUserQuestion** — human input is the value, not a placeholder.
+- **AskUserQuestion** is the only sanctioned mechanism for the 6Q loop

--- a/.claude/skills/office-hours-ddd-discovery/UPSTREAM.md
+++ b/.claude/skills/office-hours-ddd-discovery/UPSTREAM.md
@@ -1,0 +1,76 @@
+# UPSTREAM — office-hours-ddd-discovery skill
+
+> Adapted from garrytan/gstack
+> Upstream commit: 19e699ab9b69de9e1bf10d4b7c2682703b56f984
+> Date: 2026-05-06
+> Path: office-hours/SKILL.md
+> Upstream version (frontmatter `version`): 2.0.0
+
+## License (MIT — verbatim from garrytan/gstack/LICENSE)
+
+```
+MIT License
+
+Copyright (c) 2026 Garry Tan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Adaptation rationale (NOT verbatim)
+
+gstack `office-hours/SKILL.md` standalone vendor 불가:
+1. `gbrain` schema → `~/.gstack/builder-profile.jsonl`, `~/.gstack/projects/{repo_slug}/*-design-*.md`, `~/.gstack/analytics/eureka.jsonl` 의존
+2. `/plan-ceo-review`, `/plan-eng-review` cross-skill 의존
+3. `SKILL.md.tmpl` auto-generation (gen:skill-docs script — bun build infra)
+4. "Preamble (run first)" bash 명령 = gstack 환경 가정
+5. `preamble-tier`, `triggers`, `gbrain` frontmatter 키 = gstack ecosystem 전용
+
+→ 6 forcing questions 본문 (Q1-Q6) 만 MIT 표기로 인용 + DDD discovery 맥락 + Sequential Thinking MCP caveat 명시.
+
+## Fair use 범위 (Phase F PLAN.md Round 2 Ambiguity 해소)
+
+- 6Q 본문 verbatim quote (~150 단어) + MIT attribution (Copyright 2026 Garry Tan)
+- MIT 라이선스는 verbatim 인용 + attribution 시 자유 사용 허용 (위 LICENSE 본문 §3 "above copyright notice ... shall be included")
+- 본 adapted skill은 MIT 의무 충족 (위 LICENSE 전문 inline + 본문 attribution)
+
+## Frontmatter 키 정합 (PLAN.md §5 CL-08)
+
+| Key | Pocock tdd | gstack office-hours (reference only) | adapted (this skill) |
+|---|---|---|---|
+| name | ✅ | ✅ | ✅ |
+| description | ✅ | ✅ | ✅ |
+| allowed-tools | ❌ | ✅ | ✅ (3 tools: AskUserQuestion / Read / Grep) |
+| preamble-tier | ❌ | ✅ | ❌ (gstack 전용) |
+| version | ❌ | ✅ | ❌ (gstack 전용) |
+| triggers | ❌ | ✅ | ❌ (gstack 전용) |
+| gbrain | ❌ | ✅ | ❌ (gstack ecosystem 전용) |
+
+→ Pocock tdd 키 집합 + `allowed-tools` (3개) 추가만 채택.
+
+## Sync trigger + procedure (Pocock tdd UPSTREAM.md와 동일 패턴)
+
+**Trigger**: Phase 14a-bis Revision 2026-11-01
+
+**Procedure**:
+1. `gh api repos/garrytan/gstack/commits/main --jq .sha` 후 박제된 SHA `19e699ab`와 비교
+2. SHA 동일 → no-op
+3. SHA 다름 → 6Q 본문 (lines 956-1046) diff. 변경 발견 시:
+   - 별도 PR (Phase G 또는 신규 Phase) — 자동 bump 금지
+   - DONE.md에 `pending-drift` 라벨
+   - 사용자 검토 후 PIN.md 갱신 + ADR amend

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: tdd
+description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+---
+
+# Test-Driven Development
+
+## Philosophy
+
+**Core principle**: Tests should verify behavior through public interfaces, not implementation details. Code can change entirely; tests shouldn't.
+
+**Good tests** are integration-style: they exercise real code paths through public APIs. They describe _what_ the system does, not _how_ it does it. A good test reads like a specification - "user can checkout with valid cart" tells you exactly what capability exists. These tests survive refactors because they don't care about internal structure.
+
+**Bad tests** are coupled to implementation. They mock internal collaborators, test private methods, or verify through external means (like querying a database directly instead of using the interface). The warning sign: your test breaks when you refactor, but behavior hasn't changed. If you rename an internal function and tests fail, those tests were testing implementation, not behavior.
+
+See [tests.md](tests.md) for examples and [mocking.md](mocking.md) for mocking guidelines.
+
+## Anti-Pattern: Horizontal Slices
+
+**DO NOT write all tests first, then all implementation.** This is "horizontal slicing" - treating RED as "write all tests" and GREEN as "write all code."
+
+This produces **crap tests**:
+
+- Tests written in bulk test _imagined_ behavior, not _actual_ behavior
+- You end up testing the _shape_ of things (data structures, function signatures) rather than user-facing behavior
+- Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
+- You outrun your headlights, committing to test structure before understanding the implementation
+
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+
+```
+WRONG (horizontal):
+  RED:   test1, test2, test3, test4, test5
+  GREEN: impl1, impl2, impl3, impl4, impl5
+
+RIGHT (vertical):
+  RED→GREEN: test1→impl1
+  RED→GREEN: test2→impl2
+  RED→GREEN: test3→impl3
+  ...
+```
+
+## Workflow
+
+### 1. Planning
+
+When exploring the codebase, use the project's domain glossary so that test names and interface vocabulary match the project's language, and respect ADRs in the area you're touching.
+
+Before writing any code:
+
+- [ ] Confirm with user what interface changes are needed
+- [ ] Confirm with user which behaviors to test (prioritize)
+- [ ] Identify opportunities for [deep modules](deep-modules.md) (small interface, deep implementation)
+- [ ] Design interfaces for [testability](interface-design.md)
+- [ ] List the behaviors to test (not implementation steps)
+- [ ] Get user approval on the plan
+
+Ask: "What should the public interface look like? Which behaviors are most important to test?"
+
+**You can't test everything.** Confirm with the user exactly which behaviors matter most. Focus testing effort on critical paths and complex logic, not every possible edge case.
+
+### 2. Tracer Bullet
+
+Write ONE test that confirms ONE thing about the system:
+
+```
+RED:   Write test for first behavior → test fails
+GREEN: Write minimal code to pass → test passes
+```
+
+This is your tracer bullet - proves the path works end-to-end.
+
+### 3. Incremental Loop
+
+For each remaining behavior:
+
+```
+RED:   Write next test → fails
+GREEN: Minimal code to pass → passes
+```
+
+Rules:
+
+- One test at a time
+- Only enough code to pass current test
+- Don't anticipate future tests
+- Keep tests focused on observable behavior
+
+### 4. Refactor
+
+After all tests pass, look for [refactor candidates](refactoring.md):
+
+- [ ] Extract duplication
+- [ ] Deepen modules (move complexity behind simple interfaces)
+- [ ] Apply SOLID principles where natural
+- [ ] Consider what new code reveals about existing code
+- [ ] Run tests after each refactor step
+
+**Never refactor while RED.** Get to GREEN first.
+
+## Checklist Per Cycle
+
+```
+[ ] Test describes behavior, not implementation
+[ ] Test uses public interface only
+[ ] Test would survive internal refactor
+[ ] Code is minimal for this test
+[ ] No speculative features added
+```

--- a/.claude/skills/tdd/UPSTREAM.md
+++ b/.claude/skills/tdd/UPSTREAM.md
@@ -1,0 +1,53 @@
+# UPSTREAM — tdd skill
+
+> Vendored from KWONSEOK02/skills (fork of mattpocock/skills)
+> Upstream commit: b843cb5ea74b1fe5e58a0fc23cddef9e66076fb8
+> Date: 2026-04-30
+> Path: skills/engineering/tdd/
+> Files: 6 (SKILL.md + deep-modules.md + interface-design.md + mocking.md + refactoring.md + tests.md)
+> Vendor strategy: full directory verbatim — frontmatter included, no body modification (Phase F PLAN.md §2 D-1 / Round 1 CX-1 정합)
+> Verification: see Phase F Wave 0 PIN.md sha256 hashes
+
+## License (MIT — verbatim)
+
+```
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Sync trigger + procedure
+
+**Trigger**: Phase 14a-bis Revision 2026-11-01 (parent fate sharing)
+
+**Procedure**:
+1. `gh api repos/KWONSEOK02/skills/commits/main --jq .sha` 후 현재 박제된 SHA `b843cb5e`와 비교
+2. SHA 동일 → no-op (PIN.md `last_sync_check` 갱신만)
+3. SHA 다름 → 6 files diff. 변경 발견 시:
+   - 별도 PR 생성 (Phase G 또는 신규 Phase) — 자동 bump 금지
+   - DONE.md에 `pending-drift` 라벨 추가
+   - 사용자 검토 후 PIN.md 갱신 + ADR amend
+
+## Local addendum
+
+`_local-addendum.md` — Phase D C13 정정 (build-time NOT compile-time)
+
+> Reference: docs/patterns/ddd-tdd-cross-stack.md (spring), docs/patterns/ddd-discovery-via-6q.md (spring/ts)

--- a/.claude/skills/tdd/_local-addendum.md
+++ b/.claude/skills/tdd/_local-addendum.md
@@ -1,0 +1,102 @@
+# `_local-addendum.md` — mind-signal-backend TDD 스킬 로컬 컨텍스트
+
+> 본 파일은 Phase G가 Phase F 박제 `tdd` 스킬(Pocock 9 파일 byte-identical)을 mind-signal-backend에 활성화하면서 추가한 **로컬 컨텍스트**다.
+> Pocock canonical 9 파일은 byte-identical 의무. 본 addendum 1 파일만 로컬 신규.
+> ADR-005 skill-vendor-policy 정합: vendored canonical 파일과 _local-addendum.md를 명확히 분리.
+
+---
+
+## 0. 본 스킬을 mind-signal-backend에서 사용할 때 알아야 할 것
+
+mind-signal-backend는 다음 기술 스택을 쓴다:
+
+| 영역 | 사용 도구 |
+|---|---|
+| 언어 | TypeScript 5.x (strict mode) |
+| 프레임워크 | Express 4 + Mongoose 8 |
+| 테스트 러너 | **Jest 30 단일** (Vitest 도입 금지 — `.claude/rules/test-modification.md`) |
+| HTTP 테스트 | supertest (단, Phase G의 BDD 인수 테스트는 supertest 미사용 — Q1 LOCK) |
+| 통합 테스트 DB | `mongodb-memory-server` (Jest globalSetup 패턴) |
+| 빌드/타입 검사 | `tsc + tsc-alias` |
+| 정적 분석 | ESLint 9 (`--max-warnings 0`) + Prettier |
+| 계층 검사 | `dependency-cruiser` (FSD 규칙 + Phase G R-DDD-1/2) |
+
+Pocock canonical은 언어 독립적으로 작성된 outside-in TDD 흐름. mind-signal-backend에서는 **Jest + supertest + mongodb-memory-server 위에서 동일 흐름** 적용.
+
+---
+
+## 1. mind-signal-backend FSD 계층과 TDD 위치
+
+`.claude/rules/architecture.md` FSD 계층 규칙 (`01-app → 02-processes → 05-features → 06-entities → 07-shared`)에서 TDD의 각 단계가 머무는 위치:
+
+| Pocock 단계 | mind-signal-backend 적용 위치 |
+|---|---|
+| Outside acceptance test | `src/05-features/{domain}/__tests__/*.bdd.test.ts` (Jest describe/test 자연어 Given/When/Then) |
+| Application use case test | `src/05-features/{domain}/services/*.service.test.ts` (mongodb-memory-server) |
+| Domain unit test | `src/06-entities/{domain}/domain/*.aggregate.test.ts` (Jest pure, no mock, no DB) |
+| Repository integration test | `src/06-entities/{domain}/repository/*.repository.test.ts` (mongodb-memory-server) |
+
+본 단계(Phase G) `Session` 도메인에 한정하여 적용. 후속 단계 H/I 진입 시 동일 패턴을 FE/DE에 복제하는 결정은 별도 평가.
+
+---
+
+## 2. mind-signal-backend 한국어 주석 규칙과 Pocock 영문 가이드의 정합
+
+Pocock canonical은 영문 + 코드 예시 중심. mind-signal-backend의 한국어 주석 명사형 종결 규칙(`.claude/rules/code-style.md`)과 충돌하지 않는다.
+
+| 규칙 | 적용 |
+|---|---|
+| 코드 주석 명사형 종결 (~함 / ~완료 / ~처리 / ~반환 / ~생성 / ~사용 / ~임) | 본 스킬을 따라 작성한 모든 신규 코드 주석 의무 |
+| 테스트 describe/test 명칭 | Pocock 권고는 자연어 시나리오. mind-signal에서는 한국어 + Given/When/Then 키워드 혼용 (예: `test('Given operator alice가 ..., When subject bob이 ..., Then ...', ...)`) |
+| 파일 이름 | dot-role suffix 의무 (`session.aggregate.ts` / `pair-subject.service.ts` / `session.repository.ts` / `pair-subject.bdd.test.ts`) |
+
+---
+
+## 3. Pocock canonical과 Phase G LOCK의 정합 확인
+
+Pocock canonical 9 파일은 byte-identical 의무. Phase G가 그 위에 부과한 LOCK:
+
+| Phase G LOCK | Pocock 정합 |
+|---|---|
+| Q1 — BDD 인수 테스트 = Jest 단독 + 서비스 직접 호출 (supertest 미사용) | Pocock outside-in의 "outside" 정의는 HTTP에 한정하지 않음. 서비스 직접 호출도 outside-in 정합 (단위 위 응용 계층) |
+| Q2 — `SessionAggregate` 명칭 분리 | Pocock interface-design.md 정합 (도메인 객체 의도 명확화) |
+| Q3 — 6 상태 그대로 + 1 전이만 시연 | Pocock tests.md 권고 "1 시나리오 = 1 behavior" 정합 |
+| Q4 — group_counters 응용 서비스 책임 | Pocock deep-modules.md "single responsibility" 정합 (도메인 외부 책임 명시) |
+| Q5 — 응용 서비스 = `05-features/sessions/services/` (FSD 규칙) | Pocock 가이드는 위치 미규정 — FSD 규칙이 mind-signal-backend 고유 |
+| Q6 — depcruise 규칙 2개 | Pocock 가이드는 외부 도구 미규정 — depcruise는 mind-signal-backend 고유 |
+
+---
+
+## 4. 본 스킬과 mind-signal-backend의 다른 스킬·문서 간 cross-reference
+
+- **`office-hours-ddd-discovery/SKILL.md`** (같은 vendoring, 6Q 발견 인터뷰) — DDD 도메인 발견 시 사용. 본 스킬과 짝 (TDD outside-in이 BDD 인수에서 시작 → DDD 도메인 발견 → TDD 단위 사이클)
+- **`docs/patterns/ddd-discovery-via-6q.md`** (Phase F 복제 + Phase G 적용 결과 `session-aggregate-6q-applied.md`) — 6Q 답변 박제
+- **`.claude/rules/test-modification.md`** "No Vitest APIs" — 본 스킬을 적용할 때 Jest API만 사용 의무
+- **`.claude/rules/verification-loop.md`** — TDD 사이클 완료 후 `npm run verify` 6단계 PASS 의무
+- **`.plans/G-mind-signal-ddd-bdd-tdd/NAMING-GUIDE.md`** — 본 스킬을 따라 생성한 모든 영어 명사의 한국어 의미 박제
+
+---
+
+## 5. 본 스킬 사용 시 자기 체크리스트
+
+mind-signal-backend에서 본 스킬을 따라 작업할 때 다음을 매 사이클 자기 검증:
+
+- [ ] 테스트를 먼저 빨간색(실패)으로 만들었는가?
+- [ ] 통과시킬 최소 코드만 적었는가? (Minimum Code 게이트)
+- [ ] 신규 의존성 0건 (`package.json` devDependencies 추가 0)?
+- [ ] FSD 계층 import 방향 준수 (`npm run depcruise` PASS)?
+- [ ] 한국어 주석 명사형 종결 위반 0건?
+- [ ] 기존 Jest 테스트 회귀 0건 (`npm test` 결과 동일 PASS 수)?
+- [ ] `eslint-disable` / `ts-ignore` / `test.skip()` 신규 0건?
+
+---
+
+## 6. 본 addendum 변경 시
+
+본 addendum은 mind-signal-backend 로컬. Pocock canonical 9 파일과 무관하게 mind-signal 컨텍스트 변경에 따라 갱신 가능.
+
+Pocock canonical 9 파일 (SKILL.md, deep-modules.md, interface-design.md, mocking.md, refactoring.md, tests.md, UPSTREAM.md, office-hours/SKILL.md, office-hours/UPSTREAM.md)은 **수정 금지** — Phase F가 박제한 SHA256 byte-identical 의무 유지. canonical 갱신 시 Phase F의 14a-bis Revision sync trigger(2026-11-01) 절차를 거친다.
+
+---
+
+**END _local-addendum.md** — mind-signal-backend TDD 스킬 로컬 컨텍스트 박제.

--- a/.claude/skills/tdd/deep-modules.md
+++ b/.claude/skills/tdd/deep-modules.md
@@ -1,0 +1,33 @@
+# Deep Modules
+
+From "A Philosophy of Software Design":
+
+**Deep module** = small interface + lots of implementation
+
+```
+┌─────────────────────┐
+│   Small Interface   │  ← Few methods, simple params
+├─────────────────────┤
+│                     │
+│                     │
+│  Deep Implementation│  ← Complex logic hidden
+│                     │
+│                     │
+└─────────────────────┘
+```
+
+**Shallow module** = large interface + little implementation (avoid)
+
+```
+┌─────────────────────────────────┐
+│       Large Interface           │  ← Many methods, complex params
+├─────────────────────────────────┤
+│  Thin Implementation            │  ← Just passes through
+└─────────────────────────────────┘
+```
+
+When designing interfaces, ask:
+
+- Can I reduce the number of methods?
+- Can I simplify the parameters?
+- Can I hide more complexity inside?

--- a/.claude/skills/tdd/interface-design.md
+++ b/.claude/skills/tdd/interface-design.md
@@ -1,0 +1,31 @@
+# Interface Design for Testability
+
+Good interfaces make testing natural:
+
+1. **Accept dependencies, don't create them**
+
+   ```typescript
+   // Testable
+   function processOrder(order, paymentGateway) {}
+
+   // Hard to test
+   function processOrder(order) {
+     const gateway = new StripeGateway();
+   }
+   ```
+
+2. **Return results, don't produce side effects**
+
+   ```typescript
+   // Testable
+   function calculateDiscount(cart): Discount {}
+
+   // Hard to test
+   function applyDiscount(cart): void {
+     cart.total -= discount;
+   }
+   ```
+
+3. **Small surface area**
+   - Fewer methods = fewer tests needed
+   - Fewer params = simpler test setup

--- a/.claude/skills/tdd/mocking.md
+++ b/.claude/skills/tdd/mocking.md
@@ -1,0 +1,59 @@
+# When to Mock
+
+Mock at **system boundaries** only:
+
+- External APIs (payment, email, etc.)
+- Databases (sometimes - prefer test DB)
+- Time/randomness
+- File system (sometimes)
+
+Don't mock:
+
+- Your own classes/modules
+- Internal collaborators
+- Anything you control
+
+## Designing for Mockability
+
+At system boundaries, design interfaces that are easy to mock:
+
+**1. Use dependency injection**
+
+Pass external dependencies in rather than creating them internally:
+
+```typescript
+// Easy to mock
+function processPayment(order, paymentClient) {
+  return paymentClient.charge(order.total);
+}
+
+// Hard to mock
+function processPayment(order) {
+  const client = new StripeClient(process.env.STRIPE_KEY);
+  return client.charge(order.total);
+}
+```
+
+**2. Prefer SDK-style interfaces over generic fetchers**
+
+Create specific functions for each external operation instead of one generic function with conditional logic:
+
+```typescript
+// GOOD: Each function is independently mockable
+const api = {
+  getUser: (id) => fetch(`/users/${id}`),
+  getOrders: (userId) => fetch(`/users/${userId}/orders`),
+  createOrder: (data) => fetch('/orders', { method: 'POST', body: data }),
+};
+
+// BAD: Mocking requires conditional logic inside the mock
+const api = {
+  fetch: (endpoint, options) => fetch(endpoint, options),
+};
+```
+
+The SDK approach means:
+- Each mock returns one specific shape
+- No conditional logic in test setup
+- Easier to see which endpoints a test exercises
+- Type safety per endpoint

--- a/.claude/skills/tdd/refactoring.md
+++ b/.claude/skills/tdd/refactoring.md
@@ -1,0 +1,10 @@
+# Refactor Candidates
+
+After TDD cycle, look for:
+
+- **Duplication** → Extract function/class
+- **Long methods** → Break into private helpers (keep tests on public interface)
+- **Shallow modules** → Combine or deepen
+- **Feature envy** → Move logic to where data lives
+- **Primitive obsession** → Introduce value objects
+- **Existing code** the new code reveals as problematic

--- a/.claude/skills/tdd/tests.md
+++ b/.claude/skills/tdd/tests.md
@@ -1,0 +1,61 @@
+# Good and Bad Tests
+
+## Good Tests
+
+**Integration-style**: Test through real interfaces, not mocks of internal parts.
+
+```typescript
+// GOOD: Tests observable behavior
+test("user can checkout with valid cart", async () => {
+  const cart = createCart();
+  cart.add(product);
+  const result = await checkout(cart, paymentMethod);
+  expect(result.status).toBe("confirmed");
+});
+```
+
+Characteristics:
+
+- Tests behavior users/callers care about
+- Uses public API only
+- Survives internal refactors
+- Describes WHAT, not HOW
+- One logical assertion per test
+
+## Bad Tests
+
+**Implementation-detail tests**: Coupled to internal structure.
+
+```typescript
+// BAD: Tests implementation details
+test("checkout calls paymentService.process", async () => {
+  const mockPayment = jest.mock(paymentService);
+  await checkout(cart, payment);
+  expect(mockPayment.process).toHaveBeenCalledWith(cart.total);
+});
+```
+
+Red flags:
+
+- Mocking internal collaborators
+- Testing private methods
+- Asserting on call counts/order
+- Test breaks when refactoring without behavior change
+- Test name describes HOW not WHAT
+- Verifying through external means instead of interface
+
+```typescript
+// BAD: Bypasses interface to verify
+test("createUser saves to database", async () => {
+  await createUser({ name: "Alice" });
+  const row = await db.query("SELECT * FROM users WHERE name = ?", ["Alice"]);
+  expect(row).toBeDefined();
+});
+
+// GOOD: Verifies through interface
+test("createUser makes user retrievable", async () => {
+  const user = await createUser({ name: "Alice" });
+  const retrieved = await getUser(user.id);
+  expect(retrieved.name).toBe("Alice");
+});
+```

--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -40,6 +40,25 @@ module.exports = {
       from: { path: '^src/05-features' },
       to: { path: '^(fs|path|node:fs|node:path)$' },
     },
+    // (e) R-DDD-1 no-mongoose-in-domain — 도메인 레이어는 Mongoose 또는 schema 파일 import 금지
+    //     순수 타입(session.types.ts)은 정규식이 .schema$만 매칭하므로 허용됨
+    //     @07-shared/constants/experiment (ExperimentMode single source)도 본 규칙 차단 대상 외
+    {
+      name: 'no-mongoose-in-domain',
+      comment: '도메인 레이어는 Mongoose 또는 schema 파일 import 금지 (순수 타입 파일은 허용)',
+      severity: 'error',
+      from: { path: '^src/06-entities/sessions/domain/' },
+      to: { path: '(^mongoose$|^src/06-entities/sessions/model/session\\.schema$)' },
+    },
+    // (f) R-DDD-2 no-redis-socket-in-domain — 도메인 레이어는 인프라(Redis/Socket.io) import 금지
+    //     @07-shared/constants/* 는 본 규칙 정규식이 lib/(redis|socket)만 매칭하므로 허용됨
+    {
+      name: 'no-redis-socket-in-domain',
+      comment: '도메인 레이어는 인프라(Redis/Socket.io)에 의존할 수 없음',
+      severity: 'error',
+      from: { path: '^src/06-entities/sessions/domain/' },
+      to: { path: '^src/07-shared/lib/(redis|socket)' },
+    },
   ],
   options: {
     tsConfig: { fileName: 'tsconfig.json' },

--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,8 @@ ASK_USER=mks004@neurosignal.kr
 # ======================
 DUAL_2PC_TIMESTAMP_TOLERANCE_MS=200
 DUAL_2PC_REGISTRATION_TIMEOUT_MS=60000
+
+# ======================
+# K phase 강제 페어링 admin allowlist (콤마 구분, 자동 lowercase normalize)
+# ======================
+ADMIN_EMAILS=

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,17 @@ DIFF-backend.md
 
 # 기타
 
+# Phase H deep-module-poc 산출물 중 박제 제외 (Abandonment-Cost-Scoring-Rubric 4점 이하)
+# 시각화 자료는 이슈/PR 본문에 mermaid code fence로 박제
+docs/architecture/*.mmd
+docs/architecture/*.svg
+docs/architecture/puppeteer-config.json
+
+# Phase H PAAR 중 단독 가치 낮음 (다른 PAAR에 흡수됨, codex r1 → r2 흡수, slice → depth 흡수)
+docs/reports/paar-2026-05-13-deep-module-poc-slice.md
+docs/reports/paar-2026-05-13-deep-module-poc-mermaid.md
+docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md
+
 # Project planning (local only)
 .plans/
 context/

--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,10 @@ npm-debug.log*
 .DS_Store
 Thumbs.db
 
-# Claude Code (개인 설정)
-.claude/
+# Claude Code (개인 설정 — 단, Phase G가 박제한 vendored skills는 예외)
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 
 # 기밀/임시 파일
 secret.txt

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,10 @@ docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md
 # Project planning (local only)
 .plans/
 context/
+
+# AI 에이전트 문서 (마인드 시그널 한정 — 본인만 사용, 팀 공유 안 함)
+# Why: 마인드 시그널은 이 패턴 적용을 본인 학습용으로 유지하고 다른 프로젝트에 templating할 예정.
+# 다른 모델 세션이 자동으로 추적 시도하지 않도록 .git/info/exclude 대신 .gitignore에 명시.
+AGENTS.md
+CLAUDE.md
+.agents/

--- a/docs/architecture/decisions/ADR-006-session-aggregate-ddd-pilot.md
+++ b/docs/architecture/decisions/ADR-006-session-aggregate-ddd-pilot.md
@@ -1,0 +1,123 @@
+# ADR-006: Session Aggregate DDD/BDD/TDD Pilot (Phase G)
+
+<!-- Append-only after Accepted — documentation.md §Append-only rule 참조. -->
+
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-12
+- **Applies to**: BE
+- **Deciders**: @gs07103
+- **Related**: ADR-004 (engine URL abstraction), Phase 18 engine-proxy-sync (LOCK), `.plans/G-mind-signal-ddd-bdd-tdd/CRITIQUE.md` Round 2 (🟡 5 prerequisites), `DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 단일 근거)
+
+## Context
+
+본 단계(Phase G)는 다음 4 bullet의 **P1 frame** 안에서 진행됨 (Prerequisites P-4 정합 의무 — DISCUSS §1, §2 #6, PRD DR-G, 본 ADR Context 4 위치 일관 표현):
+
+1. **졸업 프로젝트 학습 + 2026-05-26 교수 면담 시연** — 효과 측정 주장 없음. 시연 통과 + 한국어 시나리오 외부 낭독 feedback 1회로 가치 박제.
+2. **산업 표준 패턴 적용** — Vernon 2011 "Effective Aggregate Design Part I" 단일 aggregate + Stemmler 2019 "TypeScript DDD Mongoose Adapter" + Pocock outside-in TDD 9 파일 (MIT) + Garry Tan gstack 6Q discovery (MIT).
+3. **Phase F 박제 자산 활성화** — `feat/F-template-ddd-tdd-augmentation` (2026-05-06 DONE) 작업으로 3 GitHub 템플릿(spring/typescript/python)에 박제된 9 파일을 mind-signal-backend에 SHA256 byte-identical 복제 + 1 신규 `_local-addendum.md`. 박제 자산이 본 단계 적용 없이는 mind-signal에 dead asset.
+4. **새 기여 주장 0건** — 차별점 = 학생 horizon + 한국어 명명 가이드 + Phase F 박제 자산 활성화 (모두 market-tier). 학술적 새 기여 주장 없음 — `arXiv 2007.09863` TDD 효과 학술 inconclusive + Cucumber.io "BDD는 collaboration이지 tooling 아님" 단일 개발자 horizon 제약 인정.
+
+추가 컨텍스트:
+
+- 기존 `Session`이라는 단어가 ① Mongoose DB 모양(`session.schema.ts`) ② 비즈니스 규칙 두 가지를 동시에 가리키고 있어 IDE 자동완성/import 검색/사람 판단에서 혼동 발생 가능. NECESSITY-EVIDENCE.md 5건 인용으로 잠재 위험 박제 (CRITIQUE Round 2 P-1 통과).
+- `code-review-graph` MCP build (130 files / 630 nodes / 4647 edges, 2026-05-12) 실측으로 기존 `pairDeviceProcess(pairingToken, userId)` 시그니처 + `Session.findOne({pairingToken})` 직접 조회 패턴 + `pairingListeners` (LD-12 대안 D) Set 등록 패턴 + `group_counters` 원자 연산이 페어링 흐름에 미사용 (creation 흐름 전용) 등 12 정정 발견.
+- Phase 17.6 (dual-trigger.service.ts 안정 동작) + Phase 18 (engine-proxy-sync LOCK, execute 5/26 이후) 충돌 회피 의무 — `02-processes/engine/` + `pairing.service.ts` 수정 0건 strict.
+
+## Decision
+
+본 단계에서 다음 8 가지 결정 LOCK:
+
+1. **명칭 분리** — Mongoose Model `Session` 이름 그대로 유지 + 도메인 통합체는 `SessionAggregate` 신규 명칭. `src/06-entities/sessions/domain/session.aggregate.ts`.
+2. **Aggregate boundary = 단일 Session 도큐먼트** — 1 `SessionAggregate` = 1 MongoDB document = 1 트랜잭션 단위. 그룹 차원 invariant(같은 `groupId`에 `subjectIndex` 1과 2 unique)는 Mongoose `groupId_subjectIndex_unique` 복합 인덱스가 enforce (aggregate 외부).
+3. **시그니처** — `SessionAggregate.create({id, groupId, subjectIndex, pairingToken, operatorId, mode, expiresAt})` 7 인자 + `pair(userId: string)` 1 인자 (mind-signal-backend `userId` 컨벤션 정합, `subjectId` 명칭 미사용).
+4. **순수 타입 분리** — `src/06-entities/sessions/types/session.types.ts` 신규에 `SessionStatus` 6종 union 단일 정의. `ExperimentMode`는 `@07-shared/constants/experiment` single source 유지(re-export only, drift 회피).
+5. **Repository strangler** — `SessionRepository` (`findById` / `findByPairingToken` / `save` / `saveNew`)가 SessionAggregate ↔ Mongoose 양방향 변환 단일 지점. `findByPairingToken`은 기존 `Session.findOne({pairingToken})` (`pairing.service.ts:94`) 어댑터.
+6. **응용 서비스 병렬 존재** — `PairSubjectService.execute({pairingToken, userId})` 5단계 흐름은 기존 `pairDeviceProcess(pairingToken, userId)`와 동일 시그니처로 병렬 존재(strangler). 본 단계는 기존 `pairing.service.ts` **수정 0건** — 컨트롤러 통합은 후속 PR.
+7. **depcruise 신규 규칙 2** — `R-DDD-1 no-mongoose-in-domain` (`domain/` → `mongoose` 또는 `sessions/model/session.schema` 차단) + `R-DDD-2 no-redis-socket-in-domain` (`domain/` → `07-shared/lib/(redis|socket)` 차단). 순수 타입(`session.types.ts`) + `@07-shared/constants/*` 차단 대상 외 (정규식 매칭 안 됨).
+8. **BDD 인수 = Jest 단독 + 서비스 직접 호출** — Q1 LOCK. supertest / HTTP 라우트 / Express app import 0건. Cucumber.js는 별도 `spike/cucumber-poc` 가지로 격리. 본 단계 정식 도구는 기존 Jest 단일.
+
+추가 결정:
+
+- **도메인 이벤트 = type-only + 메모리 기록** — `SessionPairedEvent { type, sessionId, userId, occurredAt, groupId, subjectIndex, mode }` 타입 정의 + `PairSubjectService.recordedEvents` 배열. `pullDomainEvents()` 발행 큐 / persisted outbox 미채택 (Phase E TS-Q17 A3 정합).
+- **기존 `pairingListeners` 통합 호출은 본 단계 제외** — LD-12 대안 D 호출 흐름은 후속 controller 통합 PR로 분리. 본 단계는 `pairing.service.ts` 수정 0건 의무 (G9) 보존 우선.
+- **AppError 코드 매핑 실측 정합** — 만료 토큰 `401` (`pairing.service.ts:104`), 전이 불가 (이미 PAIRED) `400` (L111), 토큰 없음 `404` (L96), userId 형식 부정합 `400` (L89). rev.2 stale 가정(410/409)은 rev.3 정정으로 폐기.
+
+## Alternatives considered
+
+### Option A: 단일 Session 통합체 (선택)
+
+단일 Session 도큐먼트를 aggregate boundary로 두고 그룹 차원 invariant는 Mongoose 인덱스에 위임함.
+
+**Trade-offs**: 도메인 응집도 명확, 단위 테스트 가볍고 빠름 (DB 없이 1초 8건). 단점 — 그룹 수준 비즈니스 규칙이 코드(도메인) + 인프라(인덱스) 두 곳 책임 (Mongoose 인덱스 변경 시 도메인 invariant 영향).
+
+**Accepted because**: Vernon 2011 "Smaller aggregates preferred" 정합 + mind-signal 동시성 모델(group_counters $inc 원자 연산)이 이미 그룹 단위 unique 보장 + 단일 도큐먼트 트랜잭션이 MongoDB cross-document 트랜잭션보다 비용/복잡도 ↓.
+
+### Option B: Group aggregate (기각)
+
+`groupId` 하나에 1~2 Session을 묶는 큰 통합체로 모델링하고 그룹 차원 invariant를 aggregate에 흡수함.
+
+**Trade-offs**: 그룹 차원 비즈니스 규칙을 한 곳에 집중 가능. 단점 — MongoDB cross-document 트랜잭션 필요 + 동시성 제어 복잡도 ↑ + 그룹 invariant("같은 groupId에 subjectIndex 1과 2 unique")는 이미 Mongoose 인덱스가 enforce하므로 흡수 net value 약함.
+
+**Rejected because**: 비용/복잡도 대비 net value 약함 + Vernon 2011 표준 권고와 반대 방향.
+
+### Option C (status quo): 현재 함수형 service 유지
+
+기존 `pairDeviceProcess` 함수만 유지하고 도메인 layer 신설 없음. Phase F 박제 자산 미활용.
+
+**Trade-offs**: 변경 0건 — 안전. 단점 — Phase F 9 파일이 mind-signal에 dead asset + 5/26 시연 자료 부재 + 학습 가치 0.
+
+**Rejected because**: 본 단계 P1 frame ("Phase F 자산 활성화") 의무 미충족.
+
+## Consequences
+
+이 결정 이후 **더 쉬워지는** 것:
+
+- "세션이라는 개념이 코드에서 한 객체(`SessionAggregate`)로 명확히 표현되며, 페어링 한 줄 흐름이 한 파일(`PairSubjectService`)에 모여 있다"고 시연 시 설명 가능 — 5/26 교수 면담 가시성 확보.
+- 도메인 단위 테스트가 DB 없이 빠르게 돔 (8건 도메인 + 5건 응용 서비스 = 0.5초 이하).
+- 후속 단계(Phase H FE / Phase I DE)가 같은 패턴(통합체 + Repository + 응용 서비스) 적용 시 한국어 명명 가이드 + 6Q 적용 문서 + skill 9 파일 재사용 가능.
+- depcruise R-DDD-1/R-DDD-2가 도메인 layer 무결성(외부 의존 0건) 자동 검사 — 후속 PR에서 실수로 mongoose import 시 즉시 차단.
+
+이 결정 이후 **더 어려워지는** 것:
+
+- `Session` ↔ `SessionAggregate` 두 명칭이 공존 — 신규 작성자는 어느 쪽을 import해야 할지 한국어 명명 가이드(`NAMING-GUIDE.md`) 참조 필요.
+- 통합체-모델 변환기(`SessionRepository`)가 추가 — 새 필드 추가 시 4 곳 수정 필요 (`session.schema.ts` + `session.types.ts` + `session.aggregate.ts` `fromDocument` + `session.repository.ts` `toAggregate`).
+- 기존 `pairDeviceProcess`와 신규 `PairSubjectService`가 병렬 존재 (strangler) — controller 통합 PR이 별도 필요. 두 경로 동시 유지 시 listener 발화 동작 차이 가능 (기존 경로 = listener 발화 / 신규 경로 = 메모리 기록만).
+
+새로 발생하는 **기술 부채** (모든 ADR은 일정 부채 수반함, 명시적 기록 의무):
+
+- **TD-G-1** (Listener 통합 후속 PR) — 신규 `PairSubjectService`가 기존 `pairingListeners` (LD-12 대안 D) fire-and-forget 호출 미수행. controller 통합 시 헬퍼 export 추가 또는 양쪽 fire 방식 결정 필요. 부채 만료 시점 = Phase H/I 또는 Phase G+1 후속 PR.
+- **TD-G-2** (mongodb-memory-server 미설치) — 본 단계 통합 테스트는 Jest mock 기반. 진짜 MongoDB 통합 검증은 후속 인프라 정비 PR (mongodb-memory-server 도입 + Repository 진짜 DB 시나리오 추가). 부채 만료 시점 = CI 인프라 정비 시점.
+- **TD-G-3** (controller 점진 이전 미완) — HTTP `GET /join/:token` 라우트는 여전히 `pairDeviceProcess` 호출. 신규 `PairSubjectService`로 점진 이전 작업이 후속 PR로 남음.
+- **TD-G-4** (`__v` 낙관적 잠금 미활성) — 현재 `toJSON()`에서 `__v` 삭제 중 — 동시성 제어 불가 상태. 본 단계 미변경, 별도 ADR로 처리 예정.
+- **TD-G-5** (Cucumber.js spike 결과 박제 보류) — `spike/cucumber-poc` 가지에서 PoC 검증은 본 phase gate 외. 후속 단계 H/I 진입 전 `SPIKE-CUCUMBER.md` 박제 + 도구 정식 채택 여부 평가 의무.
+
+## Implementation notes
+
+- 가지: `feat/G-ddd-bdd-tdd-pilot` (단일, 11 atomic commit + 1 머지)
+- 진입점:
+  - 도메인: `src/06-entities/sessions/domain/session.aggregate.ts` (199 lines)
+  - 변환기: `src/06-entities/sessions/repository/session.repository.ts` (103 lines)
+  - 순수 타입: `src/06-entities/sessions/types/session.types.ts` (24 lines)
+  - 응용 서비스: `src/05-features/sessions/services/pair-subject.service.ts` (120 lines)
+  - BDD 인수: `src/05-features/sessions/__tests__/pair-subject.bdd.test.ts` (193 lines, 3 시나리오)
+- depcruise 신규 규칙: `.dependency-cruiser.cjs` (forbidden 배열에 (e) R-DDD-1 + (f) R-DDD-2 추가)
+- 6Q 적용 문서: `docs/patterns/session-aggregate-6q-applied.md` (213 lines)
+- Skill vendoring: `.claude/skills/tdd/` + `.claude/skills/office-hours-ddd-discovery/` (9 파일 byte-identical + 1 신규 `_local-addendum.md`)
+- 산출물 PAAR:
+  - `docs/reports/paar-2026-05-12-phase-g-isolation-proof.md` (G9 통과)
+  - `docs/reports/paar-2026-05-12-phase-g-verify-green.md` (G8 통과)
+- Verify: `npm run verify` 6단계 GREEN (288 tests PASS, 회귀 0건)
+
+## References
+
+- Vernon, Vaughn (2011), "Effective Aggregate Design Part I: Modeling a Single Aggregate" — https://www.dddcommunity.org/wp-content/uploads/files/pdf_articles/Vernon_2011_1.pdf
+- Stemmler, Khalil (2019), "How to Design & Persist Aggregates - Domain-Driven Design w/ TypeScript" — https://khalilstemmler.com/articles/typescript-domain-driven-design/aggregate-design-persistence/
+- Pocock, Tim — outside-in TDD guide (MIT) (Phase F vendored)
+- Garry Tan, gstack — Six forcing questions v2.0.0 (MIT) (Phase F vendored)
+- mind-signal `mind-signal-backend/CLAUDE.md` §7 (status enum), §8 (Operator/Subject ubiquitous language)
+- `.plans/G-mind-signal-ddd-bdd-tdd/DISCUSS.md` rev.4 (Q1~Q6 LOCK + P1 frame)
+- `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 12 정정 단일 근거)
+- `.plans/G-mind-signal-ddd-bdd-tdd/CRITIQUE.md` Round 1~5 (Verdict 🟡 PROCEED-WITH-CONDITIONS + Contract/Reality/Completeness Lens PASS)
+- Related ADRs: ADR-004 (엔진 URL 추상화), 후속 미작성 ADR(s) — `__v` 낙관적 잠금, controller 통합 등

--- a/docs/architecture/decisions/ADR-007-clock-port-at-session-seam.md
+++ b/docs/architecture/decisions/ADR-007-clock-port-at-session-seam.md
@@ -1,0 +1,101 @@
+# ADR-007: Clock Port at Session Pairing Seam (PR-A7)
+
+<!-- Append-only after Accepted — documentation.md §Append-only rule 참조. -->
+
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-13
+- **Applies to**: BE
+- **Deciders**: @gs07103
+- **Related**: ADR-006 (Session Aggregate DDD Pilot), 이슈 #52, `.plans/H-deep-module-poc/RESULT.md` (Phase H GO, A-7 race trigger 발견), `.plans/I-pr-a7-clock-port/{DISCUSS,PLAN}.md`
+
+## Context
+
+Phase H deep-module-poc(2026-05-13 GO 결정)에서 다음 race condition 발견:
+
+`PairSubjectService.execute({pairingToken, userId})` 한 호출 안에서 시간을 3곳에서 독립 관찰함:
+1. `SessionAggregate.pair()` 내부 `isExpired()` 1차 호출 (`session.aggregate.ts:163` `Date.now()`)
+2. catch 분기 `isExpired()` 2차 재호출 (`pair-subject.service.ts:76`)
+3. `SessionPairedEvent.occurredAt` (`pair-subject.service.ts:101` `new Date().toISOString()`)
+
+PAIRED 상태 + boundary clock 시나리오에서 race 발생 가능:
+- 1차 `isExpired()` = false (T-1ms < expiresAt = T) → SA L117 status !== 'CREATED'로 `InvalidStatusTransitionError` throw
+- 2차 `isExpired()` = true (T+1ms ≥ expiresAt = T, 시간 진행) → `expire()` 호출 → SA L143 status !== 'CREATED'로 새 `InvalidStatusTransitionError` throw
+- 결과: `InvalidStatusTransitionError`가 `AppError`로 감싸지지 않고 외부 raw 노출 (5xx + 영문 도메인 에러 메시지)
+
+또한 hardcoded `Date.now()` / `new Date()`로 test에서 시간 분기를 결정적으로 재현 불가능.
+
+근거: Phase H codex 5.5 r2 강한 인정 (thread `019e1f19-f5b3-7150-90b7-e71bd3066b23`) + Claude 4-Lens rebuttal Lens 3 + plan-review W2 코드 트레이스 (이슈 #52 본문).
+
+## Decision
+
+본 단계에서 다음 5 가지 결정 LOCK:
+
+1. **Clock port 신규** — `src/07-shared/clock/{clock.ts, system-clock.ts, fixed-clock.ts, index.ts}` 신규. `interface Clock { now(): Date }` + SystemClock(production) + FixedClock(test). FSD 07-shared 레이어 정합 (06-entities, 05-features 모두 import 방향 정합).
+
+2. **시그니처 변경 — Method param + Date 전달** (Approach A) — `SessionAggregate`:
+   - `pair(userId: string, now: Date): void` — Date 인자 추가, 내부 `isExpired(now)` 호출 + `_pairedAt = now` 박제
+   - `isExpired(now: Date): boolean` — `Date.now()` 제거, 주입 Date와 `expiresAt` 비교
+
+3. **PS Clock 1회 관찰 + A-6 동반 fix** — `PairSubjectService`:
+   - `constructor(repo: SessionRepository, clock: Clock)` — 둘 다 required (A-6 PS constructor optional default soft seam 해소)
+   - `execute()` 진입 시 `const now = this.clock.now()` 1회 관찰 → SA `pair(userId, now)` / `isExpired(now)` / `event.occurredAt = now.toISOString()`에 동일 Date 객체 전달
+   - 한 호출 단위 내 시간 결정성 보장 → race 차단의 인터페이스 강제
+
+4. **Composition root는 PR-A1 (controller wiring)으로 분리** — 현재 PS는 controller가 호출하지 않음(importers_of=0). 본 PR은 BDD/unit test에서만 명시 주입(`new PairSubjectService(stubRepo, new FixedClock(testNow))`). production `SystemClock` 단일 인스턴스 생성 위치는 PR-A1에서 DI 패턴 정식 결정.
+
+5. **`fromDocument` 영향 0건** — Approach A는 SA에 Clock 미주입. `SessionAggregate.fromDocument(doc)` 시그니처 변경 0. A-8(fromDocument invariant locality) 별건 PR과 독립.
+
+## Alternatives considered
+
+### Option A: Method param + Date 전달 (선택)
+- 장점: race production 차단 **인터페이스 강제** (caller가 다른 시점 주입 불가) / SA pure domain 유지 (infra 의존 0) / Two-adapter rule 정합 (DEEPENING.md L29) / Phase H Step 5 시나리오 5 결정성 자연 보장
+- 단점: SA 시그니처 변경 → 기존 SA test 8건 + SR test L123 + PS test 5건 + BDD 3건 갱신
+- 채택 이유: race를 production code 차원에서 영구 차단 + Matt Pocock vendor skill `improve-codebase-architecture` 원리 100% 정합
+
+### Option B: Constructor inject SA
+- 장점: caller 시그니처 변경 최소 (pair/isExpired no-arg 유지)
+- 단점: race 차단이 SA 내부 캐싱 약속에 의존 (인터페이스 강제 불가) / SA가 Clock 의존 보유 (pure domain 깨짐) / `fromDocument` hydration 경로에서 Clock 주입 복잡 (A-8과 충돌)
+- 거부 이유: 같은 SystemClock 인스턴스를 공유해도 `now()`가 매번 새 Date 반환 → catch 분기 `isExpired()` 재호출 시 race 잔존. race 차단을 SA 내부 메모이제이션 약속에 맡기는 것은 LANGUAGE.md §Locality 약화
+
+### Option C: Static Clock + jest.useFakeTimers()
+- 장점: 시그니처 변경 0
+- 단점: production race 그대로 잔존 (test mock trick) / static `Date.now()`는 in-place 수정 위치 아님 → DEEPENING.md §Seam discipline 위반 / adapter 1개 (Two-adapter rule 미충족, mock은 의미 있는 substitution 아님)
+- 거부 이유: 본 PR의 본질 목표(race를 production에서 영구 차단)에 미달
+
+## Consequences
+
+### 긍정 결과
+- **race 차단**: 한 `execute()` 호출 단위 내 시간 관찰 1회 = 시간 결정성 인터페이스 강제. `InvalidStatusTransitionError` 외부 raw 노출 경로 차단
+- **test 결정성**: `FixedClock` 주입으로 boundary 직전/직후 결정적 재현 가능 — Phase H tdd-spec §2.4 시나리오 4 Context A/B/C + §2.5 시나리오 5 PASS 입증
+- **A-6 soft seam 동반 해소**: PS constructor required 격상으로 composition root 명시화 (DEEPENING.md §Seam discipline 정합)
+
+### 부정 결과 (수용)
+- SA test 8 → 9 갱신 + SR test L123 + PS test 5건 + BDD 3건 시그니처 정합 갱신 필요
+- `fromDocument` 영향 0건이지만, A-8(invariant locality)는 본 PR scope 외 잔존 — 별건 후속 PR
+
+### 회귀 0 박제 (이슈 #52 PR description 정합)
+- Phase G 21 test → 본 PR 후 36 PASS (SA 9 + SR 5 + PS 5 + BDD 8 + clock 4 + 외 sessions test = 73 sessions+clock 영역 PASS)
+- 기존 거동(paired/expired/retry-after-paired의 AppError statusCode + message) 불변
+- `pairing.service.ts` 수정 0건 (Phase G G9 의무 유지)
+- depcruise R-DDD-1/R-DDD-2 위반 0건 (06-entities → 07-shared 방향 정합)
+
+### 후속 의무
+- PR-A1 (controller wiring): production `SystemClock` 단일 인스턴스 composition root 정식 결정
+- PR-A8 (fromDocument invariant locality): SA `fromDocument` invariant 분담 ADR
+
+## References
+
+- 이슈 #52: https://github.com/KWONSEOK02/mind-signal-backend/issues/52
+- Phase H GO: `Team-project/.plans/H-deep-module-poc/RESULT.md`
+- Phase H tdd-spec: `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md` §2 5 시나리오
+- Phase H codex r2: thread `019e1f19-f5b3-7150-90b7-e71bd3066b23` (A-7 강한 인정)
+- vendor skill 원리: `.claude/skills/improve-codebase-architecture/`
+  - LANGUAGE.md L31-32 §Locality / L38 "the interface is the test surface"
+  - DEEPENING.md L27-32 §Seam discipline / L29 "Two adapters means a real one" / L36 "Tests assert on observable outcomes through the interface, not internal state"
+- plan-review Round 1 (`feature-dev:code-reviewer`, 2026-05-13): verdict PROCEED-WITH-CONDITIONS → 6 이슈 PLAN.md 반영 후 PROCEED
+
+## Append-only edits
+
+> Status 변경 또는 superseded 시점에만 본 섹션을 갱신함. Decision 본문 수정 금지.

--- a/docs/guides/_template.md
+++ b/docs/guides/_template.md
@@ -1,0 +1,97 @@
+# Reference Guide _template
+
+> 이 파일은 새 reference 가이드 작성의 표준 템플릿입니다.
+> 사용법: `cp docs/guides/_template.md docs/guides/<your-guide>.md` 후 7 섹션을 채우세요.
+> 출처: TruthScope BE #22 §0~§5 reference 정합 (Phase F C-D7).
+> 박제 정책: 3 templates byte-identical (Phase F PLAN.md §2 D-2).
+
+---
+
+## §0. Glossary (1 minute orientation)
+
+> 본 가이드에서 사용하는 약어/특수 용어를 1줄씩 풀이. 신규 독자가 §1로 진입하기 전 1분 안에 컨텍스트 잡을 수 있도록.
+>
+> 예: `BE` = backend (Express+TypeScript) / `PR` = Pull Request / `RDS` = AWS managed PostgreSQL / ...
+
+| Term | Meaning |
+|---|---|
+| ... | ... |
+
+---
+
+## §1. Why this guide exists
+
+- 무엇을 해결하는가? (1-2 문장)
+- 누가 읽는가? (target reader: 신규 contributor / 특정 stack 학습자 / etc.)
+- 어떤 알림 (notice) — Phase 의존성, 14a-bis 5 contracts, ADR, 다른 가이드 link
+
+---
+
+## §2. Concrete signature / contract
+
+> "권고" 수준 표현 회피. 실제 사용할 시그니처/스키마/프로토콜을 박제. Code block + 1줄 설명.
+>
+> 예: TS interface, JSON schema, REST endpoint signature, gRPC proto, ...
+
+```{lang}
+// concrete contract here
+```
+
+---
+
+## §3. Recommended → confirmed signature
+
+> §2를 더 좁힌 권고 → 확정 시그니처. PR description body의 실제 템플릿. Windows PowerShell + POSIX 양쪽 호환 명시.
+
+### Linux/macOS (bash)
+
+```bash
+# command here
+```
+
+### Windows (PowerShell)
+
+```powershell
+# command here
+```
+
+---
+
+## §4. SsrfGuard / 안전 가이드 (해당 시)
+
+> 외부 호출이 있다면 SSRF/credential leak/quota 등 정책 명시.
+> 없다면 본 섹션 삭제 가능.
+
+---
+
+## §5. Self-contained reference (Week N self-study)
+
+> 이 가이드만 읽고 작업 시작 가능하도록 self-contained 구성.
+> 외부 link 의존성 최소화. 외부 link 사용 시 마지막 §6 References에 모음.
+
+### 예시 시나리오
+
+1. ...
+2. ...
+3. ...
+
+### 검증 (verify gate)
+
+```bash
+# 작업 후 self-verify command
+```
+
+---
+
+## §6. References
+
+- [Phase F Wave 0 PIN.md](../../.plans/F-template-ddd-tdd-augmentation/upstream-pin/PIN.md) (template-internal — 이 path는 derived repo에 없음, 삭제 가능)
+- (외부 docs / RFCs / blog posts — full URL with date)
+
+---
+
+## §7. Maintenance
+
+- 마지막 갱신: YYYY-MM-DD
+- 다음 검토 예정: YYYY-MM-DD (보통 분기별)
+- Owner: @<handle>

--- a/docs/patterns/ddd-discovery-via-6q.md
+++ b/docs/patterns/ddd-discovery-via-6q.md
@@ -1,0 +1,84 @@
+# DDD Discovery via 6 Forcing Questions
+
+> Companion: `.claude/skills/office-hours-ddd-discovery/SKILL.md`
+> Purpose: 6 forcing questions (Garry Tan gstack v2.0.0, MIT)을 DDD bounded context discovery에 매핑.
+> Scope: spring-template + typescript-template (python-template은 archetype 없음 → deferred)
+
+---
+
+## §1. Why 6Q for DDD?
+
+전통적 DDD discovery (Event Storming / Domain Storytelling)은 **시간**과 **합의된 도메인 전문가**를 가정. 그런데 LLM 에이전트가 새 bounded context를 설계할 때:
+- 도메인 전문가 1명만 있고 시간 30분
+- "유저가 원하는 게 뭔지" 명확히 모름
+- 기존 모델을 pivot할지 새로 만들지 결정 needed
+
+→ Garry Tan의 6 forcing questions는 **founder/operator를 압박해서 bounded context의 demand reality를 surface하는 도구**. DDD discovery에 매핑하면 **30분 내에 aggregate boundary + UL + 전략적 위치 결정**.
+
+---
+
+## §2. 6Q × DDD 매핑 (fit score 1-5)
+
+| Question | gstack 원본 의도 | DDD 매핑 | Fit | 근거 |
+|---|---|---|---|---|
+| **Q1** Demand Reality | 누군가 진짜 원하는가? | **Domain Event** identification (monetary commitment / workflow lock-in) | 4 | "Order placed" with payment = real demand event. Click "save" = noise. |
+| **Q2** Status Quo | 지금 어떻게 해결? | **Anti-Corruption Layer** seam (where to integrate with legacy) | 4 | Existing Excel/spreadsheet workarounds = ACL boundaries. |
+| **Q3** Desperate Specificity | 누구가 가장 절실? | **Domain Expert** identification + Ubiquitous Language seed | 5 | Without a named human, no UL collaboration. "Ops team" ≠ Sarah at warehouse 3. |
+| **Q4** Narrowest Wedge | 가장 작은 wedge? | **Aggregate root boundary** | 5 | Smallest aggregate that ships value end-to-end. Can't ship in single transaction → boundary wrong. |
+| **Q5** Observation & Surprise | 무엇이 놀라웠나? | **Domain Expert collaboration** (UL drift detection) | 4 | Real moment = expert uses term you didn't expect. Real-user observation also counts (caveat). |
+| **Q6** Future-Fit | 3년 후에도 essential? | **Strategic subdomain** (core / supporting / generic) | 3 | Board-level decision, not modeling decision. Lower fit because LLM agent + dev pair often can't decide alone. |
+
+---
+
+## §3. Smart routing for DDD discovery
+
+| Stage | Questions to ask | Skip |
+|---|---|---|
+| **Greenfield** (no aggregate yet) | Q1, Q2, Q3 | Q4-Q6 (premature) |
+| **Has aggregates** (model exists) | Q2, Q4, Q5 | Q1 (already validated by existence), Q6 (defer to roadmap) |
+| **Production** (paying users) | Q4, Q5, Q6 | Q1-Q3 (already validated) |
+| **CRUD-only** (no domain logic) | Q2, Q4 | Q1, Q3, Q5, Q6 (over-engineered) — consider whether DDD is even needed |
+
+---
+
+## §4. Workflow
+
+1. Skill `office-hours-ddd-discovery` invoke (auto trigger on "new bounded context", "aggregate boundary 검증", "domain model pivot")
+2. Stage 식별 (greenfield / has aggregates / production / CRUD-only)
+3. AskUserQuestion으로 한 질문씩 (smart routing 적용)
+4. (선택) Sequential Thinking MCP로 pre-processing — "이 stage에서 가장 critical한 Q는?" 식별
+5. 6Q 종료 후 DDD artifact 작성:
+   - Bounded Context map 1장
+   - Aggregate root + entities + value objects sketch
+   - Ubiquitous Language seed (3-5 terms)
+   - Strategic classification (core / supporting / generic)
+
+---
+
+## §5. Hard constraints (skill SKILL.md와 정합)
+
+- **One question at a time** — gstack 정책 그대로
+- **No Q advancement without human response** — 절대 simulate 금지
+- **Sequential Thinking MCP**: pre-processing only ("which Q is most critical?"). **Never substitute for AskUserQuestion** — 인간 입력이 가치, ST는 placeholder 아님
+- **AskUserQuestion**이 6Q 루프의 유일한 sanctioned 메커니즘
+
+---
+
+## §6. Cross-stack 정합
+
+| Stack | DDD layer | 6Q 적용 시점 |
+|---|---|---|
+| Spring (Java) | Domain (entities/aggregates), Application (use cases), Infrastructure (adapters) | Greenfield context 시작 시 / Aggregate boundary 검증 시 |
+| TypeScript (FSD-DDD hybrid) | entities/ (Domain), features/ (Application), shared/widgets/ (Infrastructure/Presentation) | 동일 |
+| Python | (deferred — archetype 없음) | Phase G 후보 |
+
+> Spring `docs/patterns/ddd-tdd-cross-stack.md` 의 "Domain layer no-mocking" 섹션 참조.
+
+---
+
+## §7. References
+
+- gstack `office-hours/SKILL.md` v2.0.0 — Garry Tan, MIT (UPSTREAM.md inline)
+- Pocock `tdd` skill — Matt Pocock, MIT (`.claude/skills/tdd/SKILL.md`)
+- Phase F PLAN.md (template-internal) — 6Q × DDD 매핑 결정 근거
+- Eric Evans "Domain-Driven Design" (2003) — Bounded Context / Aggregate root / Ubiquitous Language 원전

--- a/docs/patterns/session-aggregate-6q-applied.md
+++ b/docs/patterns/session-aggregate-6q-applied.md
@@ -1,0 +1,213 @@
+# Session Aggregate — 6Q Discovery Applied (Phase G)
+
+> Companion: `docs/patterns/ddd-discovery-via-6q.md` (6 forcing questions 일반 가이드)
+> Companion: `.claude/skills/office-hours-ddd-discovery/SKILL.md`
+> Companion: `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` (code-review-graph 실측 단일 근거)
+> Purpose: `SessionAggregate` 도메인 모델링 결정을 6Q 형식으로 박제.
+> Scope: mind-signal-backend 단일 저장소. 페어링 흐름(`CREATED → PAIRED`) 한 줄.
+> Frame (P1): 학습/시연 + Phase F 자산 활성화 + 새 기여 주장 0건.
+
+---
+
+## §0. 도입 — 왜 Session을 통합체로 선택했나?
+
+mind-signal-backend의 핵심 비즈니스 단위는 "한 번의 EEG 실험 세션"이다. 이 한 세션이 `CREATED → PAIRED → MEASURING → COMPLETED`의 상태 머신을 거치고, 각 전이에 명확한 트리거(QR 스캔, 측정 시작, 정상 완료, 만료/취소)가 있다. 외부 의존(파이썬 엔진, GenAI API)이 적고, 도메인 규칙이 한 도큐먼트에 응집된다.
+
+후보 비교 (`DISCUSS.md §8`):
+- **Session** ✅ — 상태 머신 명확, 라이프사이클 1 도큐먼트, 5/26 시연 흐름(QR 페어링)과 직접 연관
+- `Measurement` — Python 데이터 엔진과 강결합, BE 단독 경계 흐림 (보류)
+- `AnalysisResult` — GenAI API 외부 의존이 핵심, BE 단독 의미 약함 (보류)
+
+따라서 본 단계 통합체 = `SessionAggregate` (단일). 다른 엔티티(User, EegRecord, AnalysisResult)는 그대로 엔티티 상태 유지.
+
+---
+
+## §1. 6Q 답변 (실측 정합)
+
+본 섹션은 `DOMAIN-MODEL-NOTES.md §3.4`를 그대로 옮긴 표를 코드 참조와 함께 박제한다. 모든 답변은 `code-review-graph` MCP 실측(130 files / 630 nodes / 4647 edges, 2026-05-12) 기반.
+
+### Q1. Invariant — 절대 깨지면 안 되는 규칙
+
+**답변** (두 층위로 분리):
+
+**(a) 단일 Session 도큐먼트 차원** (`SessionAggregate` 책임):
+- `pairingToken !== ''` (빈 토큰 금지)
+- `subjectIndex >= 1` (그룹 내 번호는 1부터)
+- status 전이 그래프 강제 — `canTransitionTo()`가 enforce (`session.schema.ts:131-153`)
+- 만료 후 `CREATED` 상태에서는 `EXPIRED`만 허용 (`session.schema.ts:138`)
+
+**(b) 그룹 차원** (Mongoose 인덱스 책임, aggregate 외부):
+- 같은 `groupId`에 `subjectIndex` 1과 2가 한 번씩만 등장 → `groupId_subjectIndex_unique` 복합 unique 인덱스 (`session.schema.ts:156`)
+
+**근거**: DOMAIN-MODEL-NOTES §1.1 / §3.4 Q1. **본 SessionAggregate는 그룹 invariant를 책임지지 않음** (Q4 정합).
+
+**Code참조**:
+- `session.schema.ts:13-19` (status enum)
+- `session.schema.ts:131-153` (canTransitionTo)
+- `session.schema.ts:156` (복합 unique 인덱스)
+
+---
+
+### Q2. Transitions — 상태 전이 명세
+
+**상태 6종** (`Session['status']` union):
+`CREATED` / `PAIRED` / `MEASURING` / `COMPLETED` / `EXPIRED` / `CANCELLED`
+
+**전이 표** (모든 허용/금지 명세):
+
+| 출발 상태 | 도착 상태 | 허용 | 트리거 메서드 |
+|---|---|---|---|
+| (시작) | CREATED | ✅ | `SessionAggregate.create()` |
+| CREATED | PAIRED | ✅ | `aggregate.pair(userId)` |
+| CREATED | EXPIRED | ✅ | `aggregate.expire()` (5분 타임아웃) |
+| CREATED | CANCELLED | ✅ | `aggregate.cancel(reason)` |
+| CREATED | MEASURING | ❌ | 페어링 미완 — 불허 |
+| PAIRED | MEASURING | ✅ | `aggregate.markMeasuring()` |
+| PAIRED | CANCELLED | ✅ | `aggregate.cancel(reason)` |
+| PAIRED | EXPIRED | ❌ | 이미 페어링됨 — 불허 |
+| MEASURING | COMPLETED | ✅ | `aggregate.complete()` |
+| MEASURING | CANCELLED | ✅ | `aggregate.cancel(reason)` (10초 무응답) |
+| COMPLETED/EXPIRED/CANCELLED | (어디든) | ❌ | 종착 상태 — 어떤 전이도 불허 |
+
+**만료 분기** (`canTransitionTo` 특수 규칙):
+- `isExpired() === true` + `current === 'CREATED'` → `EXPIRED`만 허용 (다른 전이 모두 차단)
+
+**근거**: `session.schema.ts:131-153` 실측. `mind-signal-backend/CLAUDE.md §7` 박제.
+
+**본 단계 시연 범위**:
+- **실제 구현**: `CREATED → PAIRED` (`SessionAggregate.pair(userId)`)
+- **메서드 골조만**: `markMeasuring()`, `complete()`, `expire()`, `cancel()` 4개 — 후속 단계에서 활성화
+
+---
+
+### Q3. Events — 어떤 사실을 발행하는가?
+
+**답변**: `SessionPairedEvent` 단일.
+
+**Shape** (`SessionPairedEvent` 타입 정의):
+
+```typescript
+export type SessionPairedEvent = {
+  type: 'SessionPaired';
+  sessionId: string;
+  userId: string;          // 페어링한 Subject의 userId
+  occurredAt: string;       // ISO 8601
+  groupId: string;          // 8-hex 대문자
+  subjectIndex: number;    // 1 또는 2
+  mode: ExperimentMode;     // DUAL | SEQUENTIAL | BTI | DUAL_2PC
+};
+```
+
+**발행 방식 — 두 가지 동시 수행** (DOMAIN-MODEL-NOTES §3.6 옵션 A — 통합):
+
+1. **메모리 내 기록** (`PairSubjectService.recordedEvents` 배열) — 테스트 검증용
+2. **기존 `pairingListeners` 호출** — 런타임 동작 보존 (LD-12 대안 D, `pairing.service.ts:13/126-135`)
+
+기존 `pairingListeners`의 callback shape는 `cb({ groupId: string; subjectIndex: number | null }) => void | Promise<void>` (`pairing.service.ts:9-12`). 본 신규 도메인 이벤트는 더 풍부한 정보(`type`, `sessionId`, `userId`, `occurredAt`, `mode`)를 포함한다.
+
+**미채택 패턴**:
+- `pullDomainEvents()` 발행 큐 (Phase E TS-Q17 A3 LOCK 정합)
+- Persisted outbox (별도 ADR 검토 대상)
+
+---
+
+### Q4. Consistency Boundary — 트랜잭션 단위는?
+
+**답변**: **단일 Session 도큐먼트**. 1 `SessionAggregate` = 1 MongoDB document = 1 트랜잭션 단위.
+
+**boundary 외부 책임** (aggregate가 책임지지 않음):
+- **그룹 단위 unique** (`groupId+subjectIndex`) → Mongoose `groupId_subjectIndex_unique` 복합 인덱스가 enforce
+- **`group_counters` 원자 할당** (`subjectIndex`) → 기존 `createGroupSessionProcess` (`pairing.service.ts:38-75`) 책임. 본 단계 페어링 흐름에 **미사용** (code-review-graph 실측 — `pairDeviceProcess` callees에 `group_counters` 호출 0건)
+
+**페어링 흐름 ↔ 세션 생성 흐름 분리**:
+- `createGroupSessionProcess` (세션 생성, `group_counters` 사용) — 본 단계 미수정
+- `pairDeviceProcess` (페어링, `Session.findOne({pairingToken})` 직접 조회) — 본 단계 미수정 (strangler — 신규 `PairSubjectService`와 병렬)
+- 두 흐름은 같은 파일에 있지만 **호출 경로가 분리**되어 있음 (callees graph 검증)
+
+**근거**: DOMAIN-MODEL-NOTES §1.2 / §3.4 Q4. DISCUSS rev.4 §9.3 stale 정정 — "본 단계가 카운터 호출을 응용 서비스에 가져오지 않음" 명시.
+
+---
+
+### Q5. Creator — 누가 통합체를 만드는가?
+
+**답변** (두 흐름 분리):
+
+**기존 흐름** (본 단계 미변경):
+- `createGroupSessionProcess(groupId?, creatorId?)` — 운영자(Operator)가 QR 발급 시 호출. `crypto.randomBytes(4)` 8-hex `groupId` 생성 → `group_counters` `$inc`로 `subjectIndex` 원자 할당 → `crypto.randomBytes(3)` 6-hex `pairingToken` 생성 → `new Session({...}).save()` (status `CREATED`, 5분 만료).
+
+**신규 흐름** (본 단계 추가, strangler):
+- `PairSubjectService.execute({pairingToken, userId})` — 피실험자(Subject)가 QR 스캔 시 호출. 페어링 한 줄 흐름만 처리 (`CREATED → PAIRED`). **새 Session 도큐먼트를 만들지 않음** — 기존 도큐먼트의 상태 전이만.
+
+**Aggregate 생성 시점**:
+- DB에서 꺼낼 때: `SessionRepository.fromDocument(doc)` 또는 `SessionRepository.findByPairingToken(token)` 어댑터가 `SessionAggregate.fromDocument()` 호출
+- 신규 생성 시: `SessionAggregate.create({ id, groupId, subjectIndex, pairingToken, operatorId, mode, expiresAt })` 7 인자 factory. 본 단계는 BDD 테스트에서만 직접 호출.
+
+**근거**: DOMAIN-MODEL-NOTES §3.4 Q5. PLAN §6.2 T1.1 코드 스케치.
+
+---
+
+### Q6. Forbidden — 절대 허용하면 안 되는 동작
+
+**답변** (3 종):
+
+**(a) `COMPLETED → MEASURING` 불가**: 측정이 정상 완료된 세션을 다시 측정 중으로 되돌리면 데이터 무결성 깨짐. `canTransitionTo`가 차단 (`session.schema.ts:147` — `COMPLETED: []`).
+
+**(b) 종착 상태에서 전이 0건**: `COMPLETED` / `EXPIRED` / `CANCELLED` 세 상태에서 어떤 전이도 금지. 모두 빈 배열 (`session.schema.ts:147-149`).
+
+**(c) `subjectIndex < 1` 불허**: 피실험자 번호는 1부터 시작. 0이나 음수는 invariant 위반 → `InvariantViolationError`. `SessionAggregate.create()` 입력 검증.
+
+**근거**: DOMAIN-MODEL-NOTES §3.4 Q6. `session.schema.ts:142-150` (transitions 표).
+
+---
+
+## §2. Aggregate Boundary 결정 — "단일 Session 도큐먼트"인 이유
+
+**대안**:
+- **A. 단일 Session** (선택) ✅
+- **B. Group을 통합체로** — `groupId` 하나에 1~2 Session을 묶는 큰 통합체
+
+**대안 B 거부 이유**:
+- 그룹 단위 unique 보장은 Mongoose 인덱스 + `group_counters` 원자 연산이 이미 충분히 처리. aggregate에 흡수 시 동시성 제어 복잡도 ↑
+- 그룹 단위 트랜잭션은 MongoDB에서 cross-document 트랜잭션 필요 — 단일 도큐먼트 쓰기보다 비용/복잡도 ↑
+- 그룹 invariant("같은 groupId에 subjectIndex 1과 2가 unique")는 이미 Mongoose 복합 인덱스가 enforce하므로 aggregate 흡수 net value 약함
+
+**근거**: Vernon 2011 "Effective Aggregate Design Part I" — "Smaller aggregates preferred. Use the aggregate as a unit for data storage operations." (`session.schema.ts:156` 정합).
+
+---
+
+## §3. P1 Frame 정합
+
+본 6Q 답변은 다음 frame 안에서 작성되었음 (학습/시연 + Phase F 자산 활성화 + 새 기여 주장 0건):
+
+1. **학습**: 6Q × DDD 매핑을 mind-signal에 적용해 본 첫 사례 — 학생 horizon 학습 가치
+2. **시연**: 2026-05-26 교수 면담에서 `SessionAggregate` + `PairSubjectService` 흐름과 BDD 시나리오를 한국어로 낭독
+3. **Phase F 자산 활성화**: `.claude/skills/office-hours-ddd-discovery/SKILL.md` (Phase F 박제, SHA256 byte-identical) 활용
+4. **새 기여 주장 0건**: 6Q gstack 원본 (Garry Tan v2.0.0 MIT) + Vernon 2011 + Stemmler 2019 산업 표준 적용. 차별점 = 학생 horizon + 한국어 명명 가이드 + Phase F 자산 활성화 (모두 market-tier)
+
+---
+
+## §4. 후속 단계로 넘기는 결정
+
+- **`pullDomainEvents()` 발행 큐** — 본 단계 미채택. Phase H/I에서 재평가.
+- **Persisted outbox 패턴** — 본 단계 미채택. 별도 ADR.
+- **`__v` 낙관적 잠금** — 현재 `toJSON()`에서 삭제 중. 본 단계 그대로 유지, 별도 ADR.
+- **HTTP 라우트 `GET /join/:token` 리팩토링** — Q1 LOCK으로 본 단계는 응용 서비스 직접 호출만. 컨트롤러 연결은 별도 PR.
+- **나머지 5개 상태 전이의 응용 서비스화** — `PAIRED → MEASURING / MEASURING → COMPLETED / * → EXPIRED / * → CANCELLED` — 후속 단계 평가.
+
+---
+
+## §5. 참조 표
+
+| 항목 | 위치 |
+|---|---|
+| 코드 실측 단일 근거 | `.plans/G-mind-signal-ddd-bdd-tdd/DOMAIN-MODEL-NOTES.md` |
+| Aggregate 설계 결정 LOCK | `.plans/G-mind-signal-ddd-bdd-tdd/DISCUSS.md` rev.4 (Q1~Q6) |
+| 한국어 명명 가이드 | `.plans/G-mind-signal-ddd-bdd-tdd/NAMING-GUIDE.md` rev.2 |
+| 실행 계획 (Wave 0~3) | `.plans/G-mind-signal-ddd-bdd-tdd/PLAN.md` rev.3 |
+| 6Q 일반 가이드 | `docs/patterns/ddd-discovery-via-6q.md` |
+| 6Q 스킬 (gstack v2.0.0 MIT) | `.claude/skills/office-hours-ddd-discovery/SKILL.md` |
+| Pocock TDD 스킬 (MIT) | `.claude/skills/tdd/SKILL.md` |
+
+---
+
+**END docs/patterns/session-aggregate-6q-applied.md** — Session aggregate 6Q discovery 박제. DOMAIN-MODEL-NOTES §3.4 정합.

--- a/docs/reports/paar-2026-05-12-phase-g-isolation-proof.md
+++ b/docs/reports/paar-2026-05-12-phase-g-isolation-proof.md
@@ -1,0 +1,113 @@
+# Phase G — Isolation Proof (Wave 3 T3.0)
+
+> 작성일: 2026-05-12
+> 가지: `feat/G-ddd-bdd-tdd-pilot`
+> 검증: Phase 18 (`02-processes/engine/`) + Phase 17.6 (`dual-trigger.service.ts`) + 기존 `pairing.service.ts` 수정 0건
+> Gate: G9 (PLAN rev.3 §9)
+
+---
+
+## 1. 검증 명령 + 실제 출력
+
+### 1.1 `src/02-processes/engine/` 수정 0건 (Phase 18 충돌 회피)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat src/02-processes/engine/
+(empty)
+```
+
+→ **0 hunks** ✅. Phase 18 engine-proxy-sync PLAN.md scope와 file overlap 0건.
+
+### 1.2 `src/05-features/sessions/services/pairing.service.ts` 수정 0건 (strangler 보존)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat -- src/05-features/sessions/services/pairing.service.ts
+(empty)
+```
+
+→ **0 hunks** ✅. 기존 함수 `pairDeviceProcess` / `createGroupSessionProcess` / `pairingListeners` / `addPairingCompleteListener` / `removePairingCompleteListener` 5종 모두 보존. 신규 `PairSubjectService`는 병렬 존재 (strangler).
+
+### 1.3 `src/02-processes/measurements/` 수정 0건 (측정 흐름 scope 외)
+
+```bash
+$ git diff dev..feat/G-ddd-bdd-tdd-pilot --stat src/02-processes/measurements/
+(empty)
+```
+
+→ **0 hunks** ✅.
+
+### 1.4 전체 변경 파일 stat (Phase G scope 내 27 files)
+
+```
+.claude/skills/office-hours-ddd-discovery/SKILL.md       |  93 +
+.claude/skills/office-hours-ddd-discovery/UPSTREAM.md    |  76 +
+.claude/skills/tdd/SKILL.md                              | 109 +
+.claude/skills/tdd/UPSTREAM.md                           |  53 +
+.claude/skills/tdd/_local-addendum.md                    | 102 +
+.claude/skills/tdd/deep-modules.md                       |  33 +
+.claude/skills/tdd/interface-design.md                   |  31 +
+.claude/skills/tdd/mocking.md                            |  59 +
+.claude/skills/tdd/refactoring.md                        |  10 +
+.claude/skills/tdd/tests.md                              |  61 +
+.dependency-cruiser.cjs                                  |  19 +
+.gitignore                                               |   6 +-
+docs/guides/_template.md                                 |  97 +
+docs/patterns/ddd-discovery-via-6q.md                    |  84 +
+docs/patterns/session-aggregate-6q-applied.md            | 213 +
+src/05-features/sessions/__tests__/pair-subject.bdd.test.ts | 193 +
+src/05-features/sessions/services/pair-subject.service.test.ts | 158 +
+src/05-features/sessions/services/pair-subject.service.ts | 120 +
+src/06-entities/sessions/domain/errors.ts                |  42 +
+src/06-entities/sessions/domain/session.aggregate.test.ts | 110 +
+src/06-entities/sessions/domain/session.aggregate.ts     | 199 +
+src/06-entities/sessions/domain/session.event.ts         |  24 +
+src/06-entities/sessions/index.ts                        |  12 +
+src/06-entities/sessions/model/session.schema.ts         |  14 +-
+src/06-entities/sessions/repository/session.repository.test.ts | 158 +
+src/06-entities/sessions/repository/session.repository.ts | 103 +
+src/06-entities/sessions/types/session.types.ts          |  24 +
+
+27 files changed, 2193 insertions(+), 10 deletions(-)
+```
+
+**변경 범위 분류**:
+
+| 범위 | 파일 수 | 변경 |
+|---|---|---|
+| Phase F skill vendoring (Wave 0 T0.1) | 10 | byte-identical 복제 + 1 신규 _local-addendum |
+| docs/patterns + docs/guides (Wave 0 T0.2) | 3 | byte-identical 복제 2 + 신규 6Q applied 1 |
+| .dependency-cruiser.cjs (Wave 0 T0.3) | 1 | R-DDD-1/R-DDD-2 규칙 2 추가 |
+| .gitignore | 1 | `.claude/skills/` unignore (T0.1) |
+| 신규 도메인 layer (Wave 1) | 7 | domain/ 4 + repository/ 2 + types/ 1 |
+| 06-entities/sessions index.ts (Wave 1) | 1 | SessionAggregate/SessionRepository 추가 export |
+| 06-entities/sessions/model/session.schema.ts (Wave 1 T1.0) | 1 | type-only 재구성 14 lines (런타임 동작 0건 변경) — SessionStatus import + L25 코멘트 |
+| 신규 응용 서비스 (Wave 2) | 3 | services/pair-subject.service + .test + __tests__/pair-subject.bdd.test |
+
+**런타임 비즈니스 로직 코드 수정**: **0건**.
+**기존 import path 변경**: **0건** (`Session`/`SessionDoc`/`SessionMethods`/`SessionModel` export 보존, 외부에서 `Session['status']` indexed access 그대로 작동).
+
+---
+
+## 2. Gate G9 통과 확정
+
+PLAN rev.3 §9 Gate G9:
+
+| 항목 | 명령 | 통과 기준 | 결과 |
+|---|---|---|---|
+| Phase 18 engine/ 수정 0건 | `git diff main..HEAD -- src/02-processes/engine/` | 빈 출력 | ✅ |
+| Phase 17.6 dual-trigger.service.ts 수정 0건 | `git diff main..HEAD -- src/02-processes/engine/services/dual-trigger.service.ts` | 빈 출력 | ✅ (engine/ 통째 확인으로 함께 검증) |
+| pairing.service.ts 수정 0건 (rev.3 G9 보강) | `git diff main..HEAD -- src/05-features/sessions/services/pairing.service.ts` | 빈 출력 | ✅ |
+| measurements/ 수정 0건 (scope 외) | `git diff main..HEAD -- src/02-processes/measurements/` | 빈 출력 | ✅ |
+
+**Gate G9 PASS** ✅.
+
+---
+
+## 3. 후속 단계
+
+- T3.1: `npm run verify` 6단계 GREEN 검증 (format:check + typecheck + depcruise + lint + test + build)
+- T3.2: ADR-NNN + RTM 행 박제 (Wave 3 종료)
+
+---
+
+**END paar-2026-05-12-phase-g-isolation-proof.md** — G9 PASS 박제 완료. Phase 18 / 17.6 / pairing.service.ts 수정 0건 확정.

--- a/docs/reports/paar-2026-05-12-phase-g-verify-green.md
+++ b/docs/reports/paar-2026-05-12-phase-g-verify-green.md
@@ -1,0 +1,75 @@
+# Phase G — Verify GREEN (Wave 3 T3.1)
+
+> 작성일: 2026-05-12
+> 가지: `feat/G-ddd-bdd-tdd-pilot`
+> 검증: `npm run verify` 6단계 모두 PASS — Gate G8
+> Baseline 회귀 0건
+
+---
+
+## 1. `npm run verify` 6단계 결과
+
+| # | 단계 | 명령 | 결과 |
+|---|---|---|---|
+| 1 | format:check | `prettier --check "src/**/*.ts"` | ✅ All matched files use Prettier code style! |
+| 2 | typecheck | `tsc --noEmit` | ✅ no errors |
+| 3 | depcruise | `depcruise src --config .dependency-cruiser.cjs` | ✅ no dependency violations found (123 modules / 300 dependencies cruised) |
+| 4 | lint | `eslint . --ext .ts` | ✅ no warnings/errors (--max-warnings 0) |
+| 5 | test | `jest` | ✅ Test Suites: 30 passed, Tests: **288 passed, 0 failed** |
+| 6 | build | `tsc && tsc-alias` | ✅ exit 0 |
+
+**Gate G8 PASS** ✅ — 6/6 단계 통과.
+
+---
+
+## 2. 회귀 안전 (baseline 비교)
+
+| 시점 | Test Suites | Tests | 변화 |
+|---|---|---|---|
+| Phase G 진입 전 (dev HEAD `9442e4d`) | 26 | 267 | baseline |
+| Wave 1 종료 (`31484d5` 직후) | 28 | 280 | +2 suites / +13 tests (T1.1 8 + T1.2 5) |
+| Wave 2 종료 (`ceb0191` 직후) | 30 | 288 | +2 suites / +8 tests (T2.1 5 + T2.2 3) |
+| Wave 3 T3.1 (`npm run verify` 시점) | **30** | **288** | 회귀 0건 ✅ |
+
+**기존 267 + 신규 21 = 288** (rev.3 명시 "≥ 18" 충족 — 실제 21 신규).
+
+**Phase G 신규 21 테스트 분류** (rev.3 정합):
+- AC3 SessionAggregate (T1.1): **8 PASS**
+- AC4 SessionRepository (T1.2): **5 PASS** (3 시나리오 + 2 null 보조)
+- AC5 PairSubjectService (T2.1): **5 PASS** (4 시나리오 + 1 userId 형식 보조)
+- AC6 BDD acceptance (T2.2): **3 PASS**
+
+---
+
+## 3. prettier 적용 7 파일 (T3.1 사전 작업)
+
+`npm run format` 실행 후 다음 7 파일이 prettier 규칙 정합으로 자동 수정됨:
+- `src/05-features/sessions/__tests__/pair-subject.bdd.test.ts`
+- `src/05-features/sessions/services/pair-subject.service.test.ts`
+- `src/05-features/sessions/services/pair-subject.service.ts`
+- `src/06-entities/sessions/domain/session.aggregate.test.ts`
+- `src/06-entities/sessions/domain/session.aggregate.ts`
+- `src/06-entities/sessions/repository/session.repository.test.ts`
+- `src/06-entities/sessions/repository/session.repository.ts`
+
+코드 동작 변경 0건 (whitespace/줄바꿈/괄호 자동 fixup만).
+
+---
+
+## 4. Gate G8 통과 의무 항목 (PLAN rev.3 §9)
+
+- [x] `npm run verify` 6단계 모두 PASS
+- [x] 기존 baseline 회귀 0건 (267 → 288 회귀 0)
+- [x] 신규 테스트 ≥ 18건 — 실제 **21건** PASS
+- [x] `eslint-disable` / `ts-ignore` / `test.skip()` 신규 0건
+- [x] Phase 18 / 17.6 / `pairing.service.ts` 수정 0건 (G9 T3.0 commit `214f481` 사전 확인 완료)
+
+---
+
+## 5. 후속 단계
+
+- T3.2 (다음): ADR-NNN-session-aggregate-ddd-pilot.md 박제 + RTM.md DR-G 행 추가
+
+---
+
+**END paar-2026-05-12-phase-g-verify-green.md** — Gate G8 PASS. 회귀 0건 + 6단계 GREEN + 신규 21 테스트 PASS.

--- a/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md
@@ -1,0 +1,219 @@
+# PAAR — Phase G slice (deep-module PoC Step 4b — Claude 4-Lens 반박)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 4b (Claude 4-Lens 반박)
+> 선행: `paar-2026-05-13-deep-module-poc-codex-r1.md` (Step 4a — codex 5.5 1차)
+> 다음: Step 4c — codex 5.5 2차 재응답
+> 검토 단위: codex r1 응답 (Q1 / Q2 / Q3) 각 항목별 4-Lens 적용 + Claude 단독 발견
+
+---
+
+## 0. 4-Lens 정의 (DISCUSS.md / HANDOFF.md §6 박제 정합)
+
+| Lens | 적용 질문 | 통과 조건 |
+|---|---|---|
+| Lens 1 — Contract | codex 응답이 인용한 Matt Pocock 원리 (LANGUAGE.md 7 terms)가 실제 코드에 적용 가능한가? | 인용 원리가 mermaid + 코드 양쪽 정합 |
+| Lens 2 — Reality | codex 응답이 mermaid 외 정보를 환각으로 추가하지 않았나? | 모든 가설이 코드 read로 검증됨 |
+| Lens 3 — Completeness | codex가 놓친 shallow / seam / 후보가 있는가? | Claude 단독 후보 ≥ 1건 |
+| Lens 4 — Runtime Contract | codex 제안이 Phase G BDD 3 시나리오 invariant를 깨뜨리는가? | invariant 보존 + 회귀 0 정합 |
+
+---
+
+## 1. Lens 1 — Contract (codex 인용 원리 정합성)
+
+### 1.1 Q1 PS shallow 의심 — 4 원리 동시 인용
+- codex: Depth + Deletion test + Locality + Adapter/Seam
+- **검증**:
+  - Depth: PS interface 2개 (`execute`, `drainRecordedEvents`) vs implementation 5단계 흐름 (L58-109) → 정성 비교상 Depth 후보 정합 ✅
+  - Deletion test: PS 제거 시 책임 분산 가설 — PS L65, L72, L78, L94, L106 5개 호출 지점 모두 caller(controller 또는 BDD test)로 흩어질 → 정합 ✅
+  - Locality: 페어링 invariant + 만료 처리 + 이벤트 기록 3개 책임이 PS에 집중 → "change concentrates at one place" 정합 ✅
+  - Adapter/Seam: D-3 hypothetical seam 직접 인용 → 정합 ✅
+- **결론**: 4 원리 모두 LANGUAGE.md 정합 인용 ✅
+
+### 1.2 Q2 §2.4 D-4 value-object 권고 — 인용 원리 위치 검토
+- codex 권고: `SessionId` / `ObjectIdParser` value-object
+- 인용 위치: codex는 "INTERFACE-DESIGN.md §design twice" 명시 인용 없음. 일반 DDD value-object 개념으로만 제시.
+- **반박**: 본 권고는 LANGUAGE.md 7 terms 영역이 아닌 INTERFACE-DESIGN.md §"design twice" 또는 DDD value-object 영역. **Pass 기준 B (adapter 후보 ≥ 3)에서는 D-4를 후보에서 제외**하는 것이 codex 응답의 함의 (codex 본인이 "adapter 누락이라고 단정하지 않음" 명시).
+- **결론**: codex 응답 자체는 정합하나, B 기준 매칭에서 D-4를 제외하는 것이 더 정확 — paar-depth §4 사전 인벤토리도 D-4를 별도 port 불필요로 박제했으므로 정합 ✅
+
+### 1.3 Lens 1 통과 ✅
+
+---
+
+## 2. Lens 2 — Reality (codex 환각 검증)
+
+### 2.1 Q1 SA "isExpired interface가 시간 제어를 드러내지 못함"
+- **코드 검증**: `session.aggregate.ts:162-164`
+  ```typescript
+  isExpired(): boolean {
+    return this._expiresAt.getTime() < Date.now();
+  }
+  ```
+- **결론**: codex 가설 정합 ✅
+  - no-arg 메서드 + 내부 `Date.now()` 호출 = caller가 시간 제어 불가
+  - 테스트 시 `jest.useFakeTimers` 또는 시스템 시간 조작 외 대안 없음 (port 부재)
+
+### 2.2 Q2 §2.4 D-4 ObjectId.isValid
+- **코드 검증**: `pair-subject.service.ts:60`
+  ```typescript
+  if (!Types.ObjectId.isValid(input.userId)) {
+    throw new AppError('유효하지 않은 사용자 ID 형식입니다', 400);
+  }
+  ```
+- **결론**: codex 가설 정합 ✅
+  - `import { Types } from 'mongoose'` (L22) — feature service가 persistence library에 직접 의존
+  - codex 권고대로 `SessionId` value-object 도입 시 persistence concern 격리 가능
+
+### 2.3 Q1 PS "구현 책임이 SR, SA, D2, D3, D4로 넓게 퍼져있다"
+- **코드 검증**: PS L60 (D-4) + L65 (SR.findByPairingToken) + L72 (SA.pair) + L76 (SA.isExpired 간접 D-2) + L77 (SA.expire) + L78 (SR.save) + L94 (SR.save) + L101 (`new Date()` 직접 D-2) + L106 (recordedEvents A-3 우회)
+- **결론**: codex 가설 정합 ✅ — 5 의존 노드 모두 PS 본문에서 호출 확인
+
+### 2.4 Lens 2 통과 ✅ — 환각 0건
+
+---
+
+## 3. Lens 3 — Completeness (codex가 놓친 Claude 단독 후보)
+
+### 3.1 🆕 SA `cancel(_reason: CancelReason)` 파라미터 미사용
+- **코드 위치**: `session.aggregate.ts:150-159`
+  ```typescript
+  cancel(_reason: CancelReason): void {
+    if (
+      this._status === 'COMPLETED' ||
+      this._status === 'EXPIRED' ||
+      this._status === 'CANCELLED'
+    ) {
+      throw new InvalidStatusTransitionError(this._status, 'CANCELLED');
+    }
+    this._status = 'CANCELLED';
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §"the interface is the test surface" — Interface가 caller에게 `reason: CancelReason`을 받지만 implementation에서 폐기 (underscore prefix `_reason`). 즉 **"Interface that lies"** 패턴.
+- **분류**: Pass A 후보 추가 (A-5로 명명) — `cancel(_reason)`은 미래 확장을 위한 Sentinel signature이나 본 단계에서는 dead parameter
+
+### 3.2 🆕 PS constructor `repo?: SessionRepository` optional default
+- **코드 위치**: `pair-subject.service.ts:47-49`
+  ```typescript
+  constructor(repo?: SessionRepository) {
+    this.repo = repo ?? new SessionRepository();
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Seam + DEEPENING.md §Seam discipline — Constructor injection이 optional default fallback을 갖는다는 것은 **caller에게 "주입 안 해도 동작"이라고 신호**. Two-adapter rule 정합 (prod = `new SessionRepository()` / test = jest.mock)이지만, default fallback 자체가 seam을 약화시킴.
+- **분류**: Pass A 후보 추가 (A-6) — adapter at seam이 "soft seam" (defaultable)
+- **참고**: INTERFACE-DESIGN.md §"design twice"에서 권고할 수 있는 영역 (required injection vs optional fallback)
+
+### 3.3 🆕 PS L72-91 try-catch + `isExpired()` 재호출 — Clock race
+- **코드 위치**: `pair-subject.service.ts:72-83`
+  ```typescript
+  try {
+    aggregate.pair(input.userId);
+  } catch (err) {
+    if (err instanceof InvalidStatusTransitionError) {
+      if (aggregate.isExpired()) {  // L76 — pair()에서 isExpired 호출 후 재호출
+        aggregate.expire();
+        await this.repo.save(aggregate);
+        throw new AppError(...401);
+      }
+      // ...
+    }
+  }
+  ```
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Locality — `aggregate.pair()` 내부에서 `isExpired()` 1차 호출 (L114, throws InvalidStatusTransitionError), catch 후 PS L76에서 `isExpired()` 2차 호출. **두 시점 사이 시간 흐름** → Clock race 가능. Clock seam이 hypothetical인 직접 증거이자, Two-adapter rule 적용 시 fixedClock으로 race 제거 가능.
+- **분류**: Pass A 후보 추가 (A-7) — Clock seam 부재의 직접 증거 (codex Q1 §1.2 SA 의심을 강화)
+
+### 3.4 🆕 SA `fromDocument` invariant 검증 부재 vs `create` invariant 강제
+- **코드 위치**:
+  - `create()` L69-77: `pairingToken === ''` 또는 `subjectIndex < 1` 시 `InvariantViolationError` throw
+  - `fromDocument()` L93-106: invariant 검증 0건. DB 도큐먼트를 그대로 신뢰
+- **codex 미언급**
+- **원리 위반**: LANGUAGE.md §Locality + §Depth — invariant 강제 책임이 `create` 한 곳에만 locality가 있고, `fromDocument`는 우회 통로. 즉 DB에 invariant 위반 데이터가 있으면 SA가 통과시켜 buggy aggregate 반환 가능.
+- **분류**: Pass A 후보 추가 (A-8) — invariant locality 균열. mermaid에 표현되지 않은 코드 내부 책임 분포.
+
+### 3.5 Lens 3 통과 ✅ — Claude 단독 후보 4건 (A-5/A-6/A-7/A-8)
+
+---
+
+## 4. Lens 4 — Runtime Contract (Phase G BDD 3 시나리오 invariant)
+
+### 4.1 BDD 3 시나리오 (Q1 LOCK, paar-2026-05-13-deep-module-poc-slice.md 박제)
+1. CREATED + valid token → PAIRED + SessionPaired event 1건
+2. CREATED + expired token → EXPIRED + AppError 401
+3. PAIRED + retry → AppError 400 (전이 불가)
+
+### 4.2 codex 권고 vs BDD 시나리오 invariant 영향
+| codex 권고 | invariant 영향 | 평가 |
+|---|---|---|
+| Q3 PS 1순위 TDD | 시나리오 추가일 뿐 — 기존 3 시나리오 보존 | ✅ 정합 |
+| Δ-3 A-2 연결도 시정 (SA → A-2, PS → A-2, A-2 → D-2) | src 수정 필요 — 본 PoC는 권고만 박제, 실제 수정 X | ✅ 회귀 0 |
+| Δ-4 A-3 → A-5 재명명 + 연결도 | src 수정 필요 — 본 PoC는 권고만 박제 | ✅ 회귀 0 |
+| Δ-5 D-4 value-object 도입 | SessionId 도입 시 SA `pair(userId: string)` 시그니처 변경 필요 — BDD 시나리오 수정 필요 가능 | 🟡 **다음 PR 결정 영역**, 본 PoC 회귀 0 정합 |
+
+### 4.3 Claude 단독 후보 vs BDD 시나리오 invariant 영향
+| 후보 | invariant 영향 | 평가 |
+|---|---|---|
+| A-5 `cancel(_reason)` dead param | 시나리오 #1/#2/#3 모두 cancel 미호출 — 영향 0 | ✅ 무관 |
+| A-6 PS constructor optional repo | BDD test에서 `new PairSubjectService(mockRepo)` 명시 주입 가능 — 영향 0 | ✅ 무관 |
+| A-7 Clock race | 시나리오 #2 expired token — Clock seam 도입 시 시나리오 더 결정적이 됨 (개선) | ✅ 정합 |
+| A-8 fromDocument invariant 부재 | 시나리오 #1 시작점이 fromDocument 경로 (DB → aggregate) — 현재 DB 데이터 유효성 가정. invariant 추가 시 시나리오 강화 | ✅ 정합 |
+
+### 4.4 Lens 4 통과 ✅ — invariant 위반 0건, 회귀 0 유지
+
+---
+
+## 5. 4-Lens 종합 + Pass 기준 갱신 매칭
+
+### 5.1 Lens 종합
+| Lens | 결론 |
+|---|---|
+| Lens 1 Contract | ✅ codex 인용 원리 모두 LANGUAGE.md 정합 (D-4 value-object는 INTERFACE-DESIGN 영역으로 이동) |
+| Lens 2 Reality | ✅ codex 응답 환각 0건 — isExpired no-arg + ObjectId.isValid 직접 의존 + 5 의존 노드 모두 코드 정합 |
+| Lens 3 Completeness | ✅ Claude 단독 후보 4건 (A-5/A-6/A-7/A-8) — mermaid에 표현되지 않은 코드 내부 책임 분포 |
+| Lens 4 Runtime Contract | ✅ Phase G BDD 3 시나리오 invariant 보존, 회귀 0 정합 |
+
+### 5.2 Pass 기준 갱신 매칭
+| 기준 | 사전 인벤토리 | codex r1 발견 | Claude 단독 추가 | Step 4b 잠정 결과 |
+|---|---|---|---|---|
+| A ≥ 2 구조 문제 | 4 (A-1~A-4) | 4 (PS shallow + SA clock + D-3 hypothetical + SA interface 약함) | 4 (A-5~A-8) | **총 8 후보, 매칭 6건 (A-1/A-2/A-3 부분/A-4)** ✅ |
+| B ≥ 3 adapter 후보 | 3 (D-1/D-2/D-3 → A-1/A-2/A-3) | 3 매칭 + 연결도 시정 권고 + Δ-1 localSubstitutable 분리 | 0 추가 | **3건 모두 매칭** ✅ |
+| C ≥ 1 cross-LLM delta | 측정 불가 | 5 신규 (Δ-1~Δ-5) | 4 신규 (A-5~A-8) | **총 9 delta** ✅ |
+| D 회귀 0 | 충족 | src 수정 0 | src 수정 0 (read-only) | **충족** ✅ |
+
+### 5.3 잠정 GO 신호 (Step 4c codex 2차 후 최종 확정)
+- A/B/C/D 4 기준 모두 잠정 충족
+- 끼워맞추기 없음 — Claude 단독 후보 4건은 mermaid + 코드 read로 객관 검증 가능
+- Step 4c에서 codex가 4-Lens 반박을 받아들이는지 + 추가 발견 있는지 확인 필요
+
+---
+
+## 6. Step 4c 진입 — codex 2차 prompt 가이드
+
+### 6.1 전달 내용
+1. codex r1 응답 (codex 자체 thread `019e1f11-50e0-7001-b4ce-2b7791d6b407` 보존)
+2. 본 4-Lens 반박 요약 4건:
+   - Lens 1 §1.2 — D-4 value-object 권고는 INTERFACE-DESIGN 영역 (B 기준에서 제외)
+   - Lens 2 — codex 환각 0건 (isExpired no-arg + ObjectId.isValid 검증)
+   - Lens 3 — Claude 단독 4건 (A-5 cancel dead param / A-6 optional repo / A-7 isExpired race / A-8 fromDocument invariant 부재)
+   - Lens 4 — invariant 보존, 회귀 0 정합
+3. 4 추가 후보에 대한 codex 인정/거부 + 추가 발견 요청
+
+### 6.2 codex 2차 질문
+- Q1' — Claude 단독 4건 (A-5/A-6/A-7/A-8) 각각에 대한 인정/거부 + 근거
+- Q2' — 본 4-Lens 반박 중 거부할 항목? (예: D-4 value-object를 B 기준에서 제외 vs 포함 논쟁)
+- Q3' — Step 5 TDD 시나리오 명세 작성 시, A-5~A-8 중 어느 후보까지 포함할지 (PoC scope vs full scope)
+
+### 6.3 산출물
+- `paar-2026-05-13-deep-module-poc-codex-r2.md`
+
+---
+
+## 7. 산출물 인덱스
+
+| 종류 | 경로 |
+|---|---|
+| 본 PAAR | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| codex r1 | `paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| 검증한 코드 | `src/06-entities/sessions/domain/session.aggregate.ts` (L150-159, L162-164, L93-106) + `src/05-features/sessions/services/pair-subject.service.ts` (L47-49, L60, L72-83) |
+| mermaid | `docs/architecture/deep-module-mermaid.{mmd, svg}` |

--- a/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md
@@ -1,0 +1,182 @@
+# PAAR — Phase G slice (deep-module PoC Step 4c — codex 5.5 2차 재응답)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 4c (codex 5.5 2차)
+> 선행: `paar-2026-05-13-deep-module-poc-claude-rebuttal.md` (Step 4b — Claude 4-Lens 반박)
+> 다음: Step 5 — TDD 시나리오 명세 추출
+> codex r2 thread: `019e1f19-f5b3-7150-90b7-e71bd3066b23`
+> 모델: gpt-5.5 / sandbox: read-only / cwd: `mind-signal-backend`
+
+---
+
+## 0. 호출 메타
+
+- 호출 도구: `mcp__codex__codex` (별 thread — r1 thread 컨텍스트 미상속, r1 결론을 prompt에 재인용)
+- prompt 길이: 약 7.8KB (r1 요약 + Claude 4-Lens 반박 4건 + Q1'/Q2'/Q3' 3 질문)
+- 응답 길이: 약 5.4KB
+
+---
+
+## 1. Q1' — Claude 단독 4건 인정/거부
+
+### 1.1 A-5 `cancel(_reason)` — **부분 인정**
+- LANGUAGE.md "Interface = caller가 올바르게 쓰기 위해 알아야 하는 모든 것" 및 "the interface is the test surface" 기준 정합
+- 강도 중간 이하 — "shallow module"보다 **거짓 interface / 미완성 domain invariant**에 가까움
+- 수정 방향: `reason` 제거 또는 aggregate 상태에 보존 또는 cancellation event에 포함
+- **Step 5 1순위 TDD 후보는 아님**
+
+### 1.2 A-6 PS constructor `repo?` optional default — **부분 인정**
+- DEEPENING.md "One adapter means a hypothetical seam. Two adapters means a real one" + "Internal seams vs external seams" 정합
+- 강도 — **composition root 부재 / soft seam**으로 분류
+- 약화 요소: `constructor(repo?: SessionRepository)`가 테스트용 stand-in을 실제로 받을 수 있음
+- 핵심 문제: PS가 `new SessionRepository()`까지 알아서 concrete persistence를 생성하는 점
+- **A-1 repository seam을 정리할 때 같이 다룰 부속 후보**
+
+### 1.3 A-7 PS try-catch + `isExpired()` 재호출 Clock race — **강하게 인정**
+- LANGUAGE.md §Locality "change, bugs, knowledge, verification concentrate at one place" 위반
+- DEEPENING.md "the interface is the test surface" — 고정 clock 없이 결정적 테스트 불가
+- **codex 추가 발견**: PAIRED 상태에서 첫 `isExpired()` false → catch 두 번째 `isExpired()` true 시:
+  - service가 expired branch 진입 → `aggregate.expire()` 호출
+  - 그러나 `expire()` L142-147은 status !== 'CREATED' 시 `InvalidStatusTransitionError` throw
+  - **결과: 다른 transition error 새로 발생 가능** — try-catch 외부로 새어나가는 실제 버그 트리거 가능성
+- **결정: 강한 인정** — r1의 SA Clock seam 의심을 PS runtime flow에서 강화하는 직접 증거
+
+### 1.4 A-8 SA `fromDocument` invariant 검증 부재 — **인정, invariant locality 후보로 분류**
+- LANGUAGE.md §Locality + §Depth — `create()` 경로와 `fromDocument()` 경로 invariant 규칙 비대칭
+- "Interface includes invariants" 정의 위반
+- **codex 추가 발견**: repository `toAggregate()`가 `doc.subjectIndex ?? 0`으로 hydrate → schema nullable이 aggregate 내부 invalid 값(0)으로 진입 가능. **A-8 위반의 실제 우회 통로 직접 증거**
+- 약화 요소: hydration factory가 DB를 신뢰하는 전략은 흔함. schema/repository가 invariant 일부 담당 가능
+- 그러나 이 코드에서는 schema가 `subjectIndex` min을 강제하지 않고 null 허용 → `fromDocument()` 무검증이 **실제 우회 통로**
+- **결정: 인정** — adapter 후보가 아닌 **aggregate invariant locality 후보**
+
+---
+
+## 2. Q2' — 4-Lens 반박 거부할 항목
+
+### 2.1 결론: 거부할 핵심 항목 없음
+- Lens 1 §1.2 "D-4 ObjectId.isValid는 adapter 후보 ≥ 3 기준에서 제외" 분류 **정확**
+- `Types.ObjectId.isValid`는 외부 라이브러리 호출이나 DEEPENING.md Ports & Adapters 대상 "remote but owned" 또는 "true external service" 성격 약함
+- deterministic in-process validation 영역. "One adapter means a hypothetical seam" 기준 별도 port 근거 부족
+
+### 2.2 codex 추가 발견 — D-4 value-object 명명 정교화
+- D-4는 value-object / parser module 후보. INTERFACE-DESIGN.md "Design It Twice" 영역
+- **개선된 명명 권고**: `UserIdValidatorPort`보다 `UserIdParserPort` 또는 `SubjectIdCodecPort`가 더 깊은 interface
+  - 이유: 단순 boolean validation보다 "parse 성공 시 domain-safe id 반환, 실패 시 error mode 고정"이 더 깊은 interface
+- **현재 PoC 기준**: B 기준 adapter count 제외, INTERFACE-DESIGN 후속 PR 영역
+
+---
+
+## 3. Q3' — Step 5 scope 선택
+
+### 3.1 결정: **옵션 B — PS 1순위 + SA Clock seam (A-7) 추가**
+- 옵션 A는 r1 핵심 결론 보존하나, A-7을 놓침 (가장 강하게 추가된 후보)
+- 옵션 C는 PoC 가치 대비 넓음. A-5/A-6/A-8은 adapter/deepening보다 interface cleanup 또는 invariant 설계 논의에 가까움
+- 검증성 PoC는 **"가장 강한 executable specification 후보"에 집중**하는 편이 적절
+
+### 3.2 Step 5 권고 시나리오 5건
+
+1. **PS happy path** — valid userId + valid token + CREATED + not expired → pair, save, event recorded
+2. **PS expired path** — CREATED but expired → expire, save, AppError 401
+3. **PS retry-after-paired** — already PAIRED → AppError 400, no expire mutation
+4. **Clock seam race** (A-7) — pair 실패 후 재호출된 `isExpired()`가 다른 판단을 만들 수 있음을 고정 clock으로 명세
+5. **Single observed now** (선택) — pair use case는 하나의 clock snapshot으로 만료 판단을 수행해야 함 (observable outcome 중심)
+
+### 3.3 명세 작성 원칙 (codex 권고)
+- LANGUAGE.md "the interface is the test surface" + DEEPENING.md "Tests assert on observable outcomes through the interface"
+- 내부 `Date.now()` 호출 횟수보다 **observable outcome 중심**으로 명세화
+
+---
+
+## 4. codex r2 추가 한계 (codex 자가 박제)
+
+1. `CancelReason`의 실제 product requirement 미확인 → A-5는 "현재 구현 기준 interface lie"로만 판단
+2. `fromDocument()`가 legacy DB 복구를 의도적으로 허용하는 설계인지 ADR / 도메인 문서 미확인 → A-8 최종 severity 가설
+
+---
+
+## 5. Pass 기준 최종 매칭 (Step 4a + 4b + 4c 종합)
+
+### 5.1 A 기준 ≥ 2 구조 문제
+
+| 후보 | 사전 박제 출처 | codex r1 | Claude 반박 | codex r2 | 최종 결정 |
+|---|---|---|---|---|---|
+| A-1 PS hypothetical seam (importers_of=0) | paar-depth §5 | ✅ 강 매칭 | ✅ Lens 1/2 검증 | (재확인 없음) | **확정** |
+| A-2 SA Clock seam 부재 | paar-depth §5 | ✅ 강 매칭 (Q1 SA) | ✅ Lens 2 isExpired no-arg 검증 | (재확인 없음) | **확정** |
+| A-3 SA interface 표면 비대 (10 getters + 7-arg) | paar-depth §5 | 🟡 부분 ("Depth 명백 안 함") | (Claude 미반박) | (재확인 없음) | **부분 매칭** |
+| A-4 PS event 경로 분기 (recordedEvents vs pairingListeners) | paar-depth §5 | ✅ 강 매칭 (Q1 D-3 + Q2 A-5 재명명) | ✅ Lens 4 회귀 0 정합 | (재확인 없음) | **확정** |
+| A-5 SA `cancel(_reason)` Interface that lies | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | 🟡 부분 인정 ("interface lie" 인정, severity 중간) | **부분 매칭** |
+| A-6 PS constructor `repo?` soft seam | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | 🟡 부분 인정 ("composition root 부재") | **부분 매칭** |
+| A-7 PS try-catch isExpired Clock race | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | ✅ **강한 인정** + 실제 버그 트리거 발견 | **확정** + 강화 |
+| A-8 SA fromDocument invariant 부재 | Step 4b Claude 단독 | (r1 미언급) | ✅ Lens 3 박제 | ✅ 인정 + toAggregate ?? 0 우회 통로 발견 | **확정** + 강화 |
+
+**Pass A 충족**: 확정 5건 (A-1/A-2/A-4/A-7/A-8) + 부분 매칭 3건 (A-3/A-5/A-6) = **총 8 후보, 확정만 5건 ≥ 2** ✅
+
+### 5.2 B 기준 ≥ 3 adapter 후보
+
+| 후보 | codex r1 | Claude 반박 (Lens 1) | codex r2 | 최종 결정 |
+|---|---|---|---|---|
+| D-1 → A-1 Repository (real seam) | ✅ Two-adapter rule 통과 + Δ-1 classDef 분리 권고 | 정합 | (재확인 없음) | **확정** |
+| D-2 → A-2 Clock (hypothetical → 승격) | ✅ Δ-2 category 구분 + Δ-3 연결도 시정 권고 | 정합 | A-7 강한 인정으로 강화 | **확정** |
+| D-3 → A-3 EventBus (hypothetical → A-5 재명명) | ✅ Δ-4 재명명 권고 | 정합 | (재확인 없음) | **확정** |
+| D-4 → adapter 후보 | 🟡 "단정하지 않음" | ✅ B 기준 제외 권고 (INTERFACE-DESIGN 영역) | ✅ Lens 1 분류 인정 + UserIdParserPort 명명 권고 (B에서는 제외) | **B 기준 제외 확정** |
+
+**Pass B 충족**: 3건 모두 확정 (D-1/D-2/D-3) + D-4는 value-object/parser 영역으로 분류 = **3 ≥ 3** ✅
+
+### 5.3 C 기준 ≥ 1 cross-LLM delta
+
+| Delta | 출처 | 검증 결과 |
+|---|---|---|
+| Δ-1 D-1 classDef localSubstitutable 분리 | codex r1 | (Claude 미반박) |
+| Δ-2 D-2 category embedded vs pure 구분 | codex r1 | (Claude 미반박) |
+| Δ-3 A-2 연결도 시정 (SA→A2, PS→A2, A2→D2) | codex r1 | (Claude 미반박) |
+| Δ-4 A-3 → A-5 PairingEventBusPort 재명명 | codex r1 | (Claude 미반박) |
+| Δ-5 D-4 value-object 후보 (SessionId/ObjectIdParser) | codex r1 | Lens 1 §1.2 분류 정합 + r2 명명 정교화 (UserIdParserPort / SubjectIdCodecPort) |
+| Δ-6 A-5 cancel(_reason) Interface that lies | Claude Step 4b | r2 부분 인정 |
+| Δ-7 A-6 PS constructor soft seam | Claude Step 4b | r2 부분 인정 (composition root 부재) |
+| Δ-8 A-7 PS Clock race 실제 버그 트리거 | Claude Step 4b + codex r2 강화 | r2 강한 인정 + PAIRED→재호출 시 expire() InvalidStatusTransitionError 새 발생 가능 |
+| Δ-9 A-8 toAggregate ?? 0 invariant 우회 통로 | codex r2 추가 발견 | (Claude Step 4b A-8을 강화) |
+
+**Pass C 충족**: **9 delta** (Claude/codex 양방향) ≥ 1 ✅
+
+### 5.4 D 기준 회귀 0
+- Step 4a / 4b / 4c 모두 src/** 수정 0 (read-only)
+- 신규 산출물: PAAR 보고서 3건 (r1 / rebuttal / r2) + mermaid 2건은 Step 3에서 이미 박제됨
+- **충족** ✅
+
+---
+
+## 6. Step 5 진입 — TDD 시나리오 명세 가이드
+
+### 6.1 codex 권고 5 시나리오 (Q3' 옵션 B 결정)
+1. PS happy path
+2. PS expired path
+3. PS retry-after-paired
+4. Clock seam race (A-7)
+5. Single observed now (선택)
+
+### 6.2 명세 작성 원칙
+- LANGUAGE.md "the interface is the test surface"
+- DEEPENING.md "Tests assert on observable outcomes through the interface"
+- 내부 `Date.now()` 호출 횟수보다 observable outcome 중심
+- spec 파일 작성 X — 명세만 박제
+
+### 6.3 산출물
+- `paar-2026-05-13-deep-module-poc-tdd-spec.md`
+- 각 시나리오: Given (preconditions) / When (interface call) / Then (observable outcomes)
+- Adapter port suggestion (A-7 Clock port 한정) 첨부
+
+---
+
+## 7. 산출물 인덱스 (Step 4 완료)
+
+| 단계 | 경로 |
+|---|---|
+| Step 4a | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| Step 4b | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| Step 4c (본 PAAR) | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-codex-r2.md` |
+
+### 7.1 GO/NO-GO 잠정 신호
+- A/B/C/D 모두 충족
+- codex r1 발견 + Claude 반박 + codex r2 추가 발견 양방향 cross-LLM delta 9건
+- 끼워맞추기 없음 — 모든 후보가 코드 read 또는 mermaid 직접 인용으로 객관 검증
+- **잠정 GO** — Step 5/6 완수 후 RESULT.md에서 최종 확정

--- a/docs/reports/paar-2026-05-13-deep-module-poc-depth.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-depth.md
@@ -1,0 +1,146 @@
+# PAAR — Phase G slice (deep-module PoC Step 2 — depth + adapter 후보)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 2 (정성 depth 평가 + dependency 분류)
+> 선행: `paar-2026-05-13-deep-module-poc-slice.md` (Step 1 그래프 baseline 35 노드)
+> 측정 도구: vendored `mattpocock/improve-codebase-architecture` skill (byte-identical SHA256, `_local-addendum.md` 임시 공식 폐기 박제)
+
+---
+
+## 0. 측정 도구 변경 — HANDOFF 임시 공식 폐기 박제
+
+`.plans/H-deep-module-poc/HANDOFF.md` §5 Step 2 잠정 공식
+`depth = behavior_size / public_interface_size, 임계값 2.0`은 **본 PoC에서 사용하지 않음**.
+
+근거: `mind-signal-backend/.claude/skills/improve-codebase-architecture/LANGUAGE.md` §"Rejected framings" 1번 — Matt Pocock이 명시적으로 거부 ("Depth as ratio of implementation-lines to interface-lines — rewards padding the implementation"). 끼워맞추기 방지(`feedback_no_fabricated_evidence`)에도 부합하므로 정성 평가 3축으로 변경:
+
+1. **Deletion test** — 삭제 시 complexity 분산 여부 (SKILL.md §Glossary)
+2. **Interface ≈ Implementation 정성 비교** (LANGUAGE.md §Depth)
+3. **Dependency 4 categories + Two-adapter rule** (DEEPENING.md §1~4, §Seam discipline)
+
+벤더링 검증 (SHA256 byte-identical):
+| 파일 | sha256 |
+|---|---|
+| SKILL.md | `9e9b617b1c70d390e37dbfd1c031c11b3de850e2e3d01c4a2c2888bdb386a247` |
+| LANGUAGE.md | `6feca2140439c54a774749e8367f18350899ff69c777144ed2248cd4407949fa` |
+| DEEPENING.md | `9577485f4fc32c0267639a9151bb41c8af0f8f6086e4bf8b84d5b236e30604e9` |
+| INTERFACE-DESIGN.md | `678c3e34f1339015053212b3316bf0b676c70aa251050a0613667d4e755fb35e` |
+
+HANDOFF §8 박제된 5번째 문서 `REFERENCE.md`는 실재 안 함 (2026-05-13 GitHub API 확인 — repo에 4 파일만 존재). 메모리 `reference_mattpocock_improve_codebase_architecture.md`의 "5 URL" 박제도 4 URL로 정정 필요.
+
+## 1. Slice scope 재확인 (Step 1 baseline 유지)
+
+| 클래스 | 파일 | LOC | public 메서드 | private 메서드 |
+|---|---|---|---|---|
+| SessionAggregate | `src/06-entities/sessions/domain/session.aggregate.ts` | 197 | create / fromDocument / pair / markMeasuring / complete / expire / cancel / isExpired + 10 getters | constructor |
+| SessionRepository | `src/06-entities/sessions/repository/session.repository.ts` | 101 | findById / findByPairingToken / save / saveNew | toAggregate / toDocumentFields / toObjectId |
+| PairSubjectService | `src/05-features/sessions/services/pair-subject.service.ts` | 117 | execute / drainRecordedEvents | (없음) |
+
+graph slice (Step 1) 35 노드 baseline 유지. 회귀 0 (read-only).
+
+## 2. 추가 graph 호출 결과 (sequential, detail_level=minimal)
+
+| # | pattern | target | result_count | 핵심 발견 |
+|---|---|---|---|---|
+| 1 | callers_of | SessionAggregate | ambiguous (5 candidates) | Class node 직접 매칭 부재 — 호출은 SessionRepository.findById/findByPairingToken/save 3건이 주 |
+| 2 | file_summary | session.aggregate.ts | 21 | 본문 Class 1 + Function 4 + 16 추가 노드 (테스트 가능성) |
+| 3 | imports_of | pair-subject.service.ts | **4** | 본문 read와 일치 (`Types`, `SessionRepository/Aggregate/InvalidStatusTransitionError`, `SessionPairedEvent`, `AppError`) |
+| 4 | importers_of | pair-subject.service.ts | **0** | 🔴 **dead path** — 어떤 src 파일도 PairSubjectService를 import 하지 않음 |
+| 5 | tests_for | pair-subject.service.ts | 0 | graph indexing 한계 (실제 test 파일 2개 존재: `pair-subject.service.test.ts` + `__tests__/pair-subject.bdd.test.ts`) |
+
+도구 안정성: 5회 순차 호출 전부 정상 응답 (Step 1 noted 병렬+standard internal error 없음).
+
+## 3. Deletion test + dependency category — 클래스별 정성 평가
+
+### 3.1 SessionAggregate
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | "complexity reappears across N callers" — 5 status transition rule + 6 invariant error가 caller(Repository, Service, 잠재 controller)로 흩어짐 → **DEEP** |
+| Interface ≈ Implementation | Interface가 비대 (7-arg factory, 10 getters, 6 transition methods, 5 status enum, 4 cancel reason). Implementation은 transition rule + invariant 강제. 정성적으로 interface 표면이 implementation 깊이를 상회 — "the interface is the test surface" 원칙상 caller가 너무 많이 알아야 함. **Depth는 있으나 interface 슬림화 여지 있음** |
+| Dependency category | 1 (In-process) — Mongoose/Redis/Socket.io 의존 0건 (file header 박제). 단 `Date.now()` (L163) + 암묵 `new Date()` (L122) **clock embed** 존재 |
+| 결론 | DEEP (5 transition + 6 invariant locality) 단 **clock seam 미존재** + **interface 표면 비대** 2건 friction |
+
+### 3.2 SessionRepository
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | "complexity reappears" — 삭제 시 Mongoose 호출 + Aggregate↔Document 변환이 PairSubjectService + 향후 controller로 흩어짐 → **DEEP (adapter seam 정합)** |
+| Interface ≈ Implementation | Interface 4 method, plain types. Implementation = 변환 3 private helper + Mongoose 호출. 정성 비교 적절 비율. **Step 1 의심 "1:1 비율 shallow"는 정정 — 본 정성 평가에서는 shallow 아님** |
+| Dependency category | **2 (Local-substitutable)** — Mongoose `Session` Model. test stand-in: `mongodb-memory-server` 도입 가능 (TD-G-2 후속). 현재 prod = Atlas/Heroku, test = `jest.mock` |
+| 결론 | DEEP — strangler 패턴 adapter at seam 정상 동작 |
+
+### 3.3 PairSubjectService
+
+| 항목 | 결과 |
+|---|---|
+| Deletion test | **현 시점 "complexity vanishes"** — importers_of=0이므로 삭제 시 src/** 영향 0건. 단 BDD 테스트(__tests__/pair-subject.bdd.test.ts)에서만 호출 → 테스트가 유일 caller. 즉 "tests-only module" 상태 |
+| Interface ≈ Implementation | Interface 2 method (execute + drainRecordedEvents). Implementation 5-step flow + 3 AppError 분기 + 1 listener 통합 보류 NOTE. 정성 비교 깊이 있음. **Interface 자체는 슬림** |
+| Dependency category | 1 (In-process, validation) + Repository 간접 (DB는 Repository가 흡수) + clock embed (L101 `new Date().toISOString()`) |
+| 결론 | **🟠 currently hypothetical seam, not yet real seam** — controller wiring (TD-G-3) 미완. 본 단계에서 deep 단정 불가. 일단 "deepenable 후보"로 분류 |
+
+## 4. 외부 의존 식별 (Pass 기준 B 사전 인벤토리)
+
+| # | 의존 | 위치 | category (DEEPENING.md) | 현재 처리 | 잠재 adapter |
+|---|---|---|---|---|---|
+| D-1 | MongoDB (Mongoose Session Model) | session.repository.ts L11-14, L22, L32, L42, L48 | 2 Local-substitutable | Repository 어댑터 (single) | + mongodb-memory-server in-memory (TD-G-2) → real seam ✅ |
+| D-2 | Clock (Date.now / new Date) | session.aggregate.ts L122, L163 / pair-subject.service.ts L101 | 1 In-process embedded | 직접 호출 (테스트 시 `jest.useFakeTimers`로 우회) | + injected clock port (production = systemClock, test = fixedClock) ✅ |
+| D-3 | Event listener fire | (현재 미존재 — `drainRecordedEvents` buffer만, pairingListeners 통합 보류) | 3 Remote but owned (잠재 Redis/Socket.io 향한 port) | recordedEvents 메모리 buffer | + production = pairingListeners fire (TD-G-1), test = buffer drain → real seam ✅ |
+| D-4 | Mongoose Types.ObjectId.isValid | pair-subject.service.ts L60 | 1 In-process | 정적 함수 (pure) | 별도 port 불필요 |
+
+**adapter 후보 ≥ 3건 잠정 충족** (D-1 / D-2 / D-3). Pass 기준 B는 codex 2라운드에서 cross-LLM이 동일 결론에 도달하면 정식 통과.
+
+## 5. 구조 문제 사전 인벤토리 (Pass 기준 A 사전 후보)
+
+| # | 문제 유형 | 위치 | 원리 위반 | 적용 측정 도구 |
+|---|---|---|---|---|
+| A-1 | hypothetical seam not real | pair-subject.service.ts (importers_of=0) | LANGUAGE.md §Principles "Two adapters means a real one" — 현재 0 adapter caller | importers_of graph |
+| A-2 | clock seam 부재 | session.aggregate.ts L163, pair-subject.service.ts L101 | DEEPENING.md §1 "In-process" 카테고리지만 testability 저해 — embedded clock | source read |
+| A-3 | interface 표면 비대 | session.aggregate.ts (10 getters + 6 transitions + 7-arg factory) | LANGUAGE.md §Depth "interface is the test surface" — caller가 학습해야 할 양이 많음 | source read |
+| A-4 | event 처리 경로 분기 | pair-subject.service.ts L96-106 vs 기존 pairingListeners (TD-G-1 보류) | LANGUAGE.md §Locality "change concentrates at one place" — 2 경로 공존 | source read + file header 박제 |
+
+**구조 문제 ≥ 2건 잠정 충족** (4건 후보). Pass 기준 A는 Step 4a codex 1차에서 mermaid만 보고 동일 결론에 도달할 수 있는지 검증.
+
+## 6. Step 1 가설 정정
+
+- Step 1 박제 "SessionRepository shallow 후보 (interface 3 : behaviour 3 = 1:1 비율)" → **정정**. LANGUAGE.md "Rejected framings"에서 line-ratio depth 거부 → 본 클래스는 정성 평가상 deep (변환 책임 locality 충족). 단 Step 1 의심 자체는 "ratio 추론은 끼워맞추기 위험"이라는 메타 교훈.
+
+## 7. Step 3 사전 결정 — mermaid 색상/모양 규약
+
+HANDOFF §7 미결 사항 해소:
+
+| 노드 종류 | 모양 | 색상 | 의미 |
+|---|---|---|---|
+| Class (deep) | 사각형 + 두꺼운 실선 | 파랑 | locality 충족 |
+| Class (shallow/hypothetical) | 사각형 + 점선 | 회색 | importer 미연결 또는 interface≈impl |
+| Adapter (real) | 마름모 + 실선 | 초록 | 2 adapter 정당화 |
+| Adapter (hypothetical) | 마름모 + 점선 | 노랑 | 1 adapter (잠재 seam) |
+| External dep | 원 | 빨강 | clock/DB/network/event |
+| Test-only path | 화살표 점선 | 회색 | importers_of=0인 path |
+
+## 8. Pass 기준 현재 진행
+
+| 기준 | 사전 인벤토리 | 정식 통과 조건 | 현재 상태 |
+|---|---|---|---|
+| A ≥ 2 구조 문제 (cross-LLM이 mermaid만 보고 발견) | 4 후보 (A-1~A-4) | Step 4a-c codex 응답 + Claude 반박 | 🟡 사전 충족, codex 검증 대기 |
+| B ≥ 3 adapter 후보 | 3 (D-1/D-2/D-3) | Step 4c codex 2라운드 동일 결론 | 🟡 사전 충족, codex 검증 대기 |
+| C ≥ 1 cross-LLM delta | 측정 불가 | Step 4b/4c 비교 | ⏳ 대기 |
+| D 회귀 0 | src/** 수정 0 | 본 단계까지 유지 | ✅ 충족 |
+
+## 9. 다음 단계 (Step 3)
+
+1. `docs/architecture/deep-module-mermaid.mmd` 작성 — §7 규약 적용
+2. mermaid-svg-renderer 스킬로 SVG
+3. 자가검증 1줄 — `graph_node_count (Step 1 baseline 35) == mermaid_node_count`
+4. 산출물: `docs/architecture/deep-module-mermaid.{mmd, svg}`
+
+## 10. 도구 사용 누적
+
+| 도구 | 호출 수 | 결과 |
+|---|---|---|
+| Bash (gh api) | 3 | repo tree + skills/ + engineering/ 디렉토리 확인 |
+| Bash (curl raw.githubusercontent) | 1 | 4 파일 byte-identical download |
+| Read (skill 원본) | 4 | SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN 직접 분석 |
+| Read (mind-signal src) | 3 | SessionAggregate/Repository/PairSubjectService 본문 |
+| query_graph_tool (sequential minimal) | 5 | callers/file_summary/imports/importers/tests |
+| 총 graph 호출 | 5 (Step 1의 3개 + Step 2의 5개 합계 8) | internal error 0건 (도구 안정성 규칙 준수 입증) |

--- a/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md
+++ b/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md
@@ -1,0 +1,353 @@
+# PAAR — Phase G slice (deep-module PoC Step 5 — TDD 시나리오 명세)
+
+> 날짜: 2026-05-13
+> 단계: H-deep-module-poc Step 5 (TDD 시나리오 명세 추출 only)
+> 선행: `paar-2026-05-13-deep-module-poc-codex-r2.md` (Step 4c — codex r2 option B 결정)
+> 다음: Step 6 — RESULT.md 측정 + GO/NO-GO
+> 본 산출물: 명세 문서 1건. **production code / test code / resource config 변경 0건**. 회귀 0 유지.
+> 작성 원칙: LANGUAGE.md L38 "the interface is the test surface" + DEEPENING.md L36 "Tests assert on observable outcomes through the interface, not internal state"
+
+---
+
+## 0. §10 검증 체크리스트 통과 보고 (HANDOFF rev.4 §10 박제 정합)
+
+> 본 표는 HANDOFF rev.4 §10 "체크리스트 통과 보고 양식" 정합. 다음 세션 재실행 시 같은 양식으로 재박제.
+
+| 항목 | 결과 | 검증 도구 / 근거 |
+|---|---|---|
+| #1 external-source | Pass | Glob `mind-signal-backend/.claude/skills/improve-codebase-architecture/*.md` → 5 파일 실재 (SKILL/LANGUAGE/DEEPENING/INTERFACE-DESIGN + `_local-addendum.md`) |
+| #2 source-quote | Pass | Grep 원문 검증: "the interface is the test surface" LANGUAGE.md L38 + DEEPENING.md L35 + SKILL.md L26 / "Rejected framings" LANGUAGE.md L49 / "Two adapters means a real one" LANGUAGE.md L39 + DEEPENING.md L29 / "Tests assert on observable outcomes through the interface" DEEPENING.md L36 / "Locality" LANGUAGE.md L31 + L47 |
+| #3 ad-hoc-formula | Pass | 본 spec Pass/Fail 기준에 line ratio / threshold 2.0 / graph_node_count == mermaid_node_count 사용 0건. §1 정성 평가 3축(deletion test + Interface≈Implementation + Dependency category)만 사용 |
+| #4 code-location | Pass | Read 직접 검증: `session.aggregate.ts` L69-90 create / L93-106 fromDocument / L113-123 pair / L142-147 expire / L150-159 cancel / L162-164 isExpired / `pair-subject.service.ts` L47-49 constructor / L58-109 execute / L60 ObjectId.isValid / L65 findByPairingToken / L72-83 try-catch + isExpired 재호출 / L97-105 event 객체 / `session.repository.ts` L62 `doc.subjectIndex ?? 0` 우회 통로 |
+| #5 principle-mapping | Pass | 본 spec 시나리오 4·5 = LANGUAGE.md §Locality + §Depth + DEEPENING.md §Seam discipline 직접 인용. 후보별 4단계 표 (§3 deferred) 동반 |
+| #6 graph-mermaid-unit | Pass | 본 spec 본문에 graph count vs mermaid count 자가검증 산식 0건. paar-mermaid §자가검증 = 분류별 inventory matching (계량적 1:1 아님) |
+| #7 llm-consensus | Pass | A-7 Clock race 강한 인정 근거 = codex r2 §1.3 + Claude rebuttal §3.3 + 코드 read L72-83 + L113-123 + L162-164 직접 인용. 합의 단독 0건 |
+| #8 stale-session-state | Pass | Glob `**/base44*` 0건 (3 프로젝트 docs/configs) + `Team-project/.claude/settings.json` Grep "UserPromptSubmit\|Stop" 0건 (PostToolUse + SessionStart 2개만 잔존) |
+| #9 observable-outcome | Pass | 본 spec §2 5 시나리오 모두 5요소(Given / When / Then / observable outcome / non-goal) 명시. 내부 Date.now() 호출 횟수 명세 0건 |
+| #10 deferred-candidate | Pass | A-5/A-6/A-8 §3 별도 섹션으로 분리. §1 spec scope / §5 Pass 기준 / §4 adapter 권고에 포함 0건 |
+
+10항목 모두 Pass — Step 5 명세 본문 진입.
+
+---
+
+## 1. Spec scope (codex r2 §3.2 option B)
+
+### 1.1 1순위 — PairSubjectService (PS)
+- **근거 3축** (paar-depth §3.3 + Step 4a codex r1 Q1):
+  1. **Deletion test** — PS 제거 시 5-step flow(L58-109) + 3 AppError 분기가 caller(controller / BDD test)로 흩어짐. "complexity reappears across N callers" (LANGUAGE.md L37) 정합
+  2. **Interface ≈ Implementation** — 인터페이스 2 메서드(execute / drainRecordedEvents)는 슬림. 5단계 흐름 + 3 분기는 그 뒤로 숨음. depth 후보 정합 (LANGUAGE.md L19)
+  3. **Dependency category 3종** (DEEPENING.md §1~4 분류) — D-1 MongoDB(Repository 어댑터 경유) / D-2 Clock(embedded) / D-4 ObjectId.isValid(in-process). PS는 3 카테고리 모두 경유하는 **응용 서비스 단일 hot path**
+
+### 1.2 추가 — A-7 Clock seam race
+- **근거**: codex r2 §1.3 강한 인정. PS `pair-subject.service.ts` L72-83 try-catch 후 `aggregate.isExpired()` 재호출 시점에 첫 호출(SA L114)과 다른 시간 판단 가능성 + PAIRED 상태에서 재호출 시 `expire()` (SA L142-147)가 새 `InvalidStatusTransitionError` 발생 가능
+- **시나리오 4**(Clock seam race) + **시나리오 5**(single observed now)로 명세화
+
+### 1.3 명세화 원칙 (LANGUAGE.md L38 + DEEPENING.md L36)
+1. **The interface is the test surface** — Test가 검증하는 대상은 PS의 `execute()` 메서드와 `drainRecordedEvents()` + 영속화 후 `SessionRepository.findByPairingToken()` 관찰 결과. SA 내부 transition rule이나 `aggregate.pair()` 호출 자체를 검증 대상에 두지 않음
+2. **Tests assert on observable outcomes through the interface, not internal state** — Then 절은 외부에서 관찰 가능한 결과(thrown AppError / 영속 상태 / drainRecordedEvents 반환값)만 검증. 내부 `Date.now()` 호출 횟수 / `aggregate.expire()` 호출 횟수는 non-goal
+
+### 1.4 회귀 0 박제
+- `mind-signal-backend/src/**` 수정 0건
+- 본 PAAR 1건 추가 (`docs/reports/`)
+- Phase G 11 commit(`feat/G-ddd-bdd-tdd-pilot`) untouched
+- Clock port 실제 구현 / `SA.isExpired()` 시그니처 변경 / `PS.constructor` 수정 0건 — 모두 후속 PR 영역
+
+---
+
+## 2. 5 시나리오 명세 (Given / When / Then / observable outcome / non-goal)
+
+### 2.1 Scenario 1 — PS happy path
+
+- **Given (preconditions)**:
+  - SessionRepository stand-in이 1 도큐먼트로 seed됨: `pairingToken = "TOK-VALID-S1"`, `status = 'CREATED'`, `expiresAt > now`, `groupId = "GRP-S1"`, `subjectIndex = 1`, `experimentMode = 'DUAL'`, `userId = null`, `pairedAt = null`, `creatorId = <operator ObjectId>`
+  - 24자 hex `userId` 입력 (`Types.ObjectId.isValid` 통과)
+  - 본 시나리오에서 Clock 관찰 시점 T0는 단조 증가하는 시스템 클럭의 한 순간 (시나리오 5에서 단일 snapshot 의무로 강화)
+- **When (interface call)**:
+  - `new PairSubjectService(stubRepo).execute({ pairingToken: "TOK-VALID-S1", userId: <24hex> })`
+- **Then (observable outcomes)**:
+  1. `Result.session.status === 'PAIRED'`
+  2. `Result.session.userId === <24hex>`
+  3. `Result.session.pairedAt instanceof Date` (non-null)
+  4. `Result.event` 객체 shape (PS L97-105 정합):
+     - `type === 'SessionPaired'`
+     - `sessionId === <seed session._id>`
+     - `userId === <24hex>`
+     - `occurredAt` is ISO 8601 string
+     - `groupId === "GRP-S1"`
+     - `subjectIndex === 1`
+     - `mode === 'DUAL'`
+  5. 영속화 검증: subsequent `stubRepo.findByPairingToken("TOK-VALID-S1")` returns aggregate with `status === 'PAIRED'` and `userId === <24hex>`
+  6. `service.drainRecordedEvents()` 첫 호출 시 `[Result.event]` 길이 1, 두 번째 호출 시 빈 배열(buffer 비움 검증 — PS L112-115 정합)
+- **Non-goal**:
+  - 내부 `Date.now()` 호출 횟수
+  - `stubRepo.save()` 호출 횟수
+  - `aggregate.pair()` 호출 빈도
+  - 기존 `pairingListeners` (외부 Set, LD-12) 발화 — pair-subject.service.ts L14-19 NOTE 정합으로 본 흐름에서는 발화하지 않음을 명시 (검증 대상 외)
+
+### 2.2 Scenario 2 — PS expired path (AppError 401)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-EXP-S2"`, `status = 'CREATED'`, `expiresAt < now` (확실히 만료된 시점)
+  - 유효 `userId` 24-hex
+- **When**:
+  - `service.execute({ pairingToken: "TOK-EXP-S2", userId: <24hex> })`
+- **Then**:
+  1. `AppError` thrown — `statusCode === 401` and `message === '페어링 토큰이 만료되었습니다. 다시 시도해주세요.'` (PS L79-82 정합)
+  2. 영속화 검증: subsequent `stubRepo.findByPairingToken("TOK-EXP-S2")` returns aggregate with `status === 'EXPIRED'` (PS L77-78 `expire() + save()` 정합 — observable through repository)
+  3. `service.drainRecordedEvents()` returns empty array
+- **Non-goal**:
+  - `aggregate.expire()` 직접 호출 횟수
+  - `aggregate.isExpired()` 호출 횟수
+  - try-catch 분기 내부 sequence
+
+### 2.3 Scenario 3 — PS retry-after-paired (AppError 400)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-PRD-S3"`, `status = 'PAIRED'`, `userId = <previous-user-24hex>`, `pairedAt = <prior Date>`, `expiresAt > now` (만료 전이지만 이미 PAIRED)
+  - 신규 `userId` 24-hex (`previous-user`와 다름)
+- **When**:
+  - `service.execute({ pairingToken: "TOK-PRD-S3", userId: <new-24hex> })`
+- **Then**:
+  1. `AppError` thrown — `statusCode === 400` and `message === '현재 세션 상태(PAIRED)에서는 페어링할 수 없습니다.'` (PS L84-88 정합)
+  2. **영속 상태 불변 검증**: subsequent `stubRepo.findByPairingToken("TOK-PRD-S3")` returns aggregate with `status === 'PAIRED'` (변경 0), `userId === <previous-user-24hex>` (덮어쓰기 0), `pairedAt` unchanged
+  3. `service.drainRecordedEvents()` returns empty array
+- **Non-goal**:
+  - catch 분기 내부 isExpired() 호출 자체
+  - PS가 `aggregate.expire()`를 호출하지 않았다는 사실의 직접 검증 (영속 상태 PAIRED 불변으로 간접 보장됨)
+
+### 2.4 Scenario 4 — Clock seam race (A-7) — 결정성 명세
+
+> 본 시나리오는 **A-7 Clock seam race**(codex r2 §1.3 강한 인정 + Claude rebuttal §3.3 Lens 3 박제)의 observable 표현. 실제 Clock port 구현은 후속 PR 영역(§4.3). 본 명세는 "Clock port가 도입되면 어떻게 결정성이 보장되어야 하는가"를 정의함.
+
+- **가정 (port hypothesis)**:
+  - 가설적 `Clock` 포트가 PS에 주입됨 (§4.1 시그니처). `SA.isExpired()`는 주입된 clock을 통해 시간을 관찰. 한 `execute()` 호출 내에서 모든 시간 관찰은 결정적이어야 함
+
+- **Given**:
+  - 동일 sessionDoc 2개 context로 seed (각각 다른 pairingToken): `pairingToken = "TOK-BND-A"`, `"TOK-BND-B"`, 두 도큐먼트 모두 `status = 'CREATED'`, `expiresAt = T`, 유효 `userId` 24-hex
+  - **Context A**: FixedClock at `T - 1ms` 주입
+  - **Context B**: FixedClock at `T + 1ms` 주입
+
+- **When**:
+  - 각 context별로 `service.execute({ pairingToken, userId })` 1회 호출
+
+- **Then (cross-context observable)**:
+  1. **Context A** — Scenario 1 결과와 동일: `Result.session.status === 'PAIRED'`, 영속 PAIRED, event recorded
+  2. **Context B** — Scenario 2 결과와 동일: `AppError(401)` thrown, 영속 EXPIRED, drain empty
+  3. **결정성**: 동일 context를 N회 반복 실행 시 N개의 결과가 모두 동일 (no flakiness, no race)
+
+- **Within-call observable invariant (race 부재 강제)**:
+  - `execute()` 한 번의 호출 안에서 `SA.pair()` 내부 `isExpired()` 첫 판단 (`SA.aggregate.ts:114`) + PS catch 분기 `aggregate.isExpired()` 재호출 (`pair-subject.service.ts:76`)가 **동일 clock snapshot**을 본다
+  - 즉 Context A에서 `pair()`는 false를 받지만 catch 분기 isExpired()가 true를 받는 race가 **존재할 수 없어야 함**
+  - 검증 방법: Context A에서 paired 결과 + Context B에서 expired 결과 + 두 context 모두 N회 반복 시 동일 결과가 유지되는지
+
+- **A-7 버그 트리거 명세 (codex r2 §1.3 추가 발견 박제)**:
+  - 현재 구현(embedded clock) 가설적 race: PAIRED 상태에서 catch 분기 진입 후 isExpired() true 반환 → `aggregate.expire()` 호출(PS L77) → SA L143 `status !== 'CREATED'` 조건으로 `InvalidStatusTransitionError` **새로** throw → AppError(401)이 아닌 raw transition error가 PS 외부로 새어나갈 가능성
+  - **Then 강화 명세**: Context C — FixedClock at `T - 1ms`, status=PAIRED(이미 PAIRED)로 seed → 결과는 Scenario 3 (AppError 400 + 영속 PAIRED 불변)이어야 함. `InvalidStatusTransitionError`가 외부로 새어나오지 않음을 검증
+
+- **Non-goal**:
+  - 실제 `Clock` 포트 구현 (§4.3 후속 PR)
+  - 내부 `Date.now()` 호출 횟수
+  - `pair()`와 catch 분기가 동일 변수 vs 동일 함수 재호출인지 (implementation detail)
+  - SA.aggregate.ts L122 `this._pairedAt = new Date()`의 clock 정합 (별도 후속 — 시나리오 1의 pairedAt observable만 검증, 정확한 값 일치는 시나리오 5에서 강화)
+
+### 2.5 Scenario 5 — Single observed now (선택, observable 강화)
+
+> 시나리오 4의 within-call observable invariant를 직접 명세화. Clock seam 도입 시 "한 번의 execute()는 한 번의 시간 관찰"이라는 결정성을 인터페이스 수준에서 보장.
+
+- **가정**:
+  - PS는 `execute()` 시작 시점에 clock을 1회 관찰하여 그 snapshot T0를 흐름 전체에 사용 (구현 방법은 자유 — 포트 호출 1회 vs 첫 관찰 결과 캐싱 vs 다른 방식. 검증 대상은 결과의 결정성)
+
+- **Given**:
+  - SessionRepository stub seeded: `pairingToken = "TOK-SON-S5"`, `status = 'CREATED'`, `expiresAt = T0 + δ` (δ는 매우 작은 양수 — boundary 직전)
+  - FixedClock at `T0` 주입
+  - 실제 wall-clock이 execute() 호출 중에 `T0 + 2δ`로 진행됨 (실제 시간 흐름과 주입 clock 분리)
+
+- **When**:
+  - `service.execute({ pairingToken: "TOK-SON-S5", userId: <24hex> })`
+
+- **Then (observable invariant)**:
+  1. 결과는 **주입된 FixedClock의 T0**가 expiresAt 미만이므로 **paired** (Scenario 1 outcome)
+  2. wall-clock이 execute() 종료 시점에 `T0 + 100ms`이든 `T0 + 5초`이든 결과는 **동일**
+  3. 동일 FixedClock + 동일 seed로 N회 반복 시 N개 결과 모두 paired
+
+- **상대 시나리오 (boundary 반대)**:
+  - 같은 seed에 FixedClock at `T0 + 2δ`(boundary 직후) 주입 시 → expired (Scenario 2 outcome). 두 경계 사이의 차이가 결정적임을 보장
+
+- **Non-goal**:
+  - Clock port API 형태(`now(): Date` vs `nowMs(): number` 등 design decision) — 후속 PR
+  - 내부 clock 관찰 횟수 — 결과의 결정성만 검증
+
+---
+
+## 3. 보류 후보 (Step 5 비포함 — 후속 PR)
+
+> 본 §은 HANDOFF rev.4 §0 표 "Step 5 포함 / 보류 결정" 정합. A-5 / A-6 / A-8은 각각 별도 PR 후보로 보류. 본 spec scope(§1) / Pass 기준(§5) / adapter 권고(§4)에 포함 0건.
+
+### 3.1 A-5 — `SessionAggregate.cancel(_reason: CancelReason)` Interface that lies
+
+- **위치**: `session.aggregate.ts:150-159`
+- **현 구현**: 메서드 시그니처는 `reason: CancelReason`을 받지만 implementation은 `_reason` (underscore prefix)으로 폐기. 상태 전이만 수행
+- **원리 위반**: LANGUAGE.md L11-13 §Interface — "Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, ..." → 시그니처가 caller에게 `reason`이 의미 있는 입력이라는 신호를 보내지만 실제로는 폐기. **거짓 인터페이스**
+- **codex r2 §1.1 인정 강도**: 부분 — "shallow module"보다 **거짓 interface / 미완성 domain invariant**에 가까움
+- **Step 5 비포함 사유**:
+  - 본 PoC scope는 페어링 흐름(CREATED → PAIRED) 1줄 — `cancel()`은 별도 hot path
+  - cancel 의미론 결정(reason 보존 vs 폐기 vs cancellation event 발화)은 도메인 차원 의사결정 필요
+- **후속 PR 후보**:
+  - **PR-A5-cleanup-interface**: reason을 도메인 의도에 맞게 처리 (3 옵션 중 택일 — aggregate state 보존 / cancellation event payload / 인터페이스에서 제거)
+  - 영향 범위: SA L150-159 + `CancelReason` type + 잠재 `cancel()` caller(현재 importers_of=0 추정, 별도 검증 필요)
+
+### 3.2 A-6 — `PairSubjectService` constructor `repo?: SessionRepository` soft seam
+
+- **위치**: `pair-subject.service.ts:47-49`
+- **현 구현**: `constructor(repo?: SessionRepository) { this.repo = repo ?? new SessionRepository(); }` — Repository 미주입 시 concrete `SessionRepository`를 직접 생성
+- **원리 위반**: DEEPENING.md §Seam discipline (L27-32) — composition root 부재. caller가 `new PairSubjectService()` 만으로 동작한다고 신호 받음 → adapter at seam이 "soft seam"(defaultable)으로 약화
+- **codex r2 §1.2 인정 강도**: 부분 — A-1 repository seam 정리 시 함께 다룰 부속 후보
+- **Step 5 비포함 사유**:
+  - 시나리오 1~5는 모두 명시 주입(`new PairSubjectService(stubRepo)`)을 사용하므로 본 명세 자체는 default fallback 동작을 호출하지 않음. 즉 보류해도 시나리오 검증 가능
+  - A-1 (PS importers_of=0 → real seam 승격)이 controller wiring PR에서 해결될 때 함께 default 제거가 자연스러움
+- **후속 PR 후보**:
+  - **PR-A6-required-injection**: A-1 controller wiring PR에 포함. `constructor(repo: SessionRepository)` (required) + composition root에서 단일 인스턴스화
+  - 영향 범위: PS L47-49 + BDD test 2건(이미 명시 주입이므로 무중단) + controller wiring PR 신규
+
+### 3.3 A-8 — `SessionAggregate.fromDocument` invariant 부재 + `toAggregate(doc.subjectIndex ?? 0)` 우회 통로
+
+- **위치**:
+  - `session.aggregate.ts:93-106` — `fromDocument()`가 `create()` (L69-77)의 invariant 검증(`pairingToken !== ''`, `subjectIndex >= 1`)을 우회
+  - `session.repository.ts:62` — `toAggregate()`가 `doc.subjectIndex ?? 0` 으로 nullable을 0으로 hydrate
+  - `session.schema.ts:45-48` — schema에서 `subjectIndex` `default: null` 허용, `min: 1` 강제 없음
+- **원리 위반**: LANGUAGE.md L31-32 §Locality — invariant 강제 책임이 `create()` 한 곳에 locality가 있어야 하나 `fromDocument()`가 비대칭 우회 통로. DB → aggregate hydration 시 invariant 위반 값(`subjectIndex = 0`)이 통과 가능
+- **codex r2 §1.4 + Δ-9 추가 발견**: `toAggregate ?? 0`이 invariant 우회 통로의 직접 증거
+- **Step 5 비포함 사유**:
+  - invariant locality 설계 결정은 다음 3 옵션 중 선택 필요 — (a) `fromDocument()`에 invariant 강제 추가 / (b) schema가 invariant 일부 담당 (`min: 1`, `required: true`) / (c) repository가 hydration 시 invariant 검증
+  - 어느 옵션이든 schema migration 또는 정합성 점검 스크립트가 필요할 수 있음 (legacy 도큐먼트의 `subjectIndex = null` 처리)
+- **후속 PR 후보**:
+  - **PR-A8-invariant-locality**: 3 옵션 중 ADR 결정 후 구현. ADR-006(Phase G)와 별도 ADR-007 후보
+  - 영향 범위: SA L93-106 + SR L62 + session.schema.ts L45-48 + 잠재 legacy 데이터 보정
+
+---
+
+## 4. Adapter port 권고 (A-7 Clock port 한정)
+
+> 본 §은 시나리오 4 / 5의 가설적 Clock port를 명세화. **본 spec에서 실제 구현은 0건** — 시그니처와 정당화만 박제. 구현은 후속 PR (TD-G-Clock 또는 별도 phase).
+
+### 4.1 Clock port 시그니처 (제안 — 후속 PR에서 확정)
+
+```
+// 의사 코드 — production code 아님, 시나리오 명세의 가설 표현
+interface Clock {
+  now(): Date;   // 또는 nowMs(): number — Design It Twice 영역
+}
+
+class SystemClock implements Clock {
+  now(): Date { return new Date(); }
+}
+
+class FixedClock implements Clock {
+  constructor(private readonly fixed: Date) {}
+  now(): Date { return this.fixed; }
+}
+```
+
+### 4.2 Two-adapter rule 정당화 (DEEPENING.md L29)
+
+- **Production adapter**: `SystemClock` — `new Date()` / `Date.now()` 캡슐화
+- **Test adapter**: `FixedClock` — 시나리오 4/5에서 결정성 보장에 필수
+- **DEEPENING.md L29 "Two adapters means a real one"**: 두 어댑터 모두 정당. test stand-in이 단순 mock이 아닌 의미 있는 substitution
+
+### 4.3 본 spec 범위 한계 박제
+
+- Clock port 실제 구현 / `SA.isExpired()` 시그니처 변경(현재 no-arg → `isExpired(clock: Clock)` 또는 생성자 주입) / PS의 clock 단일 관찰(시나리오 5 강화) — **모두 후속 PR** (예: TD-G-Clock-port)
+- 본 spec은 "Clock seam이 어떤 결정성을 보장해야 하는가"의 observable 정의만 박제
+- 후속 PR ADR 후보: ADR-008 "Clock port at SA isExpired() seam" — 시그니처 결정(method param vs constructor inject) + production 단일 SystemClock 인스턴스 위치(composition root vs SA static)
+
+### 4.4 A-7 race trigger 후속 검증 의무
+
+- 시나리오 4 §"A-7 버그 트리거 명세"의 Context C(PAIRED 상태 + boundary clock)가 현재 코드에서 실제로 `InvalidStatusTransitionError`를 raw 노출하는지는 후속 PR에서 **재현 test 1건 + 수정**으로 입증/반증 필요
+- 본 spec에서는 "그럴 가능성이 있다 (codex r2 §1.3 박제)" + "Clock port 도입 시 결정적으로 차단" 까지만 명세
+
+---
+
+## 5. Pass 기준 매칭 (Step 5 한정)
+
+| 기준 | 조건 | 결과 | 근거 |
+|---|---|---|---|
+| **A** | Step 4 산출물의 주요 후보(A-1 / A-2 / A-4 / A-7 confirmed)가 Step 5 명세 범위에 정확히 반영 | ✅ Pass | A-1(PS center, §1.1 3축) + A-2/A-7(Clock seam, 시나리오 4 + 5) + A-4(event recorded, 시나리오 1 Then 4) 모두 시나리오 본문 또는 spec scope에 반영 |
+| **B** | 신규 박제 정보는 원문 Read 검증 또는 명확한 보류 표시 보유 | ✅ Pass | 본 spec 본문 모든 원리 인용 = §0 §10 #2 검증 통과 라인 번호. A-5/A-6/A-8 보류 후보는 §3 별도 섹션 |
+| **C** | 임시 공식 / 추론 / cross-LLM 주장만으로 확정 0건 | ✅ Pass | 본 spec Pass/Fail 기준에 line ratio / threshold / count equality 0건. A-7 confirmed는 코드 read(L72-83 + L113-123 + L162-164) + r2 §1.3 + Claude rebuttal §3.3 3중 근거 |
+| **D** | Step 5 산출물이 다음 구현 세션에서 바로 TDD 입력으로 사용 가능할 만큼 구체적 | ✅ Pass | 각 시나리오 Given/When/Then/observable outcome/non-goal 5요소 + AppError statusCode/message 한국어 원문 + repository seed 필드 명시 + 24-hex userId 형식 명시 |
+
+**Step 5 완료 조건 충족** (HANDOFF rev.4 §4.1 7항목):
+- [✅] `paar-2026-05-13-deep-module-poc-tdd-spec.md` 명세 작성 완료
+- [✅] 5 시나리오(PS happy / PS expired / PS retry-after-paired / Clock seam race A-7 / single observed now)가 PS 중심 옵션 B에 맞게 정리
+- [✅] A-7 Clock seam race가 observable outcome 기반 시나리오로 포함 (Given / When / Then / observable outcome / non-goal)
+- [✅] A-5 / A-6 / A-8은 후속 후보로 보류 사유 명시 (§3)
+- [✅] 명세가 LANGUAGE.md "the interface is the test surface" + DEEPENING.md "Tests assert on observable outcomes" 원칙 정합
+- [✅] production code / test code / resource config 변경 0건
+- [✅] 회귀 0 유지
+
+---
+
+## 6. 다음 단계 (Step 6 — RESULT.md + GO/NO-GO)
+
+### 6.1 측정해야 할 항목
+- A 기준 ≥ 2 구조 문제 — 확정 5건(A-1/A-2/A-4/A-7/A-8) + 부분 매칭 3건(A-3/A-5/A-6) = 잠정 충족
+- B 기준 ≥ 3 adapter 후보 — D-1/D-2/D-3 확정 + D-4는 INTERFACE-DESIGN 영역 = 잠정 충족
+- C 기준 ≥ 1 cross-LLM delta — 9 delta (Δ-1~Δ-9) = 잠정 충족
+- D 기준 회귀 0 — src/** 수정 0 = 충족
+
+### 6.2 산출물
+- `.plans/H-deep-module-poc/RESULT.md` (8~15줄)
+- `STATE.md` Phase H 갱신 (또는 신규 생성 — 본 세션 STATE.md 미존재 확인됨)
+- 메모리: `project_phase_h_done.md` 또는 `_no_go.md`
+- 옵시디언 task amend (`/obsidian-record` 의무, [[feedback-use-obsidian-skill]] + [[feedback-obsidian-record-amend-too]])
+
+### 6.3 GO 신호 (Step 6에서 최종 확정)
+- A/B/C/D 4 기준 모두 잠정 충족
+- 끼워맞추기 없음 ([[feedback-no-fabricated-evidence]])
+- §10 검증 체크리스트 10/10 Pass
+- 본 spec이 다음 구현 세션에서 TDD 입력으로 사용 가능
+
+### 6.4 NO-GO 시 처리 (방어 절차)
+- Step 6 측정에서 임의의 Pass 기준이 객관 근거 없이 충족되었다는 사실이 드러나면 RESULT.md에 `NO-GO: <항목명>` 박제
+- 워크플로우 폐기 또는 도구 교체 결정 + 원인 분석
+- 메모리: `project_phase_h_no_go.md`
+
+---
+
+## 7. 산출물 인덱스 (Step 5 완료 기준)
+
+| 종류 | 경로 |
+|---|---|
+| 본 PAAR (Step 5) | `mind-signal-backend/docs/reports/paar-2026-05-13-deep-module-poc-tdd-spec.md` |
+| Step 1 PAAR | `paar-2026-05-13-deep-module-poc-slice.md` |
+| Step 2 PAAR | `paar-2026-05-13-deep-module-poc-depth.md` |
+| Step 3 PAAR | `paar-2026-05-13-deep-module-poc-mermaid.md` |
+| Step 4a PAAR (codex r1) | `paar-2026-05-13-deep-module-poc-codex-r1.md` |
+| Step 4b PAAR (Claude rebuttal) | `paar-2026-05-13-deep-module-poc-claude-rebuttal.md` |
+| Step 4c PAAR (codex r2) | `paar-2026-05-13-deep-module-poc-codex-r2.md` |
+| mermaid source | `docs/architecture/deep-module-mermaid.mmd` |
+| mermaid SVG | `docs/architecture/deep-module-mermaid.svg` |
+| 본 PoC HANDOFF (rev.4) | `Team-project/.plans/H-deep-module-poc/HANDOFF.md` |
+| vendor 스킬 | `mind-signal-backend/.claude/skills/improve-codebase-architecture/{SKILL,LANGUAGE,DEEPENING,INTERFACE-DESIGN}.md` + `_local-addendum.md` |
+
+---
+
+## 8. 회귀 0 박제
+
+- `mind-signal-backend/src/**` 수정 0건 (본 세션 Read only)
+- `mind-signal-backend/__tests__/**` 수정 0건
+- resource config / package.json / tsconfig.json 수정 0건
+- Phase G 11 commit (`feat/G-ddd-bdd-tdd-pilot`) untouched
+- `Team-project/.claude/settings.json` hooks(PostToolUse + SessionStart) 상태 유지 — UserPromptSubmit / Stop 부재 (§10 #8 Pass 정합)
+- 본 PAAR 1건만 신규 (`docs/reports/`)
+
+---
+
+## 9. 출처 / 참조 메모리
+
+- LANGUAGE.md L11-13 §Interface / L18-19 §Depth / L31-32 §Locality / L37-39 §Principles / L49-53 §Rejected framings
+- DEEPENING.md L27-32 §Seam discipline / L35-36 §The interface is the test surface
+- SKILL.md L15-26 §Glossary + §Deletion test + §The interface is the test surface
+- INTERFACE-DESIGN.md §Design It Twice (D-4 value-object 후보 영역, B 기준 제외)
+- 본 PoC 박제 위반 사례 4건(§10 §"본 세션 박제 위반 사례"): REFERENCE.md 5번째 파일 / depth ratio 2.0 / SR 1:1 ratio shallow / graph count == mermaid count
+- 메모리: [[reference-mattpocock-improve-codebase-architecture]] / [[feedback-no-fabricated-evidence]] / [[feedback-websearch-unverified-persist-ban]] / [[feedback-codex-model-default]] / [[feedback-obsidian-handoff-required-fields]] / [[feedback-use-obsidian-skill]] / [[feedback-obsidian-record-amend-too]] / [[feedback-external-doc-natural-language-5w1h]] / [[feedback-code-review-graph-parallel-standard-error]] / [[project-phase-h-deep-module-poc-step1]]

--- a/docs/requirements/RTM.md
+++ b/docs/requirements/RTM.md
@@ -31,6 +31,7 @@
 | FR ID | Title | Source | Implementation | Tests | PR | Status |
 |---|---|---|---|---|---|---|
 | FR-00 | (예시) 세션 생성 API | #0 | `src/05-features/sessions/api/session.routes.ts` | `__tests__/sessions/create.test.ts` | — | Draft |
+| DR-G | Session Aggregate DDD/BDD/TDD Pilot | `.plans/PRD.md` DR-G + `.plans/G-mind-signal-ddd-bdd-tdd/` | `src/06-entities/sessions/{domain,repository,types}` + `src/05-features/sessions/services/pair-subject.service.ts` | `session.aggregate.test.ts` (8) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (3) = 21 | feat/G-ddd-bdd-tdd-pilot | Done (ADR-006 Accepted) |
 
 ---
 

--- a/docs/requirements/RTM.md
+++ b/docs/requirements/RTM.md
@@ -32,6 +32,7 @@
 |---|---|---|---|---|---|---|
 | FR-00 | (예시) 세션 생성 API | #0 | `src/05-features/sessions/api/session.routes.ts` | `__tests__/sessions/create.test.ts` | — | Draft |
 | DR-G | Session Aggregate DDD/BDD/TDD Pilot | `.plans/PRD.md` DR-G + `.plans/G-mind-signal-ddd-bdd-tdd/` | `src/06-entities/sessions/{domain,repository,types}` + `src/05-features/sessions/services/pair-subject.service.ts` | `session.aggregate.test.ts` (8) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (3) = 21 | feat/G-ddd-bdd-tdd-pilot | Done (ADR-006 Accepted) |
+| DR-G-PR-A7 | Clock Port at Session Pairing Seam — A-7 race 차단 + A-6 soft seam 동반 해소 | 이슈 #52 + `.plans/I-pr-a7-clock-port/` + `.plans/H-deep-module-poc/RESULT.md` | `src/07-shared/clock/{clock,system-clock,fixed-clock,index}.ts` 신규 + `src/06-entities/sessions/domain/session.aggregate.ts` (pair/isExpired Date 인자) + `src/05-features/sessions/services/pair-subject.service.ts` (constructor required + now 1회 관찰) | `clock.test.ts` (4) + `session.aggregate.test.ts` (9, +boundary) + `session.repository.test.ts` (5) + `pair-subject.service.test.ts` (5) + `pair-subject.bdd.test.ts` (8, +S4 A/B/C +S5 ×2) = 31 | feat/52-clock-port-race-fix | Done (ADR-007 Accepted) |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.test.ts
@@ -307,10 +307,17 @@ describe('dualTriggerService — Phase 17.6', () => {
       freshModule.dualTriggerService,
       'triggerAssignGroup'
     );
+    // TS-7 (J phase amend): success path silent log 검증용 spy
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
 
     await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('grp-006');
 
     expect(triggerSpy).toHaveBeenCalledWith('grp-006', expect.any(Array));
+    // TS-7: success path는 [2PC-trigger-skip] log emit 없음
+    expect(consoleSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('[2PC-trigger-skip]')
+    );
+    consoleSpy.mockRestore();
   });
 
   // ============================================================
@@ -470,5 +477,267 @@ describe('dualTriggerService — Phase 17.6', () => {
     expect(result1).toBe(true);
     // 2회차: 이미 등록됨 → false (idempotent)
     expect(result2).toBe(false);
+  });
+
+  // ============================================================
+  // TS-1 ~ TS-6: maybeTriggerDualAssignGroup audit logging (J phase)
+  //   6 silent return reason 분기별 log emit + trigger 미호출 검증함
+  // ============================================================
+
+  it('TS-1: sessions 빈 배열 → log emit reason=no_sessions + trigger 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: { find: jest.fn().mockResolvedValue([]) },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-empty');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=no_sessions')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('groupId=g-empty')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('sessionCount=0')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-2: BTI mode → log emit reason=mode_not_dual_2pc + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-bti',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'BTI',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-bti');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=mode_not_dual_2pc')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mode=BTI')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-3: subject1 미페어링 → log emit reason=subject1_not_paired + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-s1',
+            subjectIndex: 1,
+            status: 'CREATED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-s1',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    freshModule.operatorJoinedGroups.add('g-s1');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-s1');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=subject1_not_paired')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=false')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('operatorJoined=true')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    // cleanup — Set leak 방어 (plan-review R-02)
+    freshModule.operatorJoinedGroups.delete('g-s1');
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-4: subject2 미페어링 → log emit reason=subject2_not_paired + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-s2',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-s2',
+            subjectIndex: 2,
+            status: 'CREATED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    freshModule.operatorJoinedGroups.add('g-s2');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-s2');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=subject2_not_paired')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=false')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    freshModule.operatorJoinedGroups.delete('g-s2');
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-5: operator 미참여 → log emit reason=operator_not_joined + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-op',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-op',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    // operatorJoinedGroups에 add 안 함 → operatorJoined=false 강제
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-op');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=operator_not_joined')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject1Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('subject2Paired=true')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('operatorJoined=false')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('TS-6: pending=1 (한쪽만 등록) → reason=pending_count_mismatch + 미호출됨', async () => {
+    jest.resetModules();
+    jest.mock('@07-shared/config/config', () => ({
+      config: { dataEngine: { secretKey: 'valid-secret' } },
+    }));
+    jest.mock('@06-entities/sessions', () => ({
+      Session: {
+        find: jest.fn().mockResolvedValue([
+          {
+            groupId: 'g-pc1',
+            subjectIndex: 1,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+          {
+            groupId: 'g-pc1',
+            subjectIndex: 2,
+            status: 'PAIRED',
+            experimentMode: 'DUAL_2PC',
+          },
+        ]),
+      },
+    }));
+    const freshModule = await import('./dual-2pc-trigger.service');
+    const freshRegistryModule = await import('./engine-registry.service');
+    // subject 1만 등록 → pending.length = 1 → collectPendingSubjects 빈 배열 반환
+    freshRegistryModule.engineRegistryService.registerPending(
+      1,
+      'http://de-1.ngrok-free.dev',
+      'valid-secret'
+    );
+    freshModule.operatorJoinedGroups.add('g-pc1');
+    const triggerSpy = jest.spyOn(
+      freshModule.dualTriggerService,
+      'triggerAssignGroup'
+    );
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await freshModule.dualTriggerService.maybeTriggerDualAssignGroup('g-pc1');
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=pending_count_mismatch')
+    );
+    // pendingCount 값까지 검증 (plan-review R-01/R-03)
+    // collectPendingSubjects line 421 `pending.length < 2 ? []` → subjects.length=0
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pendingCount=0')
+    );
+    expect(triggerSpy).not.toHaveBeenCalled();
+    // cleanup — registry + Set 양쪽 (unregisterPending: subjectIndex, url, secret)
+    freshRegistryModule.engineRegistryService.unregisterPending(
+      1,
+      'http://de-1.ngrok-free.dev',
+      'valid-secret'
+    );
+    freshModule.operatorJoinedGroups.delete('g-pc1');
+    consoleSpy.mockRestore();
   });
 });

--- a/src/02-processes/engine/services/dual-2pc-trigger.service.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.ts
@@ -433,10 +433,26 @@ export const dualTriggerService: DualTriggerService = {
   async maybeTriggerDualAssignGroup(groupId) {
     // Mongoose Session 조회 — 3-condition AND 체크 (LD-1)
     const sessions = await Session.find({ groupId });
-    if (sessions.length === 0) return;
+    if (sessions.length === 0) {
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=no_sessions ` +
+          `sessionCount=0 mode=n/a subject1Paired=n/a subject2Paired=n/a ` +
+          `operatorJoined=n/a pendingCount=n/a`
+      );
+      return;
+    }
 
     const mode = sessions[0].experimentMode;
-    if (mode !== 'DUAL_2PC') return; // DUAL_2PC 모드가 아니면 skip
+    if (mode !== 'DUAL_2PC') {
+      // DUAL_2PC 모드가 아니면 skip
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=mode_not_dual_2pc ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=n/a subject2Paired=n/a operatorJoined=n/a ` +
+          `pendingCount=n/a`
+      );
+      return;
+    }
 
     const subject1Paired = sessions.some(
       (s) => s.subjectIndex === 1 && s.status === 'PAIRED'
@@ -446,12 +462,37 @@ export const dualTriggerService: DualTriggerService = {
     );
     const operatorJoined = operatorJoinedGroups.has(groupId);
 
-    // 3조건 AND 체크 (LD-1)
-    if (!subject1Paired || !subject2Paired || !operatorJoined) return;
+    // 3조건 AND 체크 (LD-1) — silent return reason 3분기 식별함
+    if (!subject1Paired || !subject2Paired || !operatorJoined) {
+      const reason = !subject1Paired
+        ? 'subject1_not_paired'
+        : !subject2Paired
+          ? 'subject2_not_paired'
+          : 'operator_not_joined';
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} reason=${reason} ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=${subject1Paired} ` +
+          `subject2Paired=${subject2Paired} ` +
+          `operatorJoined=${operatorJoined} pendingCount=n/a`
+      );
+      return;
+    }
 
     // pending DE 정보 조회 (LD-13)
     const subjects = await dualTriggerService.collectPendingSubjects(groupId);
-    if (subjects.length !== 2) return;
+    if (subjects.length !== 2) {
+      console.log(
+        `[2PC-trigger-skip] groupId=${groupId} ` +
+          `reason=pending_count_mismatch ` +
+          `sessionCount=${sessions.length} mode=${mode} ` +
+          `subject1Paired=${subject1Paired} ` +
+          `subject2Paired=${subject2Paired} ` +
+          `operatorJoined=${operatorJoined} ` +
+          `pendingCount=${subjects.length}`
+      );
+      return;
+    }
 
     await dualTriggerService.triggerAssignGroup(groupId, subjects);
   },

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -83,6 +83,8 @@ async function subscribeWithAligner(groupId: string): Promise<void> {
   const intervalId = setInterval(() => {
     timestampAlignerRegistry.flush(groupId);
   }, 100);
+  // process 종료 시 flush 타이머가 Jest/Node를 block하지 않도록 unref 적용함
+  intervalId.unref();
   groupFlushIntervals.set(groupId, intervalId);
 }
 

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -14,10 +14,7 @@
  */
 
 import { Types } from 'mongoose';
-import {
-  SessionAggregate,
-  SessionRepository,
-} from '@06-entities/sessions';
+import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
 import { PairSubjectService } from '../services/pair-subject.service';
 
@@ -33,7 +30,7 @@ const makeInMemoryRepo = () => {
     findById: jest.fn(async (id: string) => store.get(id) ?? null),
     findByPairingToken: jest.fn(async (token: string) => {
       const id = tokenIndex.get(token);
-      return id ? store.get(id) ?? null : null;
+      return id ? (store.get(id) ?? null) : null;
     }),
     save: jest.fn(async (aggregate: SessionAggregate) => {
       store.set(aggregate.id, aggregate);

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -1,0 +1,193 @@
+/**
+ * pair-subject.bdd.test.ts — Phase G BDD 형식 인수 테스트
+ *
+ * Q1 LOCK — Jest 단독 + 서비스 직접 호출 (supertest / HTTP 라우트 / Express app import 0건).
+ * Cucumber.js는 별도 spike 가지에서만 검증. 본 단계 정식 도구 = Jest.
+ *
+ * 비개발자(연구원·교수)가 시나리오 텍스트를 읽고 "그래, 그게 맞아"라고 판단할 수 있도록 작성함.
+ * 5/26 교수 면담 시연용 — 한국어 자연어 시나리오 3건을 직접 낭독.
+ *
+ * 시나리오 3건 (PLAN rev.3 §7.2 + AppError 코드 실측 정합):
+ *   1. SEQUENTIAL 모드 첫 페어링 성공 — CREATED → PAIRED + SessionPairedEvent 발행
+ *   2. 만료된 토큰 — AppError 401 throw
+ *   3. 이미 사용된 토큰 (status PAIRED) — AppError 400 throw
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionAggregate,
+  SessionRepository,
+} from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+import { PairSubjectService } from '../services/pair-subject.service';
+
+/**
+ * 테스트 환경 헬퍼 — SessionRepository를 in-memory Map으로 모킹함.
+ * 진짜 MongoDB 미연결 (CI 환경 + 본 프로젝트 통합 테스트 패턴 정합).
+ */
+const makeInMemoryRepo = () => {
+  const store = new Map<string, SessionAggregate>();
+  const tokenIndex = new Map<string, string>(); // pairingToken → id
+
+  const repo: jest.Mocked<SessionRepository> = {
+    findById: jest.fn(async (id: string) => store.get(id) ?? null),
+    findByPairingToken: jest.fn(async (token: string) => {
+      const id = tokenIndex.get(token);
+      return id ? store.get(id) ?? null : null;
+    }),
+    save: jest.fn(async (aggregate: SessionAggregate) => {
+      store.set(aggregate.id, aggregate);
+    }),
+    saveNew: jest.fn(async (aggregate: SessionAggregate) => {
+      store.set(aggregate.id, aggregate);
+      tokenIndex.set(aggregate.pairingToken, aggregate.id);
+    }),
+  } as unknown as jest.Mocked<SessionRepository>;
+
+  return repo;
+};
+
+describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
+  describe('Scenario: SEQUENTIAL 모드의 첫 페어링이 성공함', () => {
+    test(
+      'Given operator alice가 SEQUENTIAL 모드 세션을 생성했고, ' +
+        'When subject bob (userId)이 pairingToken으로 합류 요청을 보내면, ' +
+        'Then 세션 상태가 CREATED 에서 PAIRED 로 전이하고 ' +
+        'SessionPairedEvent (userId/groupId/subjectIndex/mode 포함)가 발행됨',
+      async () => {
+        // Given — operator alice가 SEQUENTIAL 모드 세션을 생성함
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const session = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'A1B2C3D4',
+          subjectIndex: 1,
+          pairingToken: 'TOK001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+        await repo.saveNew(session);
+
+        // When — subject bob (userId)이 pairingToken 'TOK001'로 합류 요청을 보냄
+        const userId = new Types.ObjectId().toString();
+        const service = new PairSubjectService(repo);
+        const result = await service.execute({
+          pairingToken: 'TOK001',
+          userId,
+        });
+
+        // Then — 세션 상태가 PAIRED로 전이됨 + SessionPairedEvent 발행 검증
+        const reloaded = await repo.findById(session.id);
+        expect(reloaded).not.toBeNull();
+        expect(reloaded!.status).toBe('PAIRED');
+        expect(reloaded!.userId).toBe(userId);
+        expect(reloaded!.pairedAt).not.toBeNull();
+
+        // 이벤트 모양 검증 — userId / groupId / subjectIndex / mode 모두 포함됨
+        expect(result.event.type).toBe('SessionPaired');
+        expect(result.event.sessionId).toBe(session.id);
+        expect(result.event.userId).toBe(userId);
+        expect(result.event.groupId).toBe('A1B2C3D4');
+        expect(result.event.subjectIndex).toBe(1);
+        expect(result.event.mode).toBe('SEQUENTIAL');
+        expect(typeof result.event.occurredAt).toBe('string');
+      }
+    );
+  });
+
+  describe('Scenario: 만료된 토큰으로 페어링 시 실패함', () => {
+    test(
+      'Given 만료된 pairingToken을 가진 세션이 존재하고, ' +
+        'When subject가 그 토큰으로 합류 시도하면, ' +
+        'Then AppError 401 throw + 세션 status가 EXPIRED로 영속됨',
+      async () => {
+        // Given — 만료된 세션 (expiresAt < 현재 시각)
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const expiredSession = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'EXPIRED1',
+          subjectIndex: 1,
+          pairingToken: 'EXP001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() - 1000), // 1초 전에 만료됨
+        });
+        await repo.saveNew(expiredSession);
+
+        // When — subject가 만료된 토큰으로 합류 시도함
+        const userId = new Types.ObjectId().toString();
+        const service = new PairSubjectService(repo);
+
+        // Then — AppError 401 throw
+        let captured: AppError | null = null;
+        try {
+          await service.execute({ pairingToken: 'EXP001', userId });
+        } catch (err) {
+          captured = err as AppError;
+        }
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(401);
+
+        // 세션 status가 EXPIRED로 영속됨
+        const reloaded = await repo.findById(expiredSession.id);
+        expect(reloaded!.status).toBe('EXPIRED');
+      }
+    );
+  });
+
+  describe('Scenario: 이미 사용된 토큰으로 페어링 시 실패함', () => {
+    test(
+      'Given 이미 PAIRED 상태인 세션이 존재하고, ' +
+        'When 다른 subject가 같은 토큰으로 합류 시도하면, ' +
+        'Then AppError 400 throw + 기존 페어링 정보 보존됨',
+      async () => {
+        // Given — 이미 PAIRED 상태 세션
+        const repo = makeInMemoryRepo();
+        const operatorId = new Types.ObjectId().toString();
+        const firstUserId = new Types.ObjectId().toString();
+        const session = SessionAggregate.create({
+          id: new Types.ObjectId().toString(),
+          groupId: 'PAIRED01',
+          subjectIndex: 1,
+          pairingToken: 'PRD001',
+          operatorId,
+          mode: 'SEQUENTIAL',
+          expiresAt: new Date(Date.now() + 60_000),
+        });
+        await repo.saveNew(session);
+
+        // 첫 번째 페어링 성공
+        const service = new PairSubjectService(repo);
+        await service.execute({
+          pairingToken: 'PRD001',
+          userId: firstUserId,
+        });
+        const afterFirst = await repo.findById(session.id);
+        expect(afterFirst!.status).toBe('PAIRED');
+        expect(afterFirst!.userId).toBe(firstUserId);
+
+        // When — 두 번째 subject가 같은 토큰으로 합류 시도함
+        const secondUserId = new Types.ObjectId().toString();
+        let captured: AppError | null = null;
+        try {
+          await service.execute({
+            pairingToken: 'PRD001',
+            userId: secondUserId,
+          });
+        } catch (err) {
+          captured = err as AppError;
+        }
+
+        // Then — AppError 400 throw + 기존 페어링 정보 보존됨
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(400);
+
+        const afterSecond = await repo.findById(session.id);
+        expect(afterSecond!.status).toBe('PAIRED');
+        expect(afterSecond!.userId).toBe(firstUserId); // 첫 페어링 그대로 유지됨
+      }
+    );
+  });
+});

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -16,7 +16,11 @@
 import { Types } from 'mongoose';
 import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import { FixedClock } from '@07-shared/clock';
 import { PairSubjectService } from '../services/pair-subject.service';
+
+/** BDD 시나리오 결정성용 고정 시각 — ADR-007 정합 */
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
 
 /**
  * 테스트 환경 헬퍼 — SessionRepository를 in-memory Map으로 모킹함.
@@ -62,13 +66,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'TOK001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() + 60_000),
+          expiresAt: new Date(TEST_NOW.getTime() + 60_000),
         });
         await repo.saveNew(session);
 
         // When — subject bob (userId)이 pairingToken 'TOK001'로 합류 요청을 보냄
         const userId = new Types.ObjectId().toString();
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
         const result = await service.execute({
           pairingToken: 'TOK001',
           userId,
@@ -109,13 +113,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'EXP001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() - 1000), // 1초 전에 만료됨
+          expiresAt: new Date(TEST_NOW.getTime() - 1000), // TEST_NOW 기준 1초 전 만료
         });
         await repo.saveNew(expiredSession);
 
         // When — subject가 만료된 토큰으로 합류 시도함
         const userId = new Types.ObjectId().toString();
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
         // Then — AppError 401 throw
         let captured: AppError | null = null;
@@ -151,12 +155,12 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
           pairingToken: 'PRD001',
           operatorId,
           mode: 'SEQUENTIAL',
-          expiresAt: new Date(Date.now() + 60_000),
+          expiresAt: new Date(TEST_NOW.getTime() + 60_000),
         });
         await repo.saveNew(session);
 
         // 첫 번째 페어링 성공
-        const service = new PairSubjectService(repo);
+        const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
         await service.execute({
           pairingToken: 'PRD001',
           userId: firstUserId,

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -192,3 +192,173 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
     );
   });
 });
+
+/**
+ * 시나리오 4·5 (Scenario 4: Clock seam race A-7 / Scenario 5: Single observed now)
+ *
+ * Phase H deep-module-poc PAAR Step 5 tdd-spec §2.4 + §2.5 정합.
+ * ADR-007 Clock port 도입 후 race 차단 + 결정성 입증 — `red→green evidence`.
+ * 본 시나리오 4 Context C는 race trigger 시점에서도 AppError 400 wrapping + 영속 PAIRED 불변
+ * 임을 입증하여 InvalidStatusTransitionError 외부 raw 노출이 차단됨을 확정함.
+ */
+
+/** 매번 fresh aggregate + repo 시드 헬퍼 (plan-review I-4 — Scenario 5 state 오염 차단) */
+const makeStubRepoWithCreatedSession = async (params: {
+  pairingToken: string;
+  expiresAt: Date;
+}) => {
+  const repo = makeInMemoryRepo();
+  const aggregate = SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: new Types.ObjectId().toString(),
+    subjectIndex: 1,
+    pairingToken: params.pairingToken,
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: params.expiresAt,
+  });
+  await repo.saveNew(aggregate);
+  return { repo, aggregate };
+};
+
+describe('Feature: Clock seam race 차단 (A-7) + single observed now (ADR-007)', () => {
+  describe('Scenario 4 — Clock seam race (Context A/B/C)', () => {
+    test('Context A: FixedClock T-1ms + status=CREATED → paired (결정적)', async () => {
+      const T = new Date('2026-05-13T11:00:00.000Z');
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-BND-A',
+        expiresAt: T,
+      });
+      const clock = new FixedClock(new Date(T.getTime() - 1));
+
+      const service = new PairSubjectService(repo, clock);
+      const userId = new Types.ObjectId().toString();
+      const result = await service.execute({
+        pairingToken: 'TOK-BND-A',
+        userId,
+      });
+
+      expect(result.session.status).toBe('PAIRED');
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('PAIRED');
+      expect(reloaded!.userId).toBe(userId);
+    });
+
+    test('Context B: FixedClock T+1ms + status=CREATED → AppError 401 + 영속 EXPIRED', async () => {
+      const T = new Date('2026-05-13T11:00:00.000Z');
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-BND-B',
+        expiresAt: T,
+      });
+      const clock = new FixedClock(new Date(T.getTime() + 1));
+
+      const service = new PairSubjectService(repo, clock);
+
+      let captured: AppError | null = null;
+      try {
+        await service.execute({
+          pairingToken: 'TOK-BND-B',
+          userId: new Types.ObjectId().toString(),
+        });
+      } catch (err) {
+        captured = err as AppError;
+      }
+
+      expect(captured).toBeInstanceOf(AppError);
+      expect(captured!.statusCode).toBe(401);
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('EXPIRED');
+    });
+
+    test(
+      'Context C (A-7 race trigger): status=PAIRED + FixedClock T-1ms + expiresAt=T → ' +
+        'AppError 400 + 영속 PAIRED 불변 + InvalidStatusTransitionError 외부 노출 0건',
+      async () => {
+        const T = new Date('2026-05-13T11:00:00.000Z');
+        const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+          pairingToken: 'TOK-BND-C',
+          expiresAt: T,
+        });
+
+        // 사전 페어링 — PAIRED 상태로 전이 (이전 user 박제)
+        const previousUserId = new Types.ObjectId().toString();
+        aggregate.pair(previousUserId, new Date(T.getTime() - 1000));
+        await repo.save(aggregate);
+        expect(aggregate.status).toBe('PAIRED');
+
+        // Approach A 미적용 상태에선 race trigger 시점 (T-1ms boundary).
+        // Approach A 적용 후 같은 now가 pair() 내부 isExpired와 catch 분기 isExpired에 전달되어
+        // race 차단 + AppError 400 wrapping 유지함.
+        const clock = new FixedClock(new Date(T.getTime() - 1));
+        const service = new PairSubjectService(repo, clock);
+
+        let captured: AppError | null = null;
+        try {
+          await service.execute({
+            pairingToken: 'TOK-BND-C',
+            userId: new Types.ObjectId().toString(),
+          });
+        } catch (err) {
+          captured = err as AppError;
+        }
+
+        expect(captured).toBeInstanceOf(AppError);
+        expect(captured!.statusCode).toBe(400);
+        expect(captured!.message).toContain('현재 세션 상태(PAIRED)에서는');
+
+        const reloaded = await repo.findById(aggregate.id);
+        expect(reloaded!.status).toBe('PAIRED'); // 영속 불변
+        expect(reloaded!.userId).toBe(previousUserId); // 덮어쓰기 0
+      }
+    );
+  });
+
+  describe('Scenario 5 — Single observed now', () => {
+    test('wall clock 진행과 무관하게 FixedClock 결과 결정적 (N=5 반복, 매번 fresh seed)', async () => {
+      const T0 = new Date('2026-05-13T12:00:00.000Z');
+      const clock = new FixedClock(T0);
+
+      // plan-review I-4 정합 — 매번 fresh repo + fresh aggregate (state 오염 차단)
+      for (let i = 0; i < 5; i++) {
+        const token = `TOK-SON-${i}`;
+        const { repo } = await makeStubRepoWithCreatedSession({
+          pairingToken: token,
+          expiresAt: new Date(T0.getTime() + 1), // boundary 직전
+        });
+        const service = new PairSubjectService(repo, clock);
+        const result = await service.execute({
+          pairingToken: token,
+          userId: new Types.ObjectId().toString(),
+        });
+        expect(result.session.status).toBe('PAIRED'); // 5회 모두 동일
+      }
+    });
+
+    test('boundary 직후 FixedClock 주입 시 결정적 expired (boundary 반대 케이스)', async () => {
+      const T0 = new Date('2026-05-13T12:00:00.000Z');
+      const expiresAt = T0;
+      const clock = new FixedClock(new Date(T0.getTime() + 1)); // boundary 직후
+
+      const { repo, aggregate } = await makeStubRepoWithCreatedSession({
+        pairingToken: 'TOK-SON-AFTER',
+        expiresAt,
+      });
+      const service = new PairSubjectService(repo, clock);
+
+      let captured: AppError | null = null;
+      try {
+        await service.execute({
+          pairingToken: 'TOK-SON-AFTER',
+          userId: new Types.ObjectId().toString(),
+        });
+      } catch (err) {
+        captured = err as AppError;
+      }
+
+      expect(captured).toBeInstanceOf(AppError);
+      expect(captured!.statusCode).toBe(401);
+      const reloaded = await repo.findById(aggregate.id);
+      expect(reloaded!.status).toBe('EXPIRED');
+    });
+  });
+});

--- a/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
+++ b/src/05-features/sessions/__tests__/pair-subject.bdd.test.ts
@@ -93,6 +93,14 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         expect(result.event.subjectIndex).toBe(1);
         expect(result.event.mode).toBe('SEQUENTIAL');
         expect(typeof result.event.occurredAt).toBe('string');
+
+        // drainRecordedEvents observable (tdd-spec §2.1 #6 정합 — codex review R2-1)
+        const firstDrain = service.drainRecordedEvents();
+        expect(firstDrain).toHaveLength(1);
+        expect(firstDrain[0].type).toBe('SessionPaired');
+        expect(firstDrain[0].userId).toBe(userId);
+        // 두 번째 drain은 빈 배열 (buffer 비움 동작 검증)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });
@@ -134,6 +142,9 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         // 세션 status가 EXPIRED로 영속됨
         const reloaded = await repo.findById(expiredSession.id);
         expect(reloaded!.status).toBe('EXPIRED');
+
+        // 만료 흐름은 event 발화 0건 (tdd-spec §2.2 #3 — codex review R2-1)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });
@@ -168,6 +179,13 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         const afterFirst = await repo.findById(session.id);
         expect(afterFirst!.status).toBe('PAIRED');
         expect(afterFirst!.userId).toBe(firstUserId);
+        const firstPairedAt = afterFirst!.pairedAt;
+        expect(firstPairedAt).not.toBeNull();
+
+        // 첫 페어링 event는 buffer drain 후 retry 시 새 event 발화 0건 검증 준비
+        const firstDrain = service.drainRecordedEvents();
+        expect(firstDrain).toHaveLength(1);
+        expect(firstDrain[0].userId).toBe(firstUserId);
 
         // When — 두 번째 subject가 같은 토큰으로 합류 시도함
         const secondUserId = new Types.ObjectId().toString();
@@ -188,6 +206,10 @@ describe('Feature: 피실험자가 QR을 스캔해 세션에 합류함', () => {
         const afterSecond = await repo.findById(session.id);
         expect(afterSecond!.status).toBe('PAIRED');
         expect(afterSecond!.userId).toBe(firstUserId); // 첫 페어링 그대로 유지됨
+        // pairedAt unchanged (tdd-spec §2.3 #2 — codex review R2-1)
+        expect(afterSecond!.pairedAt!.getTime()).toBe(firstPairedAt!.getTime());
+        // retry 흐름은 새 event 발화 0건 (tdd-spec §2.3 #3)
+        expect(service.drainRecordedEvents()).toHaveLength(0);
       }
     );
   });

--- a/src/05-features/sessions/api/session.controller.ts
+++ b/src/05-features/sessions/api/session.controller.ts
@@ -6,6 +6,7 @@ import {
 import { submitConsentProcess } from '@05-features/sessions/services/submit-consent.service';
 import { createOperatorInviteToken } from '@05-features/sessions/services/invite-operator.service';
 import { joinAsOperator } from '@05-features/sessions/services/join-operator.service';
+import { adminPairDeviceProcess } from '@05-features/sessions/services/admin-pair.service';
 import { AppError } from '@07-shared/errors';
 import {
   pairDeviceSchema,
@@ -129,6 +130,36 @@ export const pairDevice = async (
       status: 'success',
       data: session,
     });
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * [Controller] 관리자 강제 페어링 처리함.
+ *
+ * @throws AppError 401 — admin/타겟 user 미존재
+ * @throws AppError 403 — 관리자 권한 없음
+ * @throws AppError 404 — target email DB 미존재
+ */
+export const adminPairDevice = async (
+  req: AuthedRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const { pairingToken } = req.params;
+    // validate middleware가 body를 adminPairSchema로 parse 후 교체함
+    const { email } = req.body as { email: string };
+
+    if (!req.user || !req.user.id) {
+      throw new AppError('인증이 필요한 서비스입니다.', 401);
+    }
+    const adminId = req.user.id;
+
+    const session = await adminPairDeviceProcess(pairingToken, email, adminId);
+
+    res.status(200).json({ status: 'success', data: session });
   } catch (error) {
     next(error);
   }

--- a/src/05-features/sessions/api/session.routes.adminpair.test.ts
+++ b/src/05-features/sessions/api/session.routes.adminpair.test.ts
@@ -1,0 +1,149 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+import { Types } from 'mongoose';
+
+// env는 모듈 로딩 전에 설정 — config.ts 초기 평가에 영향
+process.env.JWT_SECRET_KEY = 'test-secret';
+process.env.JWT_EXPIRES_IN = '1h';
+process.env.ADMIN_EMAILS = 'admin-test@example.com';
+
+// hoist-safe — factory 내부는 리터럴만 사용
+jest.mock('@06-entities/users/model/user.schema', () => {
+  const ChainedQuery = (resolveValue: unknown) => ({
+    lean: jest.fn().mockResolvedValue(resolveValue),
+  });
+  return {
+    __esModule: true,
+    default: {
+      findById: jest.fn((id: string) => {
+        if (id === 'ADMIN_ID_LITERAL') {
+          return ChainedQuery({ email: 'admin-test@example.com' });
+        }
+        if (id === 'NON_ADMIN_ID_LITERAL') {
+          return ChainedQuery({ email: 'normal@user.com' });
+        }
+        return ChainedQuery(null);
+      }),
+      findOne: jest.fn((filter: { email: string }) => {
+        if (filter.email === 'target@example.com') {
+          return {
+            lean: jest.fn().mockResolvedValue({
+              _id: new Types.ObjectId('507f191e810c19729de860ea'),
+            }),
+          };
+        }
+        return { lean: jest.fn().mockResolvedValue(null) };
+      }),
+    },
+  };
+});
+
+jest.mock('@05-features/sessions/services/pairing.service', () => ({
+  pairDeviceProcess: jest.fn().mockResolvedValue({
+    _id: 'sess-int-1',
+    groupId: 'g-int',
+    subjectIndex: 1,
+    status: 'PAIRED',
+  }),
+  addPairingCompleteListener: jest.fn(),
+  pairingListeners: new Set(),
+}));
+
+import sessionRoutes from './session.routes';
+import { AppError } from '@07-shared/errors';
+
+// bare Express app — mongoose connect 없음, app.ts side-effect 회피
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/sessions', sessionRoutes);
+  app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+    if (err instanceof AppError) {
+      return res.status(err.statusCode).json({
+        status: err.statusCode >= 500 ? 'error' : 'fail',
+        message: err.message,
+      });
+    }
+    return res.status(500).json({ status: 'error', message: 'internal' });
+  });
+  return app;
+};
+
+const makeToken = (userId: string) =>
+  jwt.sign({ id: userId }, 'test-secret', { expiresIn: '1h' });
+
+describe('POST /api/sessions/:pairingToken/admin-pair (integration)', () => {
+  const app = buildApp();
+
+  // I-1
+  it('I-1: Happy path — admin JWT + valid target email → 200 + session', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      status: 'success',
+      data: expect.objectContaining({ _id: 'sess-int-1' }),
+    });
+  });
+
+  // I-2
+  it('I-2: non-admin JWT → 403', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('NON_ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('관리자'),
+    });
+  });
+
+  // I-3
+  it('I-3: JWT missing → 401', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .send({ email: 'target@example.com' });
+
+    expect(res.status).toBe(401);
+  });
+
+  // I-4 — route 미등록 404 vs service 404 구분
+  it('I-4: target email 미존재 → 404 + service-level 메시지', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'missing@example.com' });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({
+      status: 'fail',
+      message: expect.stringContaining('대상 사용자'),
+    });
+  });
+
+  // I-5 — Zod strict mass-assignment 방어
+  it('I-5: body에 추가 필드 → 400', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: 'target@example.com', isAdmin: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  // I-6 — email normalize (대소문자/공백)
+  it('I-6: body email 대소문자/공백 → normalize 후 200', async () => {
+    const res = await request(app)
+      .post('/api/sessions/token-1/admin-pair')
+      .set('Authorization', `Bearer ${makeToken('ADMIN_ID_LITERAL')}`)
+      .send({ email: '  TARGET@example.com  ' });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/05-features/sessions/api/session.routes.ts
+++ b/src/05-features/sessions/api/session.routes.ts
@@ -1,7 +1,9 @@
 import { Router } from 'express';
 import * as sessionsController from './session.controller';
 import { authenticate, validate } from '@07-shared/middlewares'; // 인증 및 Zod body 검증 미들웨어
+import { requireAdmin } from '../middlewares/require-admin.middleware'; // K phase admin gate
 import { createSessionSchema } from './session.schema'; // 세션 생성 스키마
+import { adminPairSchema } from '../dto/session.dto'; // K phase 강제 페어링 body 스키마
 
 const router = Router();
 
@@ -206,6 +208,15 @@ router.post(
  */
 
 router.post('/:pairingToken/pair', authenticate, sessionsController.pairDevice);
+
+// K phase 관리자 강제 페어링 — chain: authenticate → requireAdmin → validate → controller
+router.post(
+  '/:pairingToken/admin-pair',
+  authenticate,
+  requireAdmin,
+  validate(adminPairSchema),
+  sessionsController.adminPairDevice
+);
 
 /**
  * @openapi

--- a/src/05-features/sessions/dto/session.dto.ts
+++ b/src/05-features/sessions/dto/session.dto.ts
@@ -21,3 +21,13 @@ export const submitConsentSchema = z.object({
 });
 
 export type SubmitConsentDto = z.infer<typeof submitConsentSchema>;
+
+// 강제 페어링 body 검증 — Zod strict() mass-assignment 방어함
+// .trim() 적용으로 normalize 시나리오가 schema 차원에서 차단되지 않게 처리함
+export const adminPairSchema = z
+  .object({
+    email: z.string().trim().email('유효한 이메일 형식이어야 합니다.'),
+  })
+  .strict();
+
+export type AdminPairDto = z.infer<typeof adminPairSchema>;

--- a/src/05-features/sessions/middlewares/require-admin.middleware.test.ts
+++ b/src/05-features/sessions/middlewares/require-admin.middleware.test.ts
@@ -1,0 +1,80 @@
+import { Response, NextFunction } from 'express';
+
+jest.mock('@07-shared/config/config', () => ({
+  config: { adminEmails: ['admin@example.com'] },
+}));
+
+const mockFindById = jest.fn();
+jest.mock('@06-entities/users/model/user.schema', () => ({
+  __esModule: true,
+  default: {
+    findById: (...args: unknown[]) => mockFindById(...args),
+  },
+}));
+
+import { requireAdmin } from './require-admin.middleware';
+import { AppError } from '@07-shared/errors';
+
+const makeReq = (userId?: string) =>
+  ({
+    user: userId ? { id: userId } : undefined,
+  }) as Parameters<typeof requireAdmin>[0];
+
+const res = {} as Response;
+
+describe('requireAdmin middleware', () => {
+  let next: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindById.mockReset();
+    next = jest.fn();
+  });
+
+  // M-1
+  it('M-1: admin email allowlist 통과 → next() 호출됨', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'admin@example.com' }),
+    });
+    await requireAdmin(makeReq('admin-id'), res, next as NextFunction);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  // M-2
+  it('M-2: req.user.id 누락 → 401', async () => {
+    await requireAdmin(makeReq(undefined), res, next as NextFunction);
+    expect(next).toHaveBeenCalledWith(expect.any(AppError));
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(401);
+  });
+
+  // M-3
+  it('M-3: DB stale (findById 결과 null) → 401', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue(null),
+    });
+    await requireAdmin(makeReq('stale-id'), res, next as NextFunction);
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(401);
+  });
+
+  // M-4
+  it('M-4: user email이 allowlist 미포함 → 403', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'normal@user.com' }),
+    });
+    await requireAdmin(makeReq('user-id'), res, next as NextFunction);
+    const err = next.mock.calls[0][0] as AppError;
+    expect(err.statusCode).toBe(403);
+  });
+
+  // M-5
+  it('M-5: findById 호출 시 projection {email:1} 적용됨', async () => {
+    mockFindById.mockReturnValue({
+      lean: jest.fn().mockResolvedValue({ email: 'admin@example.com' }),
+    });
+    await requireAdmin(makeReq('admin-id'), res, next as NextFunction);
+    expect(mockFindById).toHaveBeenCalledWith('admin-id', { email: 1 });
+  });
+});

--- a/src/05-features/sessions/middlewares/require-admin.middleware.ts
+++ b/src/05-features/sessions/middlewares/require-admin.middleware.ts
@@ -1,0 +1,37 @@
+import { Response, NextFunction } from 'express';
+import { config } from '@07-shared/config/config';
+import { AppError } from '@07-shared/errors';
+import { AuthedRequest } from '@07-shared/types';
+import User from '@06-entities/users/model/user.schema';
+
+/**
+ * 관리자 권한 검증 미들웨어 — authenticate 이후에 chain됨.
+ *
+ * @param req - AuthedRequest (req.user.id JWT payload 주입 후)
+ * @param _res - 응답 객체 미사용
+ * @param next - 다음 미들웨어 호출 함수
+ * @throws AppError 401 — req.user.id 누락 또는 DB stale
+ * @throws AppError 403 — user.email이 ADMIN_EMAILS 미포함
+ */
+export const requireAdmin = async (
+  req: AuthedRequest,
+  _res: Response,
+  next: NextFunction
+) => {
+  try {
+    if (!req.user?.id) {
+      return next(new AppError('인증이 필요합니다.', 401));
+    }
+    // projection {email:1}로 PII 최소화 + lean()으로 hydrated overhead 제거함
+    const user = await User.findById(req.user.id, { email: 1 }).lean();
+    if (!user) {
+      return next(new AppError('사용자를 찾을 수 없습니다.', 401));
+    }
+    if (!config.adminEmails.includes(user.email)) {
+      return next(new AppError('관리자 권한이 필요합니다.', 403));
+    }
+    next();
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/05-features/sessions/services/admin-pair.service.test.ts
+++ b/src/05-features/sessions/services/admin-pair.service.test.ts
@@ -1,0 +1,128 @@
+import { Types } from 'mongoose';
+
+const mockFindOne = jest.fn();
+const mockPairDeviceProcess = jest.fn();
+
+jest.mock('@06-entities/users/model/user.schema', () => ({
+  __esModule: true,
+  default: { findOne: (...args: unknown[]) => mockFindOne(...args) },
+}));
+jest.mock('./pairing.service', () => ({
+  pairDeviceProcess: (...args: unknown[]) => mockPairDeviceProcess(...args),
+}));
+
+import { adminPairDeviceProcess } from './admin-pair.service';
+
+// .lean() chain helper — Mongoose Query stub
+const leanReturning = (value: unknown) => ({
+  lean: jest.fn().mockResolvedValue(value),
+});
+
+const ADMIN_ID = new Types.ObjectId().toString();
+const TARGET_ID = new Types.ObjectId();
+const TARGET_ID_STR = TARGET_ID.toString();
+
+describe('adminPairDeviceProcess', () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  // AS-1
+  it('AS-1: target email 정상 → pairDeviceProcess 호출 + success log emit', async () => {
+    mockFindOne.mockReturnValue(leanReturning({ _id: TARGET_ID }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-1',
+      groupId: 'g-1',
+      subjectIndex: 1,
+    });
+
+    const result = await adminPairDeviceProcess(
+      'token-x',
+      'user@example.com',
+      ADMIN_ID
+    );
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      { email: 'user@example.com' },
+      { _id: 1 }
+    );
+    expect(mockPairDeviceProcess).toHaveBeenCalledWith(
+      'token-x',
+      TARGET_ID_STR
+    );
+    expect(result._id).toBe('sess-1');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[admin-force-pair] outcome=success')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`adminId=${ADMIN_ID}`)
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`targetUserId=${TARGET_ID_STR}`)
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('isSelf=false')
+    );
+  });
+
+  // AS-2
+  it('AS-2: target email 미존재 → 404 + failure log emit', async () => {
+    mockFindOne.mockReturnValue(leanReturning(null));
+
+    await expect(
+      adminPairDeviceProcess('token-x', 'missing@example.com', ADMIN_ID)
+    ).rejects.toMatchObject({ statusCode: 404 });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[admin-force-pair] outcome=failure')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reason=target_user_not_found')
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('targetEmail=missing@example.com')
+    );
+    expect(mockPairDeviceProcess).not.toHaveBeenCalled();
+  });
+
+  // AS-3
+  it('AS-3: isSelf=true (admin이 자기 자신 강제 페어링)', async () => {
+    const sameAsAdmin = new Types.ObjectId(ADMIN_ID);
+    mockFindOne.mockReturnValue(leanReturning({ _id: sameAsAdmin }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-2',
+      groupId: 'g-2',
+      subjectIndex: 1,
+    });
+
+    await adminPairDeviceProcess('token-y', 'admin@example.com', ADMIN_ID);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('isSelf=true')
+    );
+  });
+
+  // AS-4
+  it('AS-4: email normalize (대소문자 + 공백) — DB lookup은 normalized 값', async () => {
+    mockFindOne.mockReturnValue(leanReturning({ _id: TARGET_ID }));
+    mockPairDeviceProcess.mockResolvedValue({
+      _id: 'sess-3',
+      groupId: 'g-3',
+      subjectIndex: 1,
+    });
+
+    await adminPairDeviceProcess('token-z', '  Admin@Example.COM  ', ADMIN_ID);
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      { email: 'admin@example.com' },
+      { _id: 1 }
+    );
+  });
+});

--- a/src/05-features/sessions/services/admin-pair.service.ts
+++ b/src/05-features/sessions/services/admin-pair.service.ts
@@ -1,0 +1,48 @@
+import { AppError } from '@07-shared/errors';
+import User from '@06-entities/users/model/user.schema';
+import { pairDeviceProcess } from './pairing.service';
+
+/**
+ * 관리자가 사용자 email로 강제 페어링 처리함.
+ *
+ * 기존 pairDeviceProcess 재사용으로 pairing listener fire + DUAL_2PC trigger
+ * audit log (J phase) 자동 정합 유지.
+ *
+ * @param pairingToken - 세션 페어링 토큰
+ * @param targetEmail - 페어링 대상 user의 email (normalize 후 lookup함)
+ * @param adminId - 호출자 admin user의 _id (audit log 박제용)
+ * @returns 페어링 완료된 Session document
+ * @throws AppError 404 — target email DB 미존재
+ * @throws AppError - pairDeviceProcess 기존 throw 전파 (401/400 등)
+ */
+export const adminPairDeviceProcess = async (
+  pairingToken: string,
+  targetEmail: string,
+  adminId: string
+) => {
+  const normalized = targetEmail.trim().toLowerCase();
+  const targetUser = await User.findOne(
+    { email: normalized },
+    { _id: 1 }
+  ).lean();
+  if (!targetUser) {
+    console.log(
+      `[admin-force-pair] outcome=failure reason=target_user_not_found ` +
+        `adminId=${adminId} targetEmail=${normalized}`
+    );
+    throw new AppError('대상 사용자를 찾을 수 없습니다.', 404);
+  }
+
+  // lean() 도 ObjectId 반환함 — toString() 안전
+  const targetUserId = targetUser._id.toString();
+  const session = await pairDeviceProcess(pairingToken, targetUserId);
+
+  console.log(
+    `[admin-force-pair] outcome=success adminId=${adminId} ` +
+      `targetUserId=${targetUserId} ` +
+      `isSelf=${adminId === targetUserId} ` +
+      `sessionId=${session._id} groupId=${session.groupId} ` +
+      `subjectIndex=${session.subjectIndex}`
+  );
+  return session;
+};

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -1,0 +1,158 @@
+/**
+ * pair-subject.service.test.ts — PairSubjectService 단위 테스트
+ *
+ * SessionRepository는 jest.fn() mock으로 격리함 — 진짜 DB 미연결.
+ * PLAN rev.3 §7.1 시나리오 4건 (AppError 400/401/404 실측 정합).
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionAggregate,
+  SessionRepository,
+} from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+import { PairSubjectService } from './pair-subject.service';
+
+const makeAggregate = (
+  override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+) => {
+  return SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: new Date(Date.now() + 60_000),
+    ...override,
+  });
+};
+
+const makeRepoMock = () => {
+  return {
+    findById: jest.fn(),
+    findByPairingToken: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+    saveNew: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<SessionRepository> & {
+    findByPairingToken: jest.Mock;
+    save: jest.Mock;
+  };
+};
+
+describe('PairSubjectService', () => {
+  test('1. happy path — 유효 토큰 + 유효 userId → CREATED → PAIRED + 이벤트 발행', async () => {
+    const aggregate = makeAggregate();
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(aggregate);
+
+    const service = new PairSubjectService(repo);
+    const result = await service.execute({
+      pairingToken: 'TOK001',
+      userId,
+    });
+
+    expect(repo.findByPairingToken).toHaveBeenCalledWith('TOK001');
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(result.session.status).toBe('PAIRED');
+    expect(result.session.userId).toBe(userId);
+    expect(result.event.type).toBe('SessionPaired');
+    expect(result.event.userId).toBe(userId);
+    expect(result.event.groupId).toBe('A1B2C3D4');
+    expect(result.event.subjectIndex).toBe(1);
+    expect(result.event.mode).toBe('SEQUENTIAL');
+
+    // 메모리 기록 확인
+    const events = service.drainRecordedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('SessionPaired');
+  });
+
+  test('2. 만료 토큰 → AppError 401 throw + 세션 status EXPIRED 영속', async () => {
+    const expired = makeAggregate({
+      expiresAt: new Date(Date.now() - 1000), // 이미 만료됨
+    });
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(expired);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'TOK001', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(401);
+    // expire()로 status 변경 + repo.save 호출 검증
+    expect(expired.status).toBe('EXPIRED');
+    expect(repo.save).toHaveBeenCalled();
+  });
+
+  test('3. 이미 PAIRED 상태 토큰 → AppError 400 throw', async () => {
+    const aggregate = makeAggregate();
+    aggregate.pair(new Types.ObjectId().toString()); // 사전 페어링 완료
+    expect(aggregate.status).toBe('PAIRED');
+
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(aggregate);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'TOK001', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(400);
+    // 이미 PAIRED 상태에서는 save 호출 0건 (전이 불가 시 expire/save 분기 안 탐)
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  test('4. 존재하지 않는 토큰 → AppError 404 throw', async () => {
+    const userId = new Types.ObjectId().toString();
+    const repo = makeRepoMock();
+    repo.findByPairingToken.mockResolvedValueOnce(null);
+
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({ pairingToken: 'NOPE000', userId });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(404);
+    expect(repo.save).not.toHaveBeenCalled();
+  });
+
+  test('보조: userId 형식 부정합 → AppError 400 throw + repo 호출 0건', async () => {
+    const repo = makeRepoMock();
+    const service = new PairSubjectService(repo);
+
+    let captured: AppError | null = null;
+    try {
+      await service.execute({
+        pairingToken: 'TOK001',
+        userId: 'not-an-objectid',
+      });
+    } catch (err) {
+      captured = err as AppError;
+    }
+
+    expect(captured).toBeInstanceOf(AppError);
+    expect(captured!.statusCode).toBe(400);
+    // userId 검증 실패 시 토큰 조회 0건
+    expect(repo.findByPairingToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -6,10 +6,7 @@
  */
 
 import { Types } from 'mongoose';
-import {
-  SessionAggregate,
-  SessionRepository,
-} from '@06-entities/sessions';
+import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
 import { PairSubjectService } from './pair-subject.service';
 

--- a/src/05-features/sessions/services/pair-subject.service.test.ts
+++ b/src/05-features/sessions/services/pair-subject.service.test.ts
@@ -8,7 +8,10 @@
 import { Types } from 'mongoose';
 import { SessionAggregate, SessionRepository } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import { FixedClock } from '@07-shared/clock';
 import { PairSubjectService } from './pair-subject.service';
+
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
 
 const makeAggregate = (
   override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
@@ -20,7 +23,7 @@ const makeAggregate = (
     pairingToken: 'TOK001',
     operatorId: new Types.ObjectId().toString(),
     mode: 'SEQUENTIAL',
-    expiresAt: new Date(Date.now() + 60_000),
+    expiresAt: new Date(TEST_NOW.getTime() + 60_000),
     ...override,
   });
 };
@@ -44,7 +47,7 @@ describe('PairSubjectService', () => {
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(aggregate);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
     const result = await service.execute({
       pairingToken: 'TOK001',
       userId,
@@ -68,13 +71,13 @@ describe('PairSubjectService', () => {
 
   test('2. 만료 토큰 → AppError 401 throw + 세션 status EXPIRED 영속', async () => {
     const expired = makeAggregate({
-      expiresAt: new Date(Date.now() - 1000), // 이미 만료됨
+      expiresAt: new Date(TEST_NOW.getTime() - 1000), // TEST_NOW 기준 1초 전 만료
     });
     const userId = new Types.ObjectId().toString();
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(expired);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -92,14 +95,14 @@ describe('PairSubjectService', () => {
 
   test('3. 이미 PAIRED 상태 토큰 → AppError 400 throw', async () => {
     const aggregate = makeAggregate();
-    aggregate.pair(new Types.ObjectId().toString()); // 사전 페어링 완료
+    aggregate.pair(new Types.ObjectId().toString(), TEST_NOW); // 사전 페어링 완료 (plan-review I-2: Date 인자 추가)
     expect(aggregate.status).toBe('PAIRED');
 
     const userId = new Types.ObjectId().toString();
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(aggregate);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -119,7 +122,7 @@ describe('PairSubjectService', () => {
     const repo = makeRepoMock();
     repo.findByPairingToken.mockResolvedValueOnce(null);
 
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {
@@ -135,7 +138,7 @@ describe('PairSubjectService', () => {
 
   test('보조: userId 형식 부정합 → AppError 400 throw + repo 호출 0건', async () => {
     const repo = makeRepoMock();
-    const service = new PairSubjectService(repo);
+    const service = new PairSubjectService(repo, new FixedClock(TEST_NOW));
 
     let captured: AppError | null = null;
     try {

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -27,6 +27,7 @@ import {
 } from '@06-entities/sessions';
 import type { SessionPairedEvent } from '@06-entities/sessions';
 import { AppError } from '@07-shared/errors';
+import type { Clock } from '@07-shared/clock';
 
 /** PairSubjectService.execute() 입력 인자 */
 export interface PairSubjectInput {
@@ -42,10 +43,16 @@ export interface PairSubjectResult {
 
 export class PairSubjectService {
   private readonly repo: SessionRepository;
+  private readonly clock: Clock;
   private recordedEvents: SessionPairedEvent[] = [];
 
-  constructor(repo?: SessionRepository) {
-    this.repo = repo ?? new SessionRepository();
+  /**
+   * @param repo SessionRepository 어댑터 — 영속화 경유함 (required, A-6 soft seam 해소)
+   * @param clock Clock port — 한 execute() 호출 내 시간 결정성 보장 (ADR-007)
+   */
+  constructor(repo: SessionRepository, clock: Clock) {
+    this.repo = repo;
+    this.clock = clock;
   }
 
   /**
@@ -67,13 +74,17 @@ export class PairSubjectService {
       throw new AppError('존재하지 않거나 유효하지 않은 토큰입니다', 404);
     }
 
+    // 2.5. Clock 1회 관찰 — 본 호출의 모든 시간 판단에 동일 Date snapshot 사용함 (ADR-007)
+    const now = this.clock.now();
+
     // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제
     try {
-      aggregate.pair(input.userId);
+      aggregate.pair(input.userId, now);
     } catch (err) {
       if (err instanceof InvalidStatusTransitionError) {
         // 만료 시 EXPIRED 영속화 + 401 throw (기존 pairing.service.ts L101-105 정합)
-        if (aggregate.isExpired()) {
+        // race 차단 — 동일 `now`를 isExpired에 전달하여 pair() 내부 판단과 결정성 유지함
+        if (aggregate.isExpired(now)) {
           aggregate.expire();
           await this.repo.save(aggregate);
           throw new AppError(
@@ -94,11 +105,12 @@ export class PairSubjectService {
     await this.repo.save(aggregate);
 
     // 5. 도메인 이벤트 메모리 기록 (LD-12 listener 통합은 후속 controller 통합 PR로 분리함)
+    // event.occurredAt도 동일 `now`를 사용함 — 한 호출 = 한 timestamp 결정성
     const event: SessionPairedEvent = {
       type: 'SessionPaired',
       sessionId: aggregate.id,
       userId: input.userId,
-      occurredAt: new Date().toISOString(),
+      occurredAt: now.toISOString(),
       groupId: aggregate.groupId,
       subjectIndex: aggregate.subjectIndex,
       mode: aggregate.mode,

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -1,0 +1,120 @@
+/**
+ * pair-subject.service.ts — 피실험자 페어링 응용 서비스 (Application Service)
+ *
+ * Phase G strangler 패턴 — 기존 pairing.service.ts::pairDeviceProcess(pairingToken, userId)와
+ * 병렬 존재함. 동일 시그니처 + Repository 어댑터 경유 + 도메인 invariant 강제.
+ *
+ * execute({pairingToken, userId}) 5단계 흐름 (pairing.service.ts:83-138 정합):
+ *   1. Types.ObjectId.isValid(userId) 형식 검증 → 실패 시 AppError 400
+ *   2. repository.findByPairingToken(pairingToken) — 미존재 시 AppError 404
+ *   3. aggregate.pair(userId) — 만료 시 expire() + save + AppError 401 / 전이 불가 시 AppError 400
+ *   4. repository.save(aggregate) — 영속화
+ *   5. SessionPairedEvent 메모리 기록 (recordedEvents)
+ *
+ * NOTE — 기존 pairingListeners (LD-12 대안 D) 통합 호출은 본 단계에서 제외함.
+ *   이유: 기존 pairing.service.ts 수정 0건 의무 (G9) 보존 — listener Set을 외부 노출하려면
+ *         기존 파일 수정 필요. 후속 controller 통합 PR에서 별도 결정 (헬퍼 export 또는
+ *         controller 레벨에서 양쪽 fire).
+ *   영향: 본 PairSubjectService를 직접 호출하는 경로(BDD 테스트)에서는 listener 미발화.
+ *         기존 HTTP 라우트는 여전히 pairDeviceProcess 사용 — listener 발화 동작 보존.
+ */
+
+import { Types } from 'mongoose';
+import {
+  SessionRepository,
+  SessionAggregate,
+  InvalidStatusTransitionError,
+} from '@06-entities/sessions';
+import type { SessionPairedEvent } from '@06-entities/sessions';
+import { AppError } from '@07-shared/errors';
+
+/** PairSubjectService.execute() 입력 인자 */
+export interface PairSubjectInput {
+  pairingToken: string;
+  userId: string;
+}
+
+/** PairSubjectService.execute() 결과 */
+export interface PairSubjectResult {
+  session: SessionAggregate;
+  event: SessionPairedEvent;
+}
+
+export class PairSubjectService {
+  private readonly repo: SessionRepository;
+  private recordedEvents: SessionPairedEvent[] = [];
+
+  constructor(repo?: SessionRepository) {
+    this.repo = repo ?? new SessionRepository();
+  }
+
+  /**
+   * 피실험자 페어링 한 번의 시도를 실행함.
+   *
+   * @throws AppError 400 — userId 형식 부정합 또는 status 전이 불가
+   * @throws AppError 401 — 토큰 만료
+   * @throws AppError 404 — 토큰 없음
+   */
+  async execute(input: PairSubjectInput): Promise<PairSubjectResult> {
+    // 1. userId 형식 검증 (기존 pairDeviceProcess L88-90 정합)
+    if (!Types.ObjectId.isValid(input.userId)) {
+      throw new AppError('유효하지 않은 사용자 ID 형식입니다', 400);
+    }
+
+    // 2. 토큰으로 직접 조회 (기존 Session.findOne({pairingToken}) 어댑터)
+    const aggregate = await this.repo.findByPairingToken(input.pairingToken);
+    if (!aggregate) {
+      throw new AppError(
+        '존재하지 않거나 유효하지 않은 토큰입니다',
+        404
+      );
+    }
+
+    // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제
+    try {
+      aggregate.pair(input.userId);
+    } catch (err) {
+      if (err instanceof InvalidStatusTransitionError) {
+        // 만료 시 EXPIRED 영속화 + 401 throw (기존 pairing.service.ts L101-105 정합)
+        if (aggregate.isExpired()) {
+          aggregate.expire();
+          await this.repo.save(aggregate);
+          throw new AppError(
+            '페어링 토큰이 만료되었습니다. 다시 시도해주세요.',
+            401
+          );
+        }
+        // 그 외 전이 불가 (이미 PAIRED 등) → 400 (기존 L108-112 정합)
+        throw new AppError(
+          `현재 세션 상태(${aggregate.status})에서는 페어링할 수 없습니다.`,
+          400
+        );
+      }
+      throw err;
+    }
+
+    // 4. 영속화
+    await this.repo.save(aggregate);
+
+    // 5. 도메인 이벤트 메모리 기록 (LD-12 listener 통합은 후속 controller 통합 PR로 분리함)
+    const event: SessionPairedEvent = {
+      type: 'SessionPaired',
+      sessionId: aggregate.id,
+      userId: input.userId,
+      occurredAt: new Date().toISOString(),
+      groupId: aggregate.groupId,
+      subjectIndex: aggregate.subjectIndex,
+      mode: aggregate.mode,
+    };
+    this.recordedEvents.push(event);
+
+    return { session: aggregate, event };
+  }
+
+  /** 기록된 도메인 이벤트 목록을 반환하고 내부 버퍼를 비움 — 테스트 검증용 */
+  drainRecordedEvents(): ReadonlyArray<SessionPairedEvent> {
+    const events = [...this.recordedEvents];
+    this.recordedEvents = [];
+    return events;
+  }
+}

--- a/src/05-features/sessions/services/pair-subject.service.ts
+++ b/src/05-features/sessions/services/pair-subject.service.ts
@@ -64,10 +64,7 @@ export class PairSubjectService {
     // 2. 토큰으로 직접 조회 (기존 Session.findOne({pairingToken}) 어댑터)
     const aggregate = await this.repo.findByPairingToken(input.pairingToken);
     if (!aggregate) {
-      throw new AppError(
-        '존재하지 않거나 유효하지 않은 토큰입니다',
-        404
-      );
+      throw new AppError('존재하지 않거나 유효하지 않은 토큰입니다', 404);
     }
 
     // 3. 도메인 메서드 호출 — 만료/전이 invariant 강제

--- a/src/06-entities/sessions/domain/errors.ts
+++ b/src/06-entities/sessions/domain/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * errors.ts — 세션 도메인 전용 에러 클래스 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건 (순수 도메인 layer).
+ * 응용 서비스(PairSubjectService)가 본 에러를 잡아 AppError로 매핑함.
+ */
+
+import type { SessionStatus } from '../types/session.types';
+
+/**
+ * InvariantViolationError — 단일 Session 도큐먼트 차원의 불변식이 깨졌을 때 발생함.
+ *
+ * 예시: SessionAggregate.create() 호출 시 pairingToken === '' 또는 subjectIndex < 1.
+ * 그룹 단위 invariant(같은 groupId의 subjectIndex unique)는 본 에러 책임 외 — Mongoose 인덱스가 enforce함.
+ */
+export class InvariantViolationError extends Error {
+  public readonly name = 'InvariantViolationError';
+
+  constructor(reason: string) {
+    super(`Session aggregate invariant violated: ${reason}`);
+    Object.setPrototypeOf(this, InvariantViolationError.prototype);
+  }
+}
+
+/**
+ * InvalidStatusTransitionError — 허용되지 않은 상태 전이를 시도했을 때 발생함.
+ *
+ * 예시: COMPLETED에서 markMeasuring() 호출 / 만료된 CREATED에서 PAIRED 전이 시도.
+ * 응용 서비스가 본 에러를 잡아 만료 시 AppError 401, 그 외 전이 불가 시 AppError 400으로 매핑함.
+ */
+export class InvalidStatusTransitionError extends Error {
+  public readonly name = 'InvalidStatusTransitionError';
+  public readonly from: SessionStatus;
+  public readonly to: SessionStatus;
+
+  constructor(from: SessionStatus, to: SessionStatus) {
+    super(`Invalid status transition: ${from} -> ${to}`);
+    this.from = from;
+    this.to = to;
+    Object.setPrototypeOf(this, InvalidStatusTransitionError.prototype);
+  }
+}

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -11,6 +11,9 @@ import {
   InvalidStatusTransitionError,
 } from './errors';
 
+/** ADR-007 정합 — wall clock 의존 제거, 결정성 보장 */
+const TEST_NOW = new Date('2026-05-13T10:00:00.000Z');
+
 describe('SessionAggregate', () => {
   const baseParams = (
     override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
@@ -21,7 +24,7 @@ describe('SessionAggregate', () => {
     pairingToken: 'TOK001',
     operatorId: 'operator-1',
     mode: 'SEQUENTIAL' as const,
-    expiresAt: new Date(Date.now() + 60_000), // 1분 뒤 만료
+    expiresAt: new Date(TEST_NOW.getTime() + 60_000), // TEST_NOW 기준 1분 뒤 만료
     ...override,
   });
 
@@ -56,26 +59,23 @@ describe('SessionAggregate', () => {
   });
 
   describe('pair()', () => {
-    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩', () => {
+    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩 + pairedAt = now (참조 동등성)', () => {
       const aggregate = SessionAggregate.create(baseParams());
       const userId = 'user-bob';
-      const before = Date.now();
-      aggregate.pair(userId);
-      const after = Date.now();
+      const now = TEST_NOW;
+      aggregate.pair(userId, now);
 
       expect(aggregate.status).toBe('PAIRED');
       expect(aggregate.userId).toBe(userId);
-      expect(aggregate.pairedAt).not.toBeNull();
-      const pairedTime = aggregate.pairedAt!.getTime();
-      expect(pairedTime).toBeGreaterThanOrEqual(before);
-      expect(pairedTime).toBeLessThanOrEqual(after);
+      // ADR-007 정합 — _pairedAt이 주입된 now와 동일 객체 (참조 동등성)
+      expect(aggregate.pairedAt).toBe(now);
     });
 
-    test('5. 실패 — isExpired() === true → InvalidStatusTransitionError', () => {
-      const aggregate = SessionAggregate.create(
-        baseParams({ expiresAt: new Date(Date.now() - 1000) }) // 이미 만료됨
-      );
-      expect(() => aggregate.pair('user-bob')).toThrow(
+    test('5. 실패 — isExpired(now) === true → InvalidStatusTransitionError', () => {
+      const expiresAt = new Date('2026-05-13T10:00:00.000Z');
+      const now = new Date(expiresAt.getTime() + 1000); // 1초 후 (만료됨)
+      const aggregate = SessionAggregate.create(baseParams({ expiresAt }));
+      expect(() => aggregate.pair('user-bob', now)).toThrow(
         InvalidStatusTransitionError
       );
       // 상태는 그대로 CREATED (만료 처리는 별도 expire() 호출 책임)
@@ -84,8 +84,9 @@ describe('SessionAggregate', () => {
 
     test('6. 실패 — status === PAIRED에서 재호출 → InvalidStatusTransitionError', () => {
       const aggregate = SessionAggregate.create(baseParams());
-      aggregate.pair('user-bob');
-      expect(() => aggregate.pair('user-charlie')).toThrow(
+      const now = TEST_NOW;
+      aggregate.pair('user-bob', now);
+      expect(() => aggregate.pair('user-charlie', now)).toThrow(
         InvalidStatusTransitionError
       );
       // userId는 첫 페어링 그대로 유지됨
@@ -104,9 +105,26 @@ describe('SessionAggregate', () => {
 
     test('8. cancel() happy — PAIRED에서 CANCELLED 전이', () => {
       const aggregate = SessionAggregate.create(baseParams());
-      aggregate.pair('user-bob');
+      const now = TEST_NOW;
+      aggregate.pair('user-bob', now);
       aggregate.cancel('ManualEarly');
       expect(aggregate.status).toBe('CANCELLED');
+    });
+
+    test('9. isExpired(now) — boundary 비교 (ADR-007 정합)', () => {
+      const expiresAt = new Date('2026-05-13T10:00:00.000Z');
+      const aggregate = SessionAggregate.create(baseParams({ expiresAt }));
+
+      // boundary 직전 — 미만료
+      const beforeBoundary = new Date(expiresAt.getTime() - 1);
+      expect(aggregate.isExpired(beforeBoundary)).toBe(false);
+
+      // boundary 정확 — expiresAt === now 시점은 미만료 (strict less than)
+      expect(aggregate.isExpired(expiresAt)).toBe(false);
+
+      // boundary 직후 — 만료
+      const afterBoundary = new Date(expiresAt.getTime() + 1);
+      expect(aggregate.isExpired(afterBoundary)).toBe(true);
     });
   });
 });

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -1,0 +1,110 @@
+/**
+ * session.aggregate.test.ts — SessionAggregate 단위 테스트
+ *
+ * Mongoose / Redis / mongodb-memory-server 의존 0건 — 순수 도메인 단위 테스트.
+ * DOMAIN-MODEL-NOTES §3.1 정합 / PLAN rev.3 §6.2 시나리오 8건.
+ */
+
+import { SessionAggregate } from './session.aggregate';
+import {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './errors';
+
+describe('SessionAggregate', () => {
+  const baseParams = (override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}) => ({
+    id: 'session-id-1',
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: 'operator-1',
+    mode: 'SEQUENTIAL' as const,
+    expiresAt: new Date(Date.now() + 60_000), // 1분 뒤 만료
+    ...override,
+  });
+
+  describe('create()', () => {
+    test('1. happy path — SEQUENTIAL 모드 + 유효 인자 → 상태 CREATED', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      expect(aggregate.status).toBe('CREATED');
+      expect(aggregate.id).toBe('session-id-1');
+      expect(aggregate.groupId).toBe('A1B2C3D4');
+      expect(aggregate.subjectIndex).toBe(1);
+      expect(aggregate.pairingToken).toBe('TOK001');
+      expect(aggregate.operatorId).toBe('operator-1');
+      expect(aggregate.mode).toBe('SEQUENTIAL');
+      expect(aggregate.userId).toBeNull();
+      expect(aggregate.pairedAt).toBeNull();
+    });
+
+    test('2. invariant 위반 — empty pairingToken → InvariantViolationError', () => {
+      expect(() =>
+        SessionAggregate.create(baseParams({ pairingToken: '' }))
+      ).toThrow(InvariantViolationError);
+    });
+
+    test('3. invariant 위반 — subjectIndex < 1 → InvariantViolationError', () => {
+      expect(() =>
+        SessionAggregate.create(baseParams({ subjectIndex: 0 }))
+      ).toThrow(InvariantViolationError);
+      expect(() =>
+        SessionAggregate.create(baseParams({ subjectIndex: -1 }))
+      ).toThrow(InvariantViolationError);
+    });
+  });
+
+  describe('pair()', () => {
+    test('4. happy path — CREATED + 미만료 → PAIRED + userId 바인딩', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      const userId = 'user-bob';
+      const before = Date.now();
+      aggregate.pair(userId);
+      const after = Date.now();
+
+      expect(aggregate.status).toBe('PAIRED');
+      expect(aggregate.userId).toBe(userId);
+      expect(aggregate.pairedAt).not.toBeNull();
+      const pairedTime = aggregate.pairedAt!.getTime();
+      expect(pairedTime).toBeGreaterThanOrEqual(before);
+      expect(pairedTime).toBeLessThanOrEqual(after);
+    });
+
+    test('5. 실패 — isExpired() === true → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(
+        baseParams({ expiresAt: new Date(Date.now() - 1000) }) // 이미 만료됨
+      );
+      expect(() => aggregate.pair('user-bob')).toThrow(
+        InvalidStatusTransitionError
+      );
+      // 상태는 그대로 CREATED (만료 처리는 별도 expire() 호출 책임)
+      expect(aggregate.status).toBe('CREATED');
+    });
+
+    test('6. 실패 — status === PAIRED에서 재호출 → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      aggregate.pair('user-bob');
+      expect(() => aggregate.pair('user-charlie')).toThrow(
+        InvalidStatusTransitionError
+      );
+      // userId는 첫 페어링 그대로 유지됨
+      expect(aggregate.userId).toBe('user-bob');
+    });
+  });
+
+  describe('markMeasuring() & cancel()', () => {
+    test('7. markMeasuring() 실패 — CREATED에서 호출 → InvalidStatusTransitionError', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      expect(() => aggregate.markMeasuring()).toThrow(
+        InvalidStatusTransitionError
+      );
+      expect(aggregate.status).toBe('CREATED');
+    });
+
+    test('8. cancel() happy — PAIRED에서 CANCELLED 전이', () => {
+      const aggregate = SessionAggregate.create(baseParams());
+      aggregate.pair('user-bob');
+      aggregate.cancel('ManualEarly');
+      expect(aggregate.status).toBe('CANCELLED');
+    });
+  });
+});

--- a/src/06-entities/sessions/domain/session.aggregate.test.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.test.ts
@@ -12,7 +12,9 @@ import {
 } from './errors';
 
 describe('SessionAggregate', () => {
-  const baseParams = (override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}) => ({
+  const baseParams = (
+    override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+  ) => ({
     id: 'session-id-1',
     groupId: 'A1B2C3D4',
     subjectIndex: 1,

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -90,9 +90,7 @@ export class SessionAggregate {
   }
 
   /** DB 도큐먼트 → 통합체 변환 — Repository 내부에서만 호출함 */
-  static fromDocument(
-    doc: SessionAggregateDocumentFields
-  ): SessionAggregate {
+  static fromDocument(doc: SessionAggregateDocumentFields): SessionAggregate {
     return new SessionAggregate(
       doc._id,
       doc.groupId,

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -108,10 +108,16 @@ export class SessionAggregate {
   /**
    * 피실험자를 세션에 연결함 — CREATED → PAIRED 전이.
    *
+   * 호출자는 `now` Date를 1회 관찰하여 본 메서드 + `isExpired` + event timestamp에
+   * 동일 Date를 전달함. ADR-007 정합 — race condition 차단을 위해 한 호출 단위 내
+   * 시간 결정성 유지함.
+   *
+   * @param userId 페어링할 피실험자 ID
+   * @param now 호출자가 1회 관찰한 현재 시각
    * @throws InvalidStatusTransitionError 만료(isExpired) 또는 status !== 'CREATED'
    */
-  pair(userId: string): void {
-    if (this.isExpired()) {
+  pair(userId: string, now: Date): void {
+    if (this.isExpired(now)) {
       throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
     }
     if (this._status !== 'CREATED') {
@@ -119,7 +125,7 @@ export class SessionAggregate {
     }
     this._status = 'PAIRED';
     this._userId = userId;
-    this._pairedAt = new Date();
+    this._pairedAt = now;
   }
 
   /** PAIRED → MEASURING — 본 단계 시연 외, 메서드 골조만 */
@@ -158,9 +164,14 @@ export class SessionAggregate {
     this._status = 'CANCELLED';
   }
 
-  /** 만료 여부 — expiresAt < 현재 시각 */
-  isExpired(): boolean {
-    return this._expiresAt.getTime() < Date.now();
+  /**
+   * 만료 여부 — expiresAt < 주입된 시각.
+   *
+   * 호출자가 1회 관찰한 `now`를 전달함. SA가 자체 `Date.now()`를 호출하지 않으므로
+   * 호출 단위 내 시간 결정성 보장 + test에서 FixedClock 주입으로 분기 결정적 재현 가능.
+   */
+  isExpired(now: Date): boolean {
+    return this._expiresAt.getTime() < now.getTime();
   }
 
   // ===== getters =====

--- a/src/06-entities/sessions/domain/session.aggregate.ts
+++ b/src/06-entities/sessions/domain/session.aggregate.ts
@@ -1,0 +1,199 @@
+/**
+ * session.aggregate.ts — Session 도메인 통합체 (Aggregate Root)
+ *
+ * Vernon 2011 "Effective Aggregate Design Part I" 단일 aggregate 패턴 적용함.
+ * 단일 Session 도큐먼트 = 1 aggregate = 1 트랜잭션 단위.
+ * 그룹 invariant(groupId+subjectIndex unique)는 본 클래스 책임 외 — Mongoose 인덱스가 enforce함.
+ *
+ * Pure TypeScript — Mongoose / Redis / Socket.io 의존 0건 (depcruise R-DDD-1/R-DDD-2 통과).
+ * SessionStatus는 ../types/session.types에서 import (schema 직접 import 0건).
+ */
+
+import type { SessionStatus, ExperimentMode } from '../types/session.types';
+import {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './errors';
+
+/** SessionAggregate.create() factory 입력 인자 7종 */
+export interface SessionAggregateCreateParams {
+  id: string;
+  groupId: string;
+  subjectIndex: number;
+  pairingToken: string;
+  operatorId: string | null;
+  mode: ExperimentMode;
+  expiresAt: Date;
+}
+
+/** SessionAggregate.fromDocument() 입력 인자 (DB 도큐먼트 → 통합체 변환용) */
+export interface SessionAggregateDocumentFields {
+  _id: string;
+  groupId: string;
+  subjectIndex: number;
+  pairingToken: string;
+  creatorId: string | null;
+  experimentMode: ExperimentMode;
+  expiresAt: Date;
+  status: SessionStatus;
+  userId: string | null;
+  pairedAt: Date | null;
+}
+
+/** 세션 취소 사유 (Session schema stopReason 정합) */
+export type CancelReason =
+  | 'Natural'
+  | 'ManualEarly'
+  | 'HeadsetLost'
+  | 'ProcessError';
+
+export class SessionAggregate {
+  private constructor(
+    private readonly _id: string,
+    private readonly _groupId: string,
+    private readonly _subjectIndex: number,
+    private readonly _pairingToken: string,
+    private readonly _operatorId: string | null,
+    private readonly _mode: ExperimentMode,
+    private readonly _expiresAt: Date,
+    private _status: SessionStatus,
+    private _userId: string | null,
+    private _pairedAt: Date | null
+  ) {}
+
+  /**
+   * Static factory — invariant 검증 강제함.
+   *
+   * @throws InvariantViolationError pairingToken === '' 또는 subjectIndex < 1
+   */
+  static create(params: SessionAggregateCreateParams): SessionAggregate {
+    if (!params.pairingToken) {
+      throw new InvariantViolationError('empty pairing token');
+    }
+    if (params.subjectIndex < 1) {
+      throw new InvariantViolationError(
+        `subjectIndex must be >= 1, got ${params.subjectIndex}`
+      );
+    }
+    return new SessionAggregate(
+      params.id,
+      params.groupId,
+      params.subjectIndex,
+      params.pairingToken,
+      params.operatorId,
+      params.mode,
+      params.expiresAt,
+      'CREATED',
+      null,
+      null
+    );
+  }
+
+  /** DB 도큐먼트 → 통합체 변환 — Repository 내부에서만 호출함 */
+  static fromDocument(
+    doc: SessionAggregateDocumentFields
+  ): SessionAggregate {
+    return new SessionAggregate(
+      doc._id,
+      doc.groupId,
+      doc.subjectIndex,
+      doc.pairingToken,
+      doc.creatorId,
+      doc.experimentMode,
+      doc.expiresAt,
+      doc.status,
+      doc.userId,
+      doc.pairedAt
+    );
+  }
+
+  /**
+   * 피실험자를 세션에 연결함 — CREATED → PAIRED 전이.
+   *
+   * @throws InvalidStatusTransitionError 만료(isExpired) 또는 status !== 'CREATED'
+   */
+  pair(userId: string): void {
+    if (this.isExpired()) {
+      throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
+    }
+    if (this._status !== 'CREATED') {
+      throw new InvalidStatusTransitionError(this._status, 'PAIRED');
+    }
+    this._status = 'PAIRED';
+    this._userId = userId;
+    this._pairedAt = new Date();
+  }
+
+  /** PAIRED → MEASURING — 본 단계 시연 외, 메서드 골조만 */
+  markMeasuring(): void {
+    if (this._status !== 'PAIRED') {
+      throw new InvalidStatusTransitionError(this._status, 'MEASURING');
+    }
+    this._status = 'MEASURING';
+  }
+
+  /** MEASURING → COMPLETED — 본 단계 시연 외 */
+  complete(): void {
+    if (this._status !== 'MEASURING') {
+      throw new InvalidStatusTransitionError(this._status, 'COMPLETED');
+    }
+    this._status = 'COMPLETED';
+  }
+
+  /** CREATED → EXPIRED — 만료 처리, PairSubjectService 흐름에서 호출함 */
+  expire(): void {
+    if (this._status !== 'CREATED') {
+      throw new InvalidStatusTransitionError(this._status, 'EXPIRED');
+    }
+    this._status = 'EXPIRED';
+  }
+
+  /** * → CANCELLED — 종착 상태에서는 호출 불가 */
+  cancel(_reason: CancelReason): void {
+    if (
+      this._status === 'COMPLETED' ||
+      this._status === 'EXPIRED' ||
+      this._status === 'CANCELLED'
+    ) {
+      throw new InvalidStatusTransitionError(this._status, 'CANCELLED');
+    }
+    this._status = 'CANCELLED';
+  }
+
+  /** 만료 여부 — expiresAt < 현재 시각 */
+  isExpired(): boolean {
+    return this._expiresAt.getTime() < Date.now();
+  }
+
+  // ===== getters =====
+  get id(): string {
+    return this._id;
+  }
+  get groupId(): string {
+    return this._groupId;
+  }
+  get subjectIndex(): number {
+    return this._subjectIndex;
+  }
+  get pairingToken(): string {
+    return this._pairingToken;
+  }
+  get operatorId(): string | null {
+    return this._operatorId;
+  }
+  get mode(): ExperimentMode {
+    return this._mode;
+  }
+  get expiresAt(): Date {
+    return this._expiresAt;
+  }
+  get status(): SessionStatus {
+    return this._status;
+  }
+  get userId(): string | null {
+    return this._userId;
+  }
+  get pairedAt(): Date | null {
+    return this._pairedAt;
+  }
+}

--- a/src/06-entities/sessions/domain/session.event.ts
+++ b/src/06-entities/sessions/domain/session.event.ts
@@ -1,0 +1,24 @@
+/**
+ * session.event.ts — 세션 도메인 이벤트 타입 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건 (순수 타입).
+ * 발행 큐(pullDomainEvents) 미채택 (Phase E TS-Q17 A3 LOCK 정합).
+ * 응용 서비스가 메모리 내 배열에 기록 + 기존 pairingListeners 호출 (LD-12 대안 D 통합)함.
+ */
+
+import type { ExperimentMode } from '../types/session.types';
+
+/**
+ * SessionPairedEvent — 피실험자가 세션에 합류했다는 사실을 표현함.
+ *
+ * 기존 pairing.service.ts pairingListeners callback({groupId, subjectIndex})와 정보 통합됨.
+ */
+export type SessionPairedEvent = {
+  type: 'SessionPaired';
+  sessionId: string;
+  userId: string; // 페어링한 Subject의 userId (subjectId 명칭 미사용 — mind-signal 컨벤션)
+  occurredAt: string; // ISO 8601
+  groupId: string;
+  subjectIndex: number;
+  mode: ExperimentMode;
+};

--- a/src/06-entities/sessions/index.ts
+++ b/src/06-entities/sessions/index.ts
@@ -1,1 +1,13 @@
 export * from './model/session.schema';
+export { SessionAggregate } from './domain/session.aggregate';
+export type {
+  SessionAggregateCreateParams,
+  SessionAggregateDocumentFields,
+  CancelReason,
+} from './domain/session.aggregate';
+export type { SessionPairedEvent } from './domain/session.event';
+export {
+  InvariantViolationError,
+  InvalidStatusTransitionError,
+} from './domain/errors';
+export { SessionRepository } from './repository/session.repository';

--- a/src/06-entities/sessions/model/session.schema.ts
+++ b/src/06-entities/sessions/model/session.schema.ts
@@ -1,5 +1,9 @@
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 import { ExperimentMode } from '@07-shared/constants/experiment';
+import type { SessionStatus } from '../types/session.types';
+
+// SessionStatus re-export — 외부에서 schema 또는 types 양쪽 경로로 import 호환함
+export type { SessionStatus };
 
 /** * 1. 문서 필드 타입 정의
  * ERD의 필드와 Note A 규칙을 반영함
@@ -10,19 +14,13 @@ export interface Session {
   pairingToken: string; // 고유 페어링 토큰임
   userId: Types.ObjectId | null; // 페어링 성공 시 바인딩되는 사용자 ID임
   creatorId: Types.ObjectId | null; // 세션 생성자(운영자) ID임
-  status:
-    | 'CREATED'
-    | 'PAIRED'
-    | 'MEASURING'
-    | 'COMPLETED'
-    | 'EXPIRED'
-    | 'CANCELLED';
+  status: SessionStatus; // 세션 상태 6종 (session.types.ts 단일 정의 참조)
   pairedAt: Date | null; // 페어링 완료 시점
   expiresAt: Date; // 토큰 만료 시점
   measuredAt: Date | null; // 측정 시작 시점
   stopReason: 'Natural' | 'ManualEarly' | 'HeadsetLost' | 'ProcessError' | null;
   measuredDurationSeconds: number | null;
-  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI)
+  experimentMode: ExperimentMode; // 실험 모드 (DUAL | SEQUENTIAL | BTI | DUAL_2PC)
 }
 
 /** 2. 인스턴스 메서드 타입 정의 */

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -54,7 +54,10 @@ const makeAggregate = (
  * Mongoose SessionDoc-like 객체 생성기 — Repository.toAggregate가 읽는 필드만 포함함.
  * 실제 Mongoose Hydration 결과를 mock 형태로 모사함.
  */
-const makeDocLike = (aggregate: SessionAggregate, statusOverride?: SessionAggregate['status']) => ({
+const makeDocLike = (
+  aggregate: SessionAggregate,
+  statusOverride?: SessionAggregate['status']
+) => ({
   _id: aggregate.id,
   groupId: aggregate.groupId,
   subjectIndex: aggregate.subjectIndex,

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -1,0 +1,158 @@
+/**
+ * session.repository.test.ts — SessionRepository 통합 테스트
+ *
+ * Mongoose Model의 정적 메서드(findById / findOne / findByIdAndUpdate / create)를 Jest mock으로 격리함.
+ * 기존 mind-signal-backend 통합 테스트 패턴 정합 (CI는 외부 MongoDB 미연결 — mock 의무, .claude/rules/test-modification.md).
+ *
+ * 진짜 MongoDB 통합 검증은 후속 인프라 정비 후 별도 PR (mongodb-memory-server 도입 시).
+ * PLAN rev.3 §6.3 "mongodb-memory-server" 명시는 본 프로젝트 실제 패턴과 불일치로 mock 기반 통합 테스트로 채택함.
+ *
+ * 시나리오 3건:
+ *   1. saveNew → findById 왕복 (같은 상태 복원)
+ *   2. saveNew → findByPairingToken 왕복 (토큰 인덱스 정합)
+ *   3. save 상태 전이 영속 (CREATED → PAIRED)
+ */
+
+import { Types } from 'mongoose';
+import { Session } from '../model/session.schema';
+import { SessionAggregate } from '../domain/session.aggregate';
+import { SessionRepository } from './session.repository';
+
+jest.mock('../model/session.schema', () => ({
+  Session: {
+    findById: jest.fn(),
+    findOne: jest.fn(),
+    findByIdAndUpdate: jest.fn(),
+    create: jest.fn(),
+  },
+}));
+
+type AnyMock = jest.Mock;
+const SessionMock = Session as unknown as {
+  findById: AnyMock;
+  findOne: AnyMock;
+  findByIdAndUpdate: AnyMock;
+  create: AnyMock;
+};
+
+const makeAggregate = (
+  override: Partial<Parameters<typeof SessionAggregate.create>[0]> = {}
+) => {
+  return SessionAggregate.create({
+    id: new Types.ObjectId().toString(),
+    groupId: 'A1B2C3D4',
+    subjectIndex: 1,
+    pairingToken: 'TOK001',
+    operatorId: new Types.ObjectId().toString(),
+    mode: 'SEQUENTIAL',
+    expiresAt: new Date(Date.now() + 60_000),
+    ...override,
+  });
+};
+
+/**
+ * Mongoose SessionDoc-like 객체 생성기 — Repository.toAggregate가 읽는 필드만 포함함.
+ * 실제 Mongoose Hydration 결과를 mock 형태로 모사함.
+ */
+const makeDocLike = (aggregate: SessionAggregate, statusOverride?: SessionAggregate['status']) => ({
+  _id: aggregate.id,
+  groupId: aggregate.groupId,
+  subjectIndex: aggregate.subjectIndex,
+  pairingToken: aggregate.pairingToken,
+  creatorId: aggregate.operatorId,
+  userId: aggregate.userId,
+  experimentMode: aggregate.mode,
+  expiresAt: aggregate.expiresAt,
+  status: statusOverride ?? aggregate.status,
+  pairedAt: aggregate.pairedAt,
+});
+
+describe('SessionRepository (통합 — Mongoose Model mock)', () => {
+  let repo: SessionRepository;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    repo = new SessionRepository();
+  });
+
+  test('1. saveNew → findById 왕복 (같은 상태 복원)', async () => {
+    const original = makeAggregate();
+    const docLike = makeDocLike(original);
+
+    SessionMock.create.mockResolvedValueOnce(docLike);
+    SessionMock.findById.mockResolvedValueOnce(docLike);
+
+    await repo.saveNew(original);
+    const restored = await repo.findById(original.id);
+
+    expect(SessionMock.create).toHaveBeenCalledTimes(1);
+    expect(SessionMock.findById).toHaveBeenCalledWith(original.id);
+    expect(restored).not.toBeNull();
+    expect(restored!.id).toBe(original.id);
+    expect(restored!.groupId).toBe('A1B2C3D4');
+    expect(restored!.subjectIndex).toBe(1);
+    expect(restored!.pairingToken).toBe('TOK001');
+    expect(restored!.mode).toBe('SEQUENTIAL');
+    expect(restored!.status).toBe('CREATED');
+  });
+
+  test('2. saveNew → findByPairingToken 왕복 (토큰 인덱스 정합)', async () => {
+    const original = makeAggregate({ pairingToken: 'TOK999' });
+    const docLike = makeDocLike(original);
+
+    SessionMock.create.mockResolvedValueOnce(docLike);
+    SessionMock.findOne.mockResolvedValueOnce(docLike);
+
+    await repo.saveNew(original);
+    const restored = await repo.findByPairingToken('TOK999');
+
+    expect(SessionMock.findOne).toHaveBeenCalledWith({
+      pairingToken: 'TOK999',
+    });
+    expect(restored).not.toBeNull();
+    expect(restored!.pairingToken).toBe('TOK999');
+    expect(restored!.id).toBe(original.id);
+  });
+
+  test('3. save 상태 전이 영속 (CREATED → PAIRED)', async () => {
+    const aggregate = makeAggregate();
+    const userId = new Types.ObjectId().toString();
+    aggregate.pair(userId);
+
+    SessionMock.findByIdAndUpdate.mockResolvedValueOnce(makeDocLike(aggregate));
+    await repo.save(aggregate);
+
+    expect(SessionMock.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    const callArgs = SessionMock.findByIdAndUpdate.mock.calls[0];
+    expect(callArgs[0]).toBe(aggregate.id);
+
+    const fields = callArgs[1] as {
+      status: string;
+      userId: Types.ObjectId | null;
+      pairedAt: Date | null;
+      groupId: string;
+      subjectIndex: number;
+    };
+    expect(fields.status).toBe('PAIRED');
+    expect(fields.userId).not.toBeNull();
+    expect(String(fields.userId)).toBe(userId);
+    expect(fields.pairedAt).not.toBeNull();
+    expect(fields.groupId).toBe('A1B2C3D4');
+    expect(fields.subjectIndex).toBe(1);
+
+    const options = callArgs[2] as { upsert: boolean };
+    expect(options.upsert).toBe(false);
+  });
+
+  test('보조: findById 미존재 시 null 반환', async () => {
+    SessionMock.findById.mockResolvedValueOnce(null);
+    const result = await repo.findById('does-not-exist');
+    expect(result).toBeNull();
+  });
+
+  test('보조: findByPairingToken 미존재 시 null 반환', async () => {
+    SessionMock.findOne.mockResolvedValueOnce(null);
+    const result = await repo.findByPairingToken('NOPE000');
+    expect(result).toBeNull();
+  });
+});

--- a/src/06-entities/sessions/repository/session.repository.test.ts
+++ b/src/06-entities/sessions/repository/session.repository.test.ts
@@ -120,7 +120,7 @@ describe('SessionRepository (통합 — Mongoose Model mock)', () => {
   test('3. save 상태 전이 영속 (CREATED → PAIRED)', async () => {
     const aggregate = makeAggregate();
     const userId = new Types.ObjectId().toString();
-    aggregate.pair(userId);
+    aggregate.pair(userId, new Date()); // ADR-007 정합 — Date 인자 전달
 
     SessionMock.findByIdAndUpdate.mockResolvedValueOnce(makeDocLike(aggregate));
     await repo.save(aggregate);

--- a/src/06-entities/sessions/repository/session.repository.ts
+++ b/src/06-entities/sessions/repository/session.repository.ts
@@ -1,0 +1,103 @@
+/**
+ * session.repository.ts — SessionAggregate ↔ Mongoose Session 도큐먼트 양방향 변환 어댑터
+ *
+ * Stemmler 2019 "How to Design & Persist Aggregates" strangler 패턴 적용함.
+ * 도메인 통합체(순수 클래스)와 Mongoose Model(DB 영속) 사이의 단일 변환 지점.
+ * 응용 서비스(PairSubjectService)가 본 Repository만 호출 — Mongoose Model 직접 사용 0건.
+ *
+ * FSD 06-entities 레이어 — domain/ 으로의 import 0건 (역방향 import 금지, depcruise 통과).
+ */
+
+import { Types } from 'mongoose';
+import { Session } from '../model/session.schema';
+import { SessionAggregate } from '../domain/session.aggregate';
+import type { SessionDoc, SessionStatus } from '../model/session.schema';
+
+export class SessionRepository {
+  /**
+   * ID로 세션 조회 후 SessionAggregate로 변환함.
+   * @returns 미존재 시 null 반환
+   */
+  async findById(id: string): Promise<SessionAggregate | null> {
+    const doc = await Session.findById(id);
+    return doc ? this.toAggregate(doc) : null;
+  }
+
+  /**
+   * 페어링 토큰으로 세션 조회 후 SessionAggregate로 변환함.
+   * 기존 pairing.service.ts::pairDeviceProcess L94의 Session.findOne({pairingToken}) 어댑터.
+   * @returns 미존재 시 null 반환
+   */
+  async findByPairingToken(token: string): Promise<SessionAggregate | null> {
+    const doc = await Session.findOne({ pairingToken: token });
+    return doc ? this.toAggregate(doc) : null;
+  }
+
+  /**
+   * 통합체의 현재 상태를 DB에 영속화함 (기존 도큐먼트 갱신).
+   * 신규 도큐먼트 생성은 saveNew()를 사용함.
+   */
+  async save(aggregate: SessionAggregate): Promise<void> {
+    const fields = this.toDocumentFields(aggregate);
+    await Session.findByIdAndUpdate(aggregate.id, fields, { upsert: false });
+  }
+
+  /** 새 통합체를 DB에 신규 저장함 (Session.create()). */
+  async saveNew(aggregate: SessionAggregate): Promise<void> {
+    const fields = this.toDocumentFields(aggregate);
+    await Session.create({
+      _id: this.toObjectId(aggregate.id),
+      pairingToken: aggregate.pairingToken,
+      expiresAt: aggregate.expiresAt,
+      experimentMode: aggregate.mode,
+      ...fields,
+    });
+  }
+
+  /** Mongoose 도큐먼트 → SessionAggregate 변환함 */
+  private toAggregate(doc: SessionDoc): SessionAggregate {
+    return SessionAggregate.fromDocument({
+      _id: String(doc._id),
+      groupId: doc.groupId,
+      subjectIndex: doc.subjectIndex ?? 0,
+      pairingToken: doc.pairingToken,
+      creatorId: doc.creatorId ? String(doc.creatorId) : null,
+      experimentMode: doc.experimentMode,
+      expiresAt: doc.expiresAt,
+      status: doc.status,
+      userId: doc.userId ? String(doc.userId) : null,
+      pairedAt: doc.pairedAt,
+    });
+  }
+
+  /**
+   * SessionAggregate → Mongoose 도큐먼트 갱신 필드로 변환함.
+   * save()는 본 결과만, saveNew()는 본 결과 + pairingToken/expiresAt/experimentMode 추가.
+   */
+  private toDocumentFields(
+    aggregate: SessionAggregate
+  ): {
+    groupId: string;
+    subjectIndex: number;
+    creatorId: Types.ObjectId | null;
+    status: SessionStatus;
+    userId: Types.ObjectId | null;
+    pairedAt: Date | null;
+  } {
+    return {
+      groupId: aggregate.groupId,
+      subjectIndex: aggregate.subjectIndex,
+      creatorId: aggregate.operatorId
+        ? this.toObjectId(aggregate.operatorId)
+        : null,
+      status: aggregate.status,
+      userId: aggregate.userId ? this.toObjectId(aggregate.userId) : null,
+      pairedAt: aggregate.pairedAt,
+    };
+  }
+
+  /** 문자열 ID → Mongoose ObjectId 변환함 (유효성 검증은 호출 측 책임) */
+  private toObjectId(id: string): Types.ObjectId {
+    return new Types.ObjectId(id);
+  }
+}

--- a/src/06-entities/sessions/repository/session.repository.ts
+++ b/src/06-entities/sessions/repository/session.repository.ts
@@ -74,9 +74,7 @@ export class SessionRepository {
    * SessionAggregate → Mongoose 도큐먼트 갱신 필드로 변환함.
    * save()는 본 결과만, saveNew()는 본 결과 + pairingToken/expiresAt/experimentMode 추가.
    */
-  private toDocumentFields(
-    aggregate: SessionAggregate
-  ): {
+  private toDocumentFields(aggregate: SessionAggregate): {
     groupId: string;
     subjectIndex: number;
     creatorId: Types.ObjectId | null;

--- a/src/06-entities/sessions/types/session.types.ts
+++ b/src/06-entities/sessions/types/session.types.ts
@@ -1,0 +1,24 @@
+/**
+ * session.types.ts — 세션 도메인 순수 타입 정의
+ *
+ * Mongoose / Redis / Socket.io 등 외부 의존 0건.
+ * depcruise R-DDD-1 차단 대상 외 (정규식이 .schema$만 매칭하므로 .types$ 통과).
+ *
+ * - SessionStatus: 본 파일에서 단일 정의
+ * - ExperimentMode: @07-shared/constants/experiment를 single source로 유지 (re-export만 제공, drift 회피)
+ */
+
+/** 세션 상태 6종 union — CLAUDE.md §7 박제 + session.schema.ts 정합 */
+export type SessionStatus =
+  | 'CREATED'
+  | 'PAIRED'
+  | 'MEASURING'
+  | 'COMPLETED'
+  | 'EXPIRED'
+  | 'CANCELLED';
+
+/**
+ * ExperimentMode re-export — @07-shared/constants/experiment가 single source.
+ * 본 파일은 도메인 layer가 동일 타입을 import할 때 경로 정합을 제공함.
+ */
+export type { ExperimentMode } from '@07-shared/constants/experiment';

--- a/src/07-shared/clock/clock.test.ts
+++ b/src/07-shared/clock/clock.test.ts
@@ -1,0 +1,33 @@
+import { SystemClock, FixedClock } from './index';
+
+describe('SystemClock', () => {
+  it('호출 결과가 valid Date 인스턴스임', () => {
+    const result = new SystemClock().now();
+    expect(result).toBeInstanceOf(Date);
+    expect(Number.isNaN(result.getTime())).toBe(false);
+  });
+
+  it('호출 직전 wall clock 이상의 시각 반환함', () => {
+    const before = Date.now();
+    const result = new SystemClock().now();
+    expect(result.getTime()).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe('FixedClock', () => {
+  const fixed = new Date('2026-05-13T10:00:00.000Z');
+
+  it('생성자 주입 Date를 N회 호출에서 동일 객체로 반환함 (참조 동등성)', () => {
+    const clock = new FixedClock(fixed);
+    expect(clock.now()).toBe(fixed);
+    expect(clock.now()).toBe(fixed);
+    expect(clock.now().toISOString()).toBe('2026-05-13T10:00:00.000Z');
+  });
+
+  it('invalid Date 주입 시 TypeError throw — plan-review I-5', () => {
+    expect(() => new FixedClock(new Date('invalid'))).toThrow(TypeError);
+    expect(() => new FixedClock(new Date('invalid'))).toThrow(
+      'FixedClock requires a valid Date'
+    );
+  });
+});

--- a/src/07-shared/clock/clock.ts
+++ b/src/07-shared/clock/clock.ts
@@ -1,0 +1,13 @@
+/**
+ * Clock port — 시간 관찰 seam.
+ *
+ * SessionAggregate.isExpired/pair 및 PairSubjectService.execute가 직접 `Date.now()` /
+ * `new Date()`를 호출하지 않고 본 인터페이스를 통해 시간을 관찰함. 한 `execute()` 호출
+ * 단위 내 시간 결정성 보장 + test에서 FixedClock 주입을 통해 시간 분기 결정적 재현 가능.
+ *
+ * 출처: ADR-007 (Phase H deep-module-poc A-7 race 후속, 이슈 #52).
+ */
+export interface Clock {
+  /** 현재 시각을 Date 객체로 반환함 */
+  now(): Date;
+}

--- a/src/07-shared/clock/fixed-clock.ts
+++ b/src/07-shared/clock/fixed-clock.ts
@@ -1,0 +1,20 @@
+import type { Clock } from './clock';
+
+/**
+ * Test adapter — 생성자 주입 Date를 호출마다 동일하게 반환함.
+ *
+ * Scenario 4 (Clock seam race) + Scenario 5 (single observed now) 결정성 보장에 필수임.
+ * invalid Date 주입 시 TypeError를 즉시 throw하여 호출부 `toISOString()` 시점 RangeError
+ * 전파를 차단함.
+ */
+export class FixedClock implements Clock {
+  constructor(private readonly fixed: Date) {
+    if (Number.isNaN(fixed.getTime())) {
+      throw new TypeError('FixedClock requires a valid Date');
+    }
+  }
+
+  now(): Date {
+    return this.fixed;
+  }
+}

--- a/src/07-shared/clock/index.ts
+++ b/src/07-shared/clock/index.ts
@@ -1,0 +1,3 @@
+export type { Clock } from './clock';
+export { SystemClock } from './system-clock';
+export { FixedClock } from './fixed-clock';

--- a/src/07-shared/clock/system-clock.ts
+++ b/src/07-shared/clock/system-clock.ts
@@ -1,0 +1,13 @@
+import type { Clock } from './clock';
+
+/**
+ * Production adapter — wall clock 기반 Date 반환함.
+ *
+ * 호출 시점 시각을 `new Date()`로 반환하므로 호출 간 시각이 진행함.
+ * test에서는 본 클래스를 사용하지 말 것 — FixedClock으로 결정성 확보 필요.
+ */
+export class SystemClock implements Clock {
+  now(): Date {
+    return new Date();
+  }
+}

--- a/src/07-shared/config/config.ts
+++ b/src/07-shared/config/config.ts
@@ -26,6 +26,19 @@ if (nodeEnv !== 'test') {
   });
 }
 
+// 3.5 강제 페어링 admin allowlist — env ADMIN_EMAILS 콤마 구분, lowercase normalize함
+const adminEmails: readonly string[] = (process.env.ADMIN_EMAILS ?? '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+// production 환경에서 ADMIN_EMAILS 누락 시 startup fail-fast 처리함
+if (nodeEnv === 'production' && adminEmails.length === 0) {
+  throw new Error(
+    'Critical Error: ADMIN_EMAILS 환경변수가 production에서 설정되지 않았습니다.'
+  );
+}
+
 // 4. 설정 객체 내보내기
 export const config = {
   env: nodeEnv,
@@ -66,6 +79,8 @@ export const config = {
   kakaoClientId: process.env.KAKAO_CLIENT_ID,
   kakaoClientSecret: process.env.KAKAO_CLIENT_SECRET,
   kakaoRedirectUri: process.env.KAKAO_REDIRECT_URI,
+  // K phase 강제 페어링 admin allowlist — lowercase normalize됨
+  adminEmails,
   // Phase 16 DUAL_2PC 타임스탬프 정렬 설정 (optional — 기본값 사용 가능)
   dualPc: {
     // plan-review M-4: 편도 50ms + NTP skew 50ms = 200ms 기본값


### PR DESCRIPTION
## Summary

dev → main release. 누적된 7개 PR + 본 세션의 jest worker hang fix를 main으로 통합.

## 포함 변경

| 영역 | PR | 핵심 |
|------|----|------|
| Phase G | #51 | session aggregate DDD/BDD/TDD pilot + ADR-006 |
| PR-A7 | #53 | Clock port at session seam + ADR-007 |
| Phase H | #54 | deep-module-poc PAAR + Phase H artifacts gitignore |
| Phase J | #55 | dual-2pc audit logging hotfix |
| Phase K | #56 | admin force-pair endpoint (5/26 시연 백엔드) |
| 본 세션 | #57 | jest worker hang fix (unref dual-2pc flush interval) + lockfile sync |

## Test plan

- [ ] CI green (format/typecheck/depcruise/lint/test/build)
- [ ] 머지 후 Heroku/Vercel production 배포 정상 동작 확인
- [ ] `npm test -- --detectOpenHandles` 로컬 재현 — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 관리자용 강제 세션 페어링 기능 추가
  * 세션 도메인 모델 및 애그리게이트 구현
  * 시간 추상화 레이어(Clock 포트) 추가로 테스트 결정성 개선

* **Tests**
  * 세션 페어링 동작 BDD 시나리오 추가 (386줄)
  * 서비스/저장소/미들웨어 단위 테스트 추가
  * 엔드포인트 통합 테스트 추가

* **Documentation**
  * 아키텍처 의사결정 기록 (ADR-006/007)
  * DDD 디스커버리 및 TDD 기술 문서 추가
  * 세션 애그리게이트 6Q 패턴 문서화

* **Chores**
  * 의존성 규칙 및 환경 설정 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->