### PR TITLE
fix(socket): /proxy namespace MVP handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "jest": "^30.2.0",
         "open-cli": "^8.0.0",
         "prettier": "^3.7.4",
+        "socket.io-client": "^4.8.3",
         "ts-node-dev": "^2.0.0",
         "tsc-alias": "^1.8.16",
         "typescript": "^5.9.3"
@@ -4610,6 +4611,42 @@
         "node": ">=10.2.0"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
@@ -8945,6 +8982,22 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
@@ -10461,6 +10514,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "jest": "^30.2.0",
     "open-cli": "^8.0.0",
     "prettier": "^3.7.4",
+    "socket.io-client": "^4.8.3",
     "ts-node-dev": "^2.0.0",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.9.3"

--- a/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
+++ b/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
@@ -1,0 +1,176 @@
+/**
+ * socket.repro-proxy-namespace.test.ts
+ *
+ * Phase 18.1 MVP handler 회귀 박제 테스트함.
+ * mind-signal-proxy의 be-forwarder가 BE `/proxy` namespace에 ENGINE_SECRET
+ * 핸드셰이크로 connect 시도하나 namespace handler 미등록으로 `Invalid namespace`
+ * retry 누적되던 blocker (HANDOFF 1-6절) 해소 검증함.
+ *
+ * Scenario A (happy) - 정확한 engineSecret으로 connect 성공함
+ * Scenario B (regression sentinel) - 잘못된 secret 거부함
+ * Scenario C (regression sentinel) - secret 미전송 거부함
+ * Scenario D - proxy:sample 이벤트는 not_implemented ack 반환함 (MVP stub)
+ * Scenario E - 기본 namespace join-room 동작 영향 없음
+ */
+
+import http from 'http';
+import { AddressInfo } from 'net';
+import { io as ioClient, Socket as ClientSocket } from 'socket.io-client';
+
+jest.mock('@07-shared/config/config', () => ({
+  config: {
+    dataEngine: {
+      secretKey: 'test-engine-secret-abc123',
+    },
+  },
+}));
+
+import { SocketService } from './socket';
+
+jest.setTimeout(10_000);
+
+describe('SocketService /proxy namespace MVP handler (Phase 18.1)', () => {
+  let httpServer: http.Server;
+  let serverUrl: string;
+
+  beforeAll((done) => {
+    httpServer = http.createServer();
+    SocketService.init(httpServer);
+    httpServer.listen(0, '127.0.0.1', () => {
+      const { port } = httpServer.address() as AddressInfo;
+      serverUrl = `http://127.0.0.1:${port}`;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    SocketService.getIO().close(() => {
+      httpServer.close(() => done());
+    });
+  });
+
+  it('Scenario A: 정확한 engineSecret으로 /proxy namespace connect 성공함', (done) => {
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      auth: { engineSecret: 'test-engine-secret-abc123' },
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      expect(client.connected).toBe(true);
+      client.disconnect();
+      done();
+    });
+
+    client.once('connect_error', (err: Error) => {
+      done(new Error(`unexpected connect_error: ${err.message}`));
+    });
+  });
+
+  it('Scenario B: 잘못된 engineSecret으로 connect_error invalid_engine_secret 반환함', (done) => {
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      auth: { engineSecret: 'wrong-secret' },
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      client.disconnect();
+      done(new Error('unexpected connect succeeded with wrong secret'));
+    });
+
+    client.once('connect_error', (err: Error) => {
+      expect(err.message).toBe('invalid_engine_secret');
+      done();
+    });
+  });
+
+  it('Scenario C: engineSecret 미전송 시 connect_error invalid_engine_secret 반환함', (done) => {
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      client.disconnect();
+      done(new Error('unexpected connect succeeded without secret'));
+    });
+
+    client.once('connect_error', (err: Error) => {
+      expect(err.message).toBe('invalid_engine_secret');
+      done();
+    });
+  });
+
+  it('Scenario D: proxy:sample 이벤트는 not_implemented ack 반환함 (MVP stub)', (done) => {
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      auth: { engineSecret: 'test-engine-secret-abc123' },
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      client
+        .timeout(2_000)
+        .emit(
+          'proxy:sample',
+          { dummy: 'envelope' },
+          (
+            err: Error | null,
+            ack: { ok: boolean; retryable?: boolean; error?: string }
+          ) => {
+            try {
+              expect(err).toBeNull();
+              expect(ack).toEqual({
+                ok: false,
+                retryable: false,
+                error: 'not_implemented',
+              });
+              client.disconnect();
+              done();
+            } catch (e) {
+              client.disconnect();
+              done(e as Error);
+            }
+          }
+        );
+    });
+
+    client.once('connect_error', (err: Error) => {
+      done(new Error(`unexpected connect_error: ${err.message}`));
+    });
+  });
+
+  it('Scenario E: 기본 namespace의 join-room은 변경 없이 정상 동작함', (done) => {
+    const client: ClientSocket = ioClient(serverUrl, {
+      transports: ['websocket'],
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      client.emit(
+        'join-room',
+        'test-group-id',
+        (ack: { ok: boolean; groupId?: string; error?: string }) => {
+          try {
+            expect(ack).toEqual({ ok: true, groupId: 'test-group-id' });
+            client.disconnect();
+            done();
+          } catch (e) {
+            client.disconnect();
+            done(e as Error);
+          }
+        }
+      );
+    });
+
+    client.once('connect_error', (err: Error) => {
+      done(new Error(`unexpected connect_error: ${err.message}`));
+    });
+  });
+});

--- a/src/07-shared/lib/socket/socket.ts
+++ b/src/07-shared/lib/socket/socket.ts
@@ -1,5 +1,6 @@
 import { Server as HttpServer } from 'http';
 import { Server, Socket } from 'socket.io';
+import { config } from '@07-shared/config/config';
 
 /**
  * Socket.io 서버 관리 유틸리티
@@ -48,7 +49,66 @@ export class SocketService {
       });
     });
 
+    // Phase 18.1 MVP - mind-signal-proxy의 be-forwarder 핸드셰이크 수용 처리함
+    this._initProxyNamespace();
+
     return this.io;
+  }
+
+  /**
+   * /proxy namespace handler 등록함.
+   *
+   * mind-signal-proxy의 `be-forwarder`가 ENGINE_SECRET 핸드셰이크로 connect 시도함
+   * (`be-forwarder.ts` `auth: { engineSecret }`).
+   * 현재 MVP 단계는 auth 검증만 활성화하고 `proxy:sample` 이벤트는
+   * `{ok:false, retryable:false, error:'not_implemented'}` ack 반환함.
+   * 후속 Phase 18.2에서 envelope 검증/persist/dedup 로직 구현 예정.
+   *
+   * @throws Error('invalid_engine_secret') 핸드셰이크 secret 미일치 시 발생
+   */
+  private static _initProxyNamespace(): void {
+    const nsp = this.io.of('/proxy');
+
+    // auth 핸드셰이크 - engineSecret 일치 검증함
+    nsp.use((socket, next) => {
+      const handshakeSecret = socket.handshake.auth?.engineSecret;
+      if (typeof handshakeSecret !== 'string' || handshakeSecret.length === 0) {
+        next(new Error('invalid_engine_secret'));
+        return;
+      }
+      if (handshakeSecret !== config.dataEngine.secretKey) {
+        next(new Error('invalid_engine_secret'));
+        return;
+      }
+      next();
+    });
+
+    nsp.on('connection', (socket: Socket) => {
+      console.log(`[/proxy] connected: ${socket.id}`);
+
+      // proxy:sample 이벤트 - Phase 18.1 MVP는 persist 미구현 상태로 drop 반환함
+      socket.on(
+        'proxy:sample',
+        (
+          _envelope: unknown,
+          ack?: (response: {
+            ok: boolean;
+            retryable?: boolean;
+            error?: string;
+          }) => void
+        ) => {
+          ack?.({
+            ok: false,
+            retryable: false,
+            error: 'not_implemented',
+          });
+        }
+      );
+
+      socket.on('disconnect', () => {
+        console.log(`[/proxy] disconnected: ${socket.id}`);
+      });
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- mind-signal-proxy be-forwarder의 ENGINE_SECRET 핸드셰이크를 BE socket.io에서 수용
- `proxy:sample` 이벤트는 `{ok:false, retryable:false, error:'not_implemented'}` ack 반환 (MVP stub)
- envelope persist/dedup/aligner readiness는 Phase 18.2 후속 트랙

## 배경
HANDOFF.md 1-6절에 박제된 blocker: proxy → BE `/proxy` namespace 미구현으로 `Invalid namespace` 30초 간격 무한 재시도 (지수 backoff cap 30s, 누적 6.4시간+). 측정 단계 EEG forwarding 차단 상태.

## 변경 사항
- `src/07-shared/lib/socket/socket.ts:52-112` — `_initProxyNamespace()` 신규. `io.of('/proxy')` namespace + auth middleware (engineSecret 일치 검증) + connection handler + `proxy:sample` 이벤트 stub ack
- `src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts` — 신규 5 시나리오 회귀 박제 (A happy / B 잘못된 secret / C secret 미전송 / D ack stub / E 기본 namespace 무영향)
- `package.json` — `socket.io-client` devDep 추가

## verify 결과
- format:check / typecheck / depcruise / lint / test (38 suites / 345 tests) / build 전부 GREEN

## plan-review cross-review
- Claude feature-dev:code-reviewer: PROCEED, Critical 0, High 1 (Phase 18.2 백로그 = SocketService DI 전환 시 같이 해결)
- codex 5.5 thread `019e6db5-ddd0-77a1-96f2-7cde773714fd`: PROCEED, 8 lens 전부 PASS, timing attack은 내부망 환경에서 prod hardening 백로그

## 회귀 시뮬레이션 ABC 박제
| Sim | 무력화 | 예상 fail 테스트 | 예상 에러 fragment |
|---|---|---|---|
| A | socket.ts:53 `this._initProxyNamespace()` 주석 처리 | Scenario A | `unexpected connect_error: Invalid namespace` |
| B | socket.ts:73-84 auth middleware bypass | Scenario B/C | `unexpected connect succeeded with wrong secret` |
| C | socket.ts:100-104 ack `{ok:true}` 변경 | Scenario D | `Expected: {ok:false, retryable:false, error:'not_implemented'}, Received: {ok:true}` |

## Test plan
- [x] BE verify GREEN (38 suites / 345 tests / build)
- [x] Claude + codex 5.5 병렬 plan-review-deep 양 verdict PROCEED
- [ ] dev 머지 후 start-realdevice-dual-2pc.ps1 일괄 기동
- [ ] proxy stdout `Invalid namespace` 로그 30초 이상 정적 + `[/proxy] connected` 핸드셰이크 성공 로그 시각 확인 (HANDOFF C-7)

Co-authored-by: KWONSEOK02 <gwonseok02@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 프록시 네임스페이스 기능이 추가되었습니다. 엔진 시크릿 기반 인증 검증이 포함되어 있습니다.

* **Tests**
  * 프록시 네임스페이스 인증 및 이벤트 처리에 대한 회귀 테스트가 추가되었습니다.

* **Dependencies**
  * Socket.io 클라이언트 패키지가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KWONSEOK02/mind-signal-backend/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->