### PR TITLE
fix(database): add mongodb srv dns resolver fallback switch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,15 @@ NODE_ENV=development
 # ======================
 MONGODB_URI=mongodb+srv://<DB_USER>:<DB_PASSWORD>@todo-dev-cluster.1eldpej.mongodb.net/mind_signal_dev?retryWrites=true&w=majority
 
+# ADR-011 MongoDB SRV DNS resolver fallback (Phase 18.1 D-0 hotspot 함정 우회용)
+# Node c-ares가 OS Wi-Fi 어댑터 DNS 변경을 후속 감지 안 함. 5/26 D-0 시연 환경 같은
+# 학교 Wi-Fi에서 OS DNS를 8.8.8.8로 변경해도 mongoose SRV 조회 ECONNREFUSED 발생함.
+# 본 env 활성화 시 mongoose.connect 직전에 dns.setServers 호출함.
+# 비어 있으면 OS 기본 DNS 경로 유지 (production 권장). production 사용 시 사내 DNS
+# 차단망 가정 안 됨 확인 의무 (8.8.8.8 outbound 차단 시 BE 기동 실패).
+# 예: MONGODB_SRV_DNS_SERVERS=8.8.8.8,1.1.1.1
+MONGODB_SRV_DNS_SERVERS=
+
 # ======================
 # Authentication (JWT)
 # ======================

--- a/docs/architecture/decisions/ADR-011-mongodb-srv-dns-resolver-fallback.md
+++ b/docs/architecture/decisions/ADR-011-mongodb-srv-dns-resolver-fallback.md
@@ -1,0 +1,94 @@
+# ADR-011: MongoDB Atlas SRV DNS resolver fallback policy
+
+---
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Applies to**: BE
+- **Deciders**: @KWONSEOK02
+- **Related**: ADR-010 (Stage 1 alignment authority + proxy ingress ns), Phase 18.1 D-0 시연 함정 4 박제 (옵시디언 [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]])
+
+## Context
+
+2026-05-26 Phase 18.1 D-0 시연 setup 진행 도중 BE 기동 시 MongoDB Atlas SRV 조회가 다음 시퀀스로 실패함.
+
+1. `querySrv ECONNREFUSED _mongodb._tcp.todo-dev-cluster.1eldpej.mongodb.net`
+2. Wi-Fi 어댑터 DNS를 8.8.8.8/8.8.4.4로 변경 + `ipconfig /flushdns` 실행
+3. `Resolve-DnsName -Type SRV` 시스템 기본 DNS 응답 정상, `nslookup -type=SRV ... 8.8.8.8` 명시 응답 정상
+4. BE 재기동 결과 여전히 ECONNREFUSED
+
+근본 원인은 Node DNS API의 두 경로 분기임. `dns.lookup()`은 OS facility (getaddrinfo) 계열이고, `dns.resolveSrv()`와 `dns.resolveTxt()`는 DNS protocol 질의를 직접 수행함. MongoDB Node driver는 `mongodb+srv` 파싱 시 내부에서 `dns.promises.resolveSrv()`와 `resolveTxt()`를 호출함. 즉 `nslookup` 또는 `Resolve-DnsName`이 정상이어도 driver의 SRV path가 다른 resolver 상태를 타면 실패함. 이 구조는 Windows 특정 문제 아니고 Node 공통임.
+
+5/26 D-0 임시 patch로 `src/01-app/app.ts` L1-L3에 `import dns from 'dns'` + `dns.setServers(['8.8.8.8','8.8.4.4'])` 2줄을 unconditional로 박았으나, codex 5.5 자문(thread `019e64ac`)에서 production 환경 (사내 DNS 또는 split-horizon DNS 또는 audit 정책 또는 8.8.8.8 outbound 차단망)에서 BE 기동 실패 risk 발견됨. 따라서 unconditional patch는 부적절하며 conditional override가 필요함.
+
+본 ADR은 5/26 D-0 함정 영구 해소 + production 안전성 + Atlas best practice (SRV 권장) 정합 트레이드오프를 박제함.
+
+## Decision
+
+`config.mongoSrvDnsServers`를 신설하고 환경변수 `MONGODB_SRV_DNS_SERVERS` (콤마 구분 IP 리스트)로 제어함. 본 env가 비어 있으면 OS 기본 DNS 경로를 유지하고, 값이 있으면 `mongoose.connect` 직전에 `dns.setServers(...)`를 호출함. production default off 정합으로 사내 DNS 정책 우회 risk를 제거함.
+
+구현 위치:
+
+- `src/07-shared/config/config.ts` — `mongoSrvDnsServers: string[] | undefined` 신설, env 파싱 + trim + 빈 항목 제외함
+- `src/01-app/app.ts` `connectDB()` — `mongoose.connect()` 직전에 conditional `dns.setServers` 호출 + 로그 박제함
+- `.env.example` — Database 섹션 직후 신규 키 + 주석 박제함
+
+## Alternatives considered
+
+### Option A: unconditional `dns.setServers(['8.8.8.8','8.8.4.4'])` 영구 박제
+
+`src/01-app/app.ts` L1-L3에 박힌 5/26 D-0 임시 patch를 그대로 유지함.
+
+**Trade-offs**: 5/26 D-0 setup 함정 4 즉시 해소함. dev 재현성 강함.
+
+**Rejected because**: production 환경에서 사내 DNS 또는 Private DNS 또는 split-horizon DNS 또는 audit 정책 우회 risk 발생함. 회사 또는 학교 또는 병원 또는 공공망에서 8.8.8.8 outbound 차단 시 오히려 BE 기동 실패 원인이 됨. Codex 5.5 자문 thread `019e64ac` 권장 거부 사유 정합.
+
+### Option B-3: MongoDB Atlas standard URI 전환
+
+`mongodb+srv://...` 대신 `mongodb://host1,host2,host3/...`로 변경하여 SRV resolver path 자체 우회함.
+
+**Trade-offs**: DNS resolver 분기 함정 자체 차단함. Google DNS 차단망 시나리오도 무관해짐.
+
+**Rejected because**: Atlas best practice (SRV 권장) 위반함. Atlas cluster topology 변경 (replicaSet rotation, version 업그레이드, hostname 갱신) 시 URI 재배포 의무로 operational burden 큼. SRV는 seed list host를 자동 포함하고 server rotation을 client 재설정 없이 지원하므로 가능하면 SRV를 쓰라는 MongoDB 공식 권장과 충돌함.
+
+### Option C: conditional patch (env flag로 활성화) — **채택**
+
+위 Decision 절 정합.
+
+**Trade-offs**: env flag 1개 추가, 운영자 setup 가이드 1줄 복잡화함 (.env.example 주석 박제로 완화). production default off로 사내 DNS 정책 정합함. dev 환경에서만 활성화하여 5/26 D-0 함정 즉시 해소함. Atlas SRV best practice 유지함.
+
+**Accepted because**: A의 production risk 회피 + B-3의 operational burden 회피 + dev 시점 함정 해소를 모두 충족하는 sweet spot임. Codex 5.5 자문 thread `019e64ac` 권장 정합.
+
+## Consequences
+
+### Positive
+
+- 5/26 D-0 시연 함정 4 (BE Node c-ares가 OS DNS 미적용) 영구 해소함. 운영자가 `.env.local`에 `MONGODB_SRV_DNS_SERVERS=8.8.8.8,1.1.1.1` 박제 시 자동 적용함.
+- production 환경 default off로 사내 DNS 정책 정합 유지함. 회사 또는 학교 또는 병원 또는 공공망에서 8.8.8.8 outbound 차단 시 BE 기동 정상 (OS 기본 DNS 사용함).
+- ADR-011로 미래 재논쟁 방지함. 같은 함정이 재발 시 본 ADR이 단일 진실원임.
+- Atlas SRV best practice 유지함. cluster topology 변경 시 운영자 부담 0건.
+
+### Negative
+
+- env flag 1개 추가로 .env.example 변경 + 운영자 setup 가이드 1줄 복잡화함 (주석 박제로 완화함).
+- production 환경에서 env flag를 잘못 활성화 시 (8.8.8.8 차단망) BE 기동 실패 가능. default off + .env.example 주석 경고 박제로 완화함.
+- Google DNS 차단망 cascade 함정 발생 시 (예: 사내 DNS만 허용 + 8.8.8.8 차단) 본 ADR로 해결 안 됨. 별도 fallback runbook (B-3 standard URI 사용 + ADR-XXX-superseding-fallback 신설) 박제 의무 미래 트리거임.
+
+## Implementation Notes
+
+회귀 시뮬레이션 ABC (PR description 박제 정합):
+
+- A 정상: `MONGODB_SRV_DNS_SERVERS=` 비어 있음 + SRV 정상망 → OS 기본 DNS 사용 + 기존 SRV 연결 성공함.
+- B 5/26 D-0 fix 경로: `MONGODB_SRV_DNS_SERVERS=8.8.8.8,1.1.1.1` 활성화 + 함정 재현망 → `dns.getServers()`가 지정 resolver로 바뀌고 mongoose.connect 성공함.
+- C 무력화 시뮬레이션: `src/01-app/app.ts` `connectDB()` 안의 `if (config.mongoSrvDnsServers...)` 분기 1줄을 false로 강제 (예: `if (false)`) → 5/26 D-0 함정 재현 가능 박제 (regression detection 검증).
+
+5/26 D-0 임시 patch (`src/01-app/app.ts` L1-L3 unconditional `dns.setServers`)는 본 ADR 채택 시 revert 의무. 본 PR (`fix/database-srv-dns-fallback`)이 dev 머지 시 자동 적용됨.
+
+## References
+
+- Codex 5.5 자문 thread `019e64ac` (model: gpt-5.5, sandbox: read-only, 2026-05-26) — 본 결정의 1차 근거
+- Node DNS 공식 문서: https://nodejs.org/api/dns.html — `dns.lookup` vs `dns.resolve*` 구현 차이 + `setServers()` 영향 범위
+- MongoDB 공식 문서: https://www.mongodb.com/docs/manual/reference/connection-string/ — SRV vs standard URI 비교 + "가능하면 SRV 사용" 권장
+- 옵시디언 [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 4 — 함정 진단 과정
+- 옵시디언 [[2026-05-26-hotspot-pivot-next-session-handoff]] 트랙 2 — 본 ADR 트리거
+- `scripts/migrate-2026-05-16-pr-a8-subject-index.ts` L110 선례 — 일회성 마이그레이션 public DNS pin (본 ADR scope 외, 별도 정책)

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -53,6 +53,18 @@ async function connectDB() {
       );
     }
 
+    // ADR-011 MongoDB SRV DNS resolver fallback — env 활성화 시에만 적용함
+    // Node c-ares가 OS Wi-Fi 어댑터 DNS 변경을 후속 감지 안 함. mongoose는 mongodb+srv 파싱
+    // 시 내부에서 dns.promises.resolveSrv를 호출하여 c-ares 경로 사용. OS DNS 변경해도
+    // 미적용 함정 우회용 conditional override. production 환경 default off 유지함.
+    if (config.mongoSrvDnsServers && config.mongoSrvDnsServers.length > 0) {
+      const dns = await import('dns');
+      dns.setServers(config.mongoSrvDnsServers);
+      console.log(
+        `MongoDB SRV DNS resolver override 적용: ${config.mongoSrvDnsServers.join(', ')}`
+      );
+    }
+
     // Mongoose v8 기준 기본값을 사용하며 타임아웃만 명시한다.
     await mongoose.connect(mongoURI, {
       // 10초 내 연결 실패 시 에러

--- a/src/07-shared/config/config.ts
+++ b/src/07-shared/config/config.ts
@@ -81,6 +81,13 @@ export const config = {
   kakaoRedirectUri: process.env.KAKAO_REDIRECT_URI,
   // K phase 강제 페어링 admin allowlist — lowercase normalize됨
   adminEmails,
+  // ADR-011 MongoDB SRV DNS resolver fallback — env 비어 있으면 OS 기본 경로 유지
+  // 값 있으면 mongoose.connect 직전에 dns.setServers 호출함 (Node c-ares OS DNS 미감지 우회용)
+  mongoSrvDnsServers: process.env.MONGODB_SRV_DNS_SERVERS
+    ? process.env.MONGODB_SRV_DNS_SERVERS.split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : undefined,
   // Phase 16 DUAL_2PC 타임스탬프 정렬 설정 (optional — 기본값 사용 가능)
   dualPc: {
     // plan-review M-4: 편도 50ms + NTP skew 50ms = 200ms 기본값


### PR DESCRIPTION
## Summary

- `MONGODB_SRV_DNS_SERVERS` env (콤마 구분 IP 리스트) 활성화 시 `mongoose.connect` 직전에 `dns.setServers(...)` 호출
- production default off로 사내 DNS 정책 정합 유지 (8.8.8.8 outbound 차단망 risk 회피)
- 5/26 D-0 시연 setup 도중 노출된 Node c-ares가 OS Wi-Fi 어댑터 DNS 변경 미감지 함정 영구 해소
- ADR-011 Accepted (Codex 5.5 자문 thread `019e64ac` 권장 정합)

## Why

2026-05-26 Phase 18.1 D-0 시연 setup 도중 BE 기동 시 MongoDB Atlas SRV `querySrv ECONNREFUSED _mongodb._tcp.todo-dev-cluster.1eldpej.mongodb.net` 발생. OS Wi-Fi 어댑터 DNS를 8.8.8.8/8.8.4.4로 변경하고 `ipconfig /flushdns` 실행해도 BE 재기동 결과 ECONNREFUSED 지속. `Resolve-DnsName -Type SRV` 시스템 기본 DNS 응답 정상, `nslookup -type=SRV ... 8.8.8.8` 명시 응답 정상.

근본 원인: Node DNS API 두 경로 분기. `dns.lookup()`은 OS getaddrinfo, `dns.resolveSrv()`는 DNS protocol 직접. MongoDB Node driver는 `mongodb+srv` 파싱 시 내부에서 `dns.promises.resolveSrv()` 사용. 즉 OS DNS 변경 후속 감지 안 함. Windows 특정 문제 아니고 Node 공통.

5/26 D-0 임시 patch (`src/01-app/app.ts` L1-L3에 unconditional `dns.setServers`)는 production 환경에서 사내 DNS 또는 split-horizon DNS 또는 audit 정책 우회 risk 발견됨 (Codex 5.5 자문). 본 PR은 conditional override 채택.

## Changes

- `src/07-shared/config/config.ts` — `mongoSrvDnsServers: string[] | undefined` 신설, env 파싱 + trim + 빈 항목 제외
- `src/01-app/app.ts` `connectDB()` — `mongoose.connect()` 직전에 conditional `dns.setServers` 호출 + 로그 박제
- `.env.example` — Database 섹션 직후 신규 키 + 주석 박제 (production 활성화 경고 포함)
- `docs/architecture/decisions/ADR-011-mongodb-srv-dns-resolver-fallback.md` 신설 (Status: Accepted, Codex 5.5 자문 정합)

## 회귀 시뮬레이션 ABC

| 시나리오 | 입력 | 기대 동작 | 검증 |
|---|---|---|---|
| A 정상 | `MONGODB_SRV_DNS_SERVERS=` 비어 있음 + SRV 정상망 | OS 기본 DNS 사용 + 기존 SRV 연결 성공 | 본 PR `npm run verify` 36 suites/333 tests GREEN |
| B 5/26 D-0 fix 경로 | env=`8.8.8.8,1.1.1.1` 활성화 + 함정 재현망 | `dns.getServers()`가 지정 resolver로 바뀌고 mongoose.connect 성공 | 운영자 `.env.local` 박제 + 실기기 재현 의무 |
| C 무력화 시뮬레이션 | `connectDB()`의 `if (config.mongoSrvDnsServers...)` 분기 1줄을 `if (false)`로 강제 | 5/26 D-0 함정 4 재현 가능 박제 | regression detection 검증 의무 |

## Test plan

- [x] `npm run verify` GREEN (format:check + typecheck + depcruise + lint + test 36/333 + build)
- [ ] 운영자 `.env.local`에 `MONGODB_SRV_DNS_SERVERS=8.8.8.8,1.1.1.1` 박제 후 BE 기동 확인 (5/26 D-0 재현망 시점)
- [ ] env 비어 있는 production 환경에서 OS 기본 DNS 사용 확인 (heroku/main 시점)
- [ ] C 무력화 시뮬레이션 재현 확인 (regression detection 의무)

## Codex 5.5 자문 (thread `019e64ac`)

Q1 옵션 A (unconditional) robust? — **❌**, production 사내 DNS 또는 split-horizon DNS 또는 8.8.8.8 차단망 risk
Q2 옵션 B-3 (standard URI) native? — **△**, Atlas best practice는 SRV. standard URI는 cluster topology 변경 시 재배포 의무
Q3 근본 원인 — Node DNS API 두 경로 분기 (dns.lookup OS facility vs dns.resolveSrv DNS protocol 직접). Windows 특정 문제 아님
Q4 ADR 가치 — 있음. 단 A를 Accepted ADR로 박제 반대. "MongoDB SRV DNS resolver fallback policy" 명명 권장
Q5 Phase 18 안 vs 별도 — 별도 hotfix 권장 (engine-proxy-sync 기능 외 BE bootstrap/infra reliability hotfix)

**Codex 권장 옵션 C 채택**: env flag conditional patch + ADR + B-3 fallback runbook 박제 (Google DNS 차단망 시나리오 대비, 별도 ADR-XXX-superseding-fallback 트리거 의무 미래)

## 5/26 D-0 임시 patch revert 의무

`src/01-app/app.ts` L1-L3에 박힌 unconditional `dns.setServers(['8.8.8.8','8.8.4.4'])` 2줄 patch는 본 PR (`fix/database-srv-dns-fallback`)이 dev 머지 시 자동 미적용됨 (본 PR은 dev base에서 분기, 5/26 임시 patch는 feat/18 working tree dirty에 stash됨). feat/18-engine-proxy-sync 브랜치에 본 fix를 cherry-pick 또는 rebase는 별도 결정.

## 관련

- 함정 박제: [[2026-05-26-phase-18.1-d-0-hotspot-pivot-postponed]] 핵심 발견 4
- 트랙 박제: [[2026-05-26-hotspot-pivot-next-session-handoff]] 트랙 2
- 선행 ADR: ADR-010 (Stage 1 alignment authority + proxy ingress ns)
- 선례: `scripts/migrate-2026-05-16-pr-a8-subject-index.ts` L110 (일회성 마이그레이션 public DNS pin, 별도 정책)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * MongoDB SRV 연결을 위한 커스텀 DNS 서버 설정 지원
  * `MONGODB_SRV_DNS_SERVERS` 환경 변수를 통해 DNS 리졸버 서버 구성 가능

* **문서**
  * MongoDB SRV DNS 리졸버 폴백 전략에 관한 아키텍처 결정 문서 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->