### PR TITLE
docs(reports): redact leaked db credential in pr-a1 regression logs

### DIFF
--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/A-broken-fail.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/A-broken-fail.log
@@ -13,7 +13,7 @@
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
   console.log
-    연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+    연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 

--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/A-restored-pass.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/A-restored-pass.log
@@ -13,7 +13,7 @@
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
   console.log
-    연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+    연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 

--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/B-broken-fail.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/B-broken-fail.log
@@ -13,7 +13,7 @@
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
   console.log
-    연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+    연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 

--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/B-restored-pass.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/B-restored-pass.log
@@ -13,7 +13,7 @@
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
   console.log
-    연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+    연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 

--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/C-broken-fail.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/C-broken-fail.log
@@ -50,7 +50,7 @@ PASS src/05-features/sessions/api/session.routes.psa1.test.ts (11.079 s)
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
     console.log
-      연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+      연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 

--- a/docs/reports/paar-2026-05-15-pr-a1-regression-sim/C-restored-pass.log
+++ b/docs/reports/paar-2026-05-15-pr-a1-regression-sim/C-restored-pass.log
@@ -17,7 +17,7 @@ PASS src/05-features/sessions/api/session.routes.psa1.test.ts (10.584 s)
       at Object.<anonymous> (src/07-shared/config/config.ts:96:9)
 
     console.log
-      연결된 DB URI: mongodb+srv://gwonseok02:lHY1VGqLcfcGbZy1@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
+      연결된 DB URI: mongodb+srv://gwonseok02:***@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority&appName=todo-dev-cluster
 
       at Object.<anonymous> (src/07-shared/config/config.ts:97:9)
 


### PR DESCRIPTION
## 요약

PR-A1 회귀 시뮬레이션 로그 6개(`docs/reports/paar-2026-05-15-pr-a1-regression-sim/{A,B,C}-{broken-fail,restored-pass}.log`)에 DB 자격증명이 평문 박제돼 있어 redact (`gwonseok02:***@`). 당시 config.ts가 local/test에서 URI를 평문 로깅 → 회귀 stdout이 그대로 박제된 것. 현재 PR-A8에서 config.ts 환경무관 마스킹(`5b2a8a6`/`42121dd`)으로 향후는 차단됨.

⚠️ **이 redact는 비파괴 hygiene일 뿐, 노출값 무효화가 아님.** 푸시된 히스토리·PR #59/#60 페이지에 잔존하므로 **Atlas 비밀번호 회전이 유일한 실효 조치**(별도 운영자 작업, 진행 예정).

## 변경

- 6 `.log` 파일: `mongodb+srv://gwonseok02:<password>@` → `mongodb+srv://gwonseok02:***@` (패턴 치환, 코드 변경 0)

## Test plan

- [x] 잔여 평문 자격증명 0 (`git grep` 검증)
- [x] 코드/테스트 변경 0 (docs-only) → 회귀 없음