### PR TITLE
feat(socket): Phase 18.2 proxy:sample envelope persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "verify": "npm run format:check && npm run typecheck && npm run depcruise && npm run lint && npm run test && npm run build",
     "commitlint": "commitlint --from=HEAD~1 --to=HEAD --verbose",
     "migrate:pr-a8:dry-run": "ts-node -r tsconfig-paths/register ./scripts/migrate-2026-05-16-pr-a8-subject-index.ts --dry-run",
-    "migrate:pr-a8:apply": "ts-node -r tsconfig-paths/register ./scripts/migrate-2026-05-16-pr-a8-subject-index.ts --apply"
+    "migrate:pr-a8:apply": "ts-node -r tsconfig-paths/register ./scripts/migrate-2026-05-16-pr-a8-subject-index.ts --apply",
+    "e2e:synthetic": "ts-node -r tsconfig-paths/register ./scripts/dual2pc-synthetic-e2e.ts"
   },
   "description": "Mind Signal Project Backend",
   "dependencies": {

--- a/scripts/dual2pc-synthetic-e2e.ts
+++ b/scripts/dual2pc-synthetic-e2e.ts
@@ -1,0 +1,80 @@
+/* eslint-disable camelcase */
+/**
+ * dual2pc-synthetic-e2e.ts — DUAL_2PC 합성 E2E (레벨 2)
+ *
+ * 하드웨어/노트북 B 없이 1 PC에서 proxy:sample → BE publish → Redis subject:2
+ * broadcast 경로를 실증함. 가짜 DE_B가 합성 envelope을 송신하고 별도 구독자가
+ * 채널 broadcast를 카운트함.
+ *
+ * 전제: BE dev 기동(:5000) + npm run infra:up(Redis). CI 대상 아님.
+ * 실행: npm run e2e:synthetic
+ */
+
+import { io } from 'socket.io-client';
+import { createClient } from 'redis';
+import { config } from '@07-shared/config/config';
+
+const GROUP_ID = 'synthetic-grp';
+const SUBJECT_IDX = 2;
+const SAMPLE_COUNT = 5;
+const CHANNEL = `mind-signal:${GROUP_ID}:subject:${SUBJECT_IDX}`;
+
+async function main(): Promise<void> {
+  let received = 0;
+  const sub = createClient({ url: config.redis.url });
+  await sub.connect();
+  await sub.subscribe(CHANNEL, (msg: string) => {
+    const parsed = JSON.parse(msg);
+    if (parsed.type === 'brain_sync_all') received += 1;
+    console.log(`[recv] ${CHANNEL} type=${parsed.type} count=${received}`);
+  });
+
+  const socket = io(`http://localhost:${config.port}/proxy`, {
+    transports: ['websocket'],
+    auth: { engineSecret: config.dataEngine.secretKey },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', () => resolve());
+    socket.once('connect_error', reject);
+  });
+
+  for (let seq = 0; seq < SAMPLE_COUNT; seq += 1) {
+    const envelope = {
+      group_id: GROUP_ID,
+      subject_idx: SUBJECT_IDX,
+      de_ts_ns: String(Date.now() * 1_000_000),
+      proxy_ingress_ts_ns: String(Date.now() * 1_000_000),
+      seq,
+      payload: { delta: seq, theta: 0, alpha: 0, beta: 0, gamma: 0 },
+      sync_meta: {},
+    };
+    const ack: { ok: boolean; retryable?: boolean; error?: string } =
+      await socket.timeout(2_000).emitWithAck('proxy:sample', envelope);
+    console.log(`[send] seq=${seq} ack=${JSON.stringify(ack)}`);
+    // ack 거부 시 조기 종료함 - count 불일치보다 명확한 신호
+    if (!ack.ok) {
+      console.error(`FAIL: seq=${seq} ack 거부됨`, ack);
+      socket.disconnect();
+      await sub.quit();
+      process.exit(1);
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  socket.disconnect();
+  await sub.quit();
+
+  if (received === SAMPLE_COUNT) {
+    console.log(`PASS: ${received}/${SAMPLE_COUNT} broadcast on ${CHANNEL}`);
+    process.exit(0);
+  } else {
+    console.error(`FAIL: ${received}/${SAMPLE_COUNT} received`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/dual2pc-synthetic-e2e.ts
+++ b/scripts/dual2pc-synthetic-e2e.ts
@@ -14,7 +14,8 @@ import { io } from 'socket.io-client';
 import { createClient } from 'redis';
 import { config } from '@07-shared/config/config';
 
-const GROUP_ID = 'synthetic-grp';
+// 실행마다 고유 group id - 같은 Redis에 대한 반복/병렬 실행 간 채널 충돌 방지함
+const GROUP_ID = `synthetic-grp-${Date.now()}`;
 const SUBJECT_IDX = 2;
 const SAMPLE_COUNT = 5;
 const CHANNEL = `mind-signal:${GROUP_ID}:subject:${SUBJECT_IDX}`;
@@ -24,9 +25,14 @@ async function main(): Promise<void> {
   const sub = createClient({ url: config.redis.url });
   await sub.connect();
   await sub.subscribe(CHANNEL, (msg: string) => {
-    const parsed = JSON.parse(msg);
-    if (parsed.type === 'brain_sync_all') received += 1;
-    console.log(`[recv] ${CHANNEL} type=${parsed.type} count=${received}`);
+    try {
+      const parsed = JSON.parse(msg) as { type?: string };
+      if (parsed.type === 'brain_sync_all') received += 1;
+      console.log(`[recv] ${CHANNEL} type=${parsed.type} count=${received}`);
+    } catch (err) {
+      // 비정상 메시지 1건이 전체 스크립트를 죽이지 않도록 로깅 후 무시함
+      console.error(`[recv] invalid JSON on ${CHANNEL}:`, err);
+    }
   });
 
   const socket = io(`http://localhost:${config.port}/proxy`, {

--- a/src/07-shared/lib/socket/proxy-envelope.schema.ts
+++ b/src/07-shared/lib/socket/proxy-envelope.schema.ts
@@ -1,0 +1,28 @@
+/* eslint-disable camelcase */
+import { z } from 'zod';
+
+/**
+ * proxy be-forwarder가 `proxy:sample`로 보내는 envelope의 집중 검증 스키마.
+ *
+ * publish에 필요한 필드(group_id, subject_idx, payload)만 검증함.
+ * de_ts_ns/proxy_ingress_ts_ns/seq/sync_meta는 BE 미소비라 미검증함 (Zod가 strip).
+ * 계약 출처: mind-signal-proxy/src/types/envelope.ts
+ */
+const WavePowerSchema = z.object({
+  delta: z.number(),
+  theta: z.number(),
+  alpha: z.number(),
+  beta: z.number(),
+  gamma: z.number(),
+});
+
+export const ProxySampleSchema = z.object({
+  group_id: z.string().min(1),
+  // subject_idx는 1-based 계약임 (measurement.service.ts [1, 2] 루프 정합).
+  // proxy 원본은 z.number().int()로 더 느슨하나 BE는 0/음수를 의도적 fail-closed로
+  // invalid_frame 처리함.
+  subject_idx: z.number().int().min(1),
+  payload: WavePowerSchema,
+});
+
+export type ProxySample = z.infer<typeof ProxySampleSchema>;

--- a/src/07-shared/lib/socket/proxy-envelope.schema.ts
+++ b/src/07-shared/lib/socket/proxy-envelope.schema.ts
@@ -18,10 +18,10 @@ const WavePowerSchema = z.object({
 
 export const ProxySampleSchema = z.object({
   group_id: z.string().min(1),
-  // subject_idx는 1-based 계약임 (measurement.service.ts [1, 2] 루프 정합).
-  // proxy 원본은 z.number().int()로 더 느슨하나 BE는 0/음수를 의도적 fail-closed로
-  // invalid_frame 처리함.
-  subject_idx: z.number().int().min(1),
+  // subject_idx는 1-based 계약이며 Group 최대 2 Subject라 1..2만 유효함
+  // (measurement.service.ts [1, 2] 루프 정합). 범위 밖(0/음수/3+)은 구독자 없는
+  // 채널로 publish되어 ack는 ok인데 silent drop되므로 의도적 fail-closed로 invalid_frame 거부함.
+  subject_idx: z.number().int().min(1).max(2),
   payload: WavePowerSchema,
 });
 

--- a/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
+++ b/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
@@ -1,16 +1,17 @@
+/* eslint-disable camelcase */
 /**
  * socket.repro-proxy-namespace.test.ts
  *
- * Phase 18.1 MVP handler 회귀 박제 테스트함.
+ * Phase 18.1 핸드셰이크 + Phase 18.2 envelope persist 회귀 박제 테스트함.
  * mind-signal-proxy의 be-forwarder가 BE `/proxy` namespace에 ENGINE_SECRET
- * 핸드셰이크로 connect 시도하나 namespace handler 미등록으로 `Invalid namespace`
- * retry 누적되던 blocker (HANDOFF 1-6절) 해소 검증함.
+ * 핸드셰이크로 connect하고 `proxy:sample` envelope을 송신하는 경로를 검증함.
  *
  * Scenario A (happy) - 정확한 engineSecret으로 connect 성공함
  * Scenario B (regression sentinel) - 잘못된 secret 거부함
  * Scenario C (regression sentinel) - secret 미전송 거부함
- * Scenario D - proxy:sample 이벤트는 not_implemented ack 반환함 (MVP stub)
+ * Scenario D - 유효 envelope은 Redis publish 후 {ok:true} 반환함 (Phase 18.2)
  * Scenario E - 기본 namespace join-room 동작 영향 없음
+ * Scenario F - 비정상 envelope은 invalid_frame non-retryable 반환 + publish 미호출함
  */
 
 import http from 'http';
@@ -25,11 +26,22 @@ jest.mock('@07-shared/config/config', () => ({
   },
 }));
 
+// redis는 mock - 팩토리 내부에서 jest.fn 생성(외부 const 미참조로 TDZ 차단), import로 참조 회수함
+jest.mock('@07-shared/lib/redis', () => ({
+  redisService: {
+    client: { publish: jest.fn() },
+    connect: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { redisService } from '@07-shared/lib/redis';
 import { SocketService } from './socket';
+
+const mockPublish = jest.mocked(redisService.client.publish);
 
 jest.setTimeout(10_000);
 
-describe('SocketService /proxy namespace MVP handler (Phase 18.1)', () => {
+describe('SocketService /proxy namespace handler (Phase 18.1 + 18.2)', () => {
   let httpServer: http.Server;
   let serverUrl: string;
 
@@ -105,31 +117,42 @@ describe('SocketService /proxy namespace MVP handler (Phase 18.1)', () => {
     });
   });
 
-  it('Scenario D: proxy:sample 이벤트는 not_implemented ack 반환함 (MVP stub)', (done) => {
+  it('Scenario D: 유효 envelope은 Redis publish 후 {ok:true} 반환함 (Phase 18.2)', (done) => {
+    mockPublish.mockClear();
+    mockPublish.mockResolvedValue(1);
     const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
       transports: ['websocket'],
       auth: { engineSecret: 'test-engine-secret-abc123' },
       forceNew: true,
       reconnection: false,
     });
+    const envelope = {
+      group_id: 'g-abc',
+      subject_idx: 2,
+      payload: { delta: 1, theta: 2, alpha: 3, beta: 4, gamma: 5 },
+    };
 
     client.once('connect', () => {
       client
         .timeout(2_000)
         .emit(
           'proxy:sample',
-          { dummy: 'envelope' },
+          envelope,
           (
             err: Error | null,
             ack: { ok: boolean; retryable?: boolean; error?: string }
           ) => {
             try {
               expect(err).toBeNull();
-              expect(ack).toEqual({
-                ok: false,
-                retryable: false,
-                error: 'not_implemented',
-              });
+              expect(ack).toEqual({ ok: true });
+              // 채널 키(계약 A) + 메시지 형태(계약 B) 동시 검증
+              expect(mockPublish).toHaveBeenCalledWith(
+                'mind-signal:g-abc:subject:2',
+                JSON.stringify({
+                  type: 'brain_sync_all',
+                  waves: { delta: 1, theta: 2, alpha: 3, beta: 4, gamma: 5 },
+                })
+              );
               client.disconnect();
               done();
             } catch (e) {
@@ -167,6 +190,48 @@ describe('SocketService /proxy namespace MVP handler (Phase 18.1)', () => {
           }
         }
       );
+    });
+
+    client.once('connect_error', (err: Error) => {
+      done(new Error(`unexpected connect_error: ${err.message}`));
+    });
+  });
+
+  it('Scenario F: 비정상 envelope은 invalid_frame non-retryable 반환 + publish 미호출함', (done) => {
+    mockPublish.mockClear();
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      auth: { engineSecret: 'test-engine-secret-abc123' },
+      forceNew: true,
+      reconnection: false,
+    });
+
+    client.once('connect', () => {
+      client
+        .timeout(2_000)
+        .emit(
+          'proxy:sample',
+          { dummy: 'envelope' },
+          (
+            err: Error | null,
+            ack: { ok: boolean; retryable?: boolean; error?: string }
+          ) => {
+            try {
+              expect(err).toBeNull();
+              expect(ack).toEqual({
+                ok: false,
+                retryable: false,
+                error: 'invalid_frame',
+              });
+              expect(mockPublish).not.toHaveBeenCalled();
+              client.disconnect();
+              done();
+            } catch (e) {
+              client.disconnect();
+              done(e as Error);
+            }
+          }
+        );
     });
 
     client.once('connect_error', (err: Error) => {

--- a/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
+++ b/src/07-shared/lib/socket/socket.repro-proxy-namespace.test.ts
@@ -12,6 +12,7 @@
  * Scenario D - 유효 envelope은 Redis publish 후 {ok:true} 반환함 (Phase 18.2)
  * Scenario E - 기본 namespace join-room 동작 영향 없음
  * Scenario F - 비정상 envelope은 invalid_frame non-retryable 반환 + publish 미호출함
+ * Scenario G - 범위 밖 subject_idx(3+)는 invalid_frame 거부 + publish 미호출함
  */
 
 import http from 'http';
@@ -53,6 +54,11 @@ describe('SocketService /proxy namespace handler (Phase 18.1 + 18.2)', () => {
       serverUrl = `http://127.0.0.1:${port}`;
       done();
     });
+  });
+
+  beforeEach(() => {
+    // 시나리오 간 mock 호출 이력 누수 방지함
+    jest.clearAllMocks();
   });
 
   afterAll((done) => {
@@ -118,7 +124,6 @@ describe('SocketService /proxy namespace handler (Phase 18.1 + 18.2)', () => {
   });
 
   it('Scenario D: 유효 envelope은 Redis publish 후 {ok:true} 반환함 (Phase 18.2)', (done) => {
-    mockPublish.mockClear();
     mockPublish.mockResolvedValue(1);
     const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
       transports: ['websocket'],
@@ -198,7 +203,6 @@ describe('SocketService /proxy namespace handler (Phase 18.1 + 18.2)', () => {
   });
 
   it('Scenario F: 비정상 envelope은 invalid_frame non-retryable 반환 + publish 미호출함', (done) => {
-    mockPublish.mockClear();
     const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
       transports: ['websocket'],
       auth: { engineSecret: 'test-engine-secret-abc123' },
@@ -212,6 +216,53 @@ describe('SocketService /proxy namespace handler (Phase 18.1 + 18.2)', () => {
         .emit(
           'proxy:sample',
           { dummy: 'envelope' },
+          (
+            err: Error | null,
+            ack: { ok: boolean; retryable?: boolean; error?: string }
+          ) => {
+            try {
+              expect(err).toBeNull();
+              expect(ack).toEqual({
+                ok: false,
+                retryable: false,
+                error: 'invalid_frame',
+              });
+              expect(mockPublish).not.toHaveBeenCalled();
+              client.disconnect();
+              done();
+            } catch (e) {
+              client.disconnect();
+              done(e as Error);
+            }
+          }
+        );
+    });
+
+    client.once('connect_error', (err: Error) => {
+      done(new Error(`unexpected connect_error: ${err.message}`));
+    });
+  });
+
+  it('Scenario G: 범위 밖 subject_idx는 invalid_frame 거부 + publish 미호출함', (done) => {
+    const client: ClientSocket = ioClient(`${serverUrl}/proxy`, {
+      transports: ['websocket'],
+      auth: { engineSecret: 'test-engine-secret-abc123' },
+      forceNew: true,
+      reconnection: false,
+    });
+    // subject_idx 3은 구독자 없는 채널이라 silent drop 위험 - 검증 단계에서 거부해야 함
+    const envelope = {
+      group_id: 'g-abc',
+      subject_idx: 3,
+      payload: { delta: 1, theta: 2, alpha: 3, beta: 4, gamma: 5 },
+    };
+
+    client.once('connect', () => {
+      client
+        .timeout(2_000)
+        .emit(
+          'proxy:sample',
+          envelope,
           (
             err: Error | null,
             ack: { ok: boolean; retryable?: boolean; error?: string }

--- a/src/07-shared/lib/socket/socket.ts
+++ b/src/07-shared/lib/socket/socket.ts
@@ -1,6 +1,8 @@
 import { Server as HttpServer } from 'http';
 import { Server, Socket } from 'socket.io';
 import { config } from '@07-shared/config/config';
+import { redisService } from '@07-shared/lib/redis';
+import { ProxySampleSchema } from './proxy-envelope.schema';
 
 /**
  * Socket.io 서버 관리 유틸리티
@@ -60,14 +62,20 @@ export class SocketService {
    *
    * mind-signal-proxy의 `be-forwarder`가 ENGINE_SECRET 핸드셰이크로 connect 시도함
    * (`be-forwarder.ts` `auth: { engineSecret }`).
-   * 현재 MVP 단계는 auth 검증만 활성화하고 `proxy:sample` 이벤트는
-   * `{ok:false, retryable:false, error:'not_implemented'}` ack 반환함.
-   * 후속 Phase 18.2에서 envelope 검증/persist/dedup 로직 구현 예정.
+   * auth 검증 후 `proxy:sample` 이벤트는 envelope을 검증하여 Redis로 publish함으로써
+   * 기존 `subscribeWithAligner` 소비 경로에 합류시킴 (Phase 18.2).
    *
    * @throws Error('invalid_engine_secret') 핸드셰이크 secret 미일치 시 발생
    */
   private static _initProxyNamespace(): void {
     const nsp = this.io.of('/proxy');
+
+    // proxy:sample은 공유 redis client로 publish함. app 시작 시 이 client는 연결되지
+    // 않으므로(subscribe 경로는 전부 client.duplicate() 경유) 여기서 연결을 보장함.
+    // 실패해도 핸들러 try/catch가 retryable ack로 처리해 be-forwarder가 재시도함.
+    void redisService.connect().catch((err) => {
+      console.error('[/proxy] redis 연결 실패:', err);
+    });
 
     // auth 핸드셰이크 - engineSecret 일치 검증함
     nsp.use((socket, next) => {
@@ -86,22 +94,45 @@ export class SocketService {
     nsp.on('connection', (socket: Socket) => {
       console.log(`[/proxy] connected: ${socket.id}`);
 
-      // proxy:sample 이벤트 - Phase 18.1 MVP는 persist 미구현 상태로 drop 반환함
+      // proxy:sample 이벤트 - envelope 검증 후 Redis publish로 aligner 경로에 합류시킴 (Phase 18.2)
       socket.on(
         'proxy:sample',
-        (
-          _envelope: unknown,
+        async (
+          envelope: unknown,
           ack?: (response: {
             ok: boolean;
             retryable?: boolean;
             error?: string;
           }) => void
         ) => {
-          ack?.({
-            ok: false,
-            retryable: false,
-            error: 'not_implemented',
-          });
+          const parsed = ProxySampleSchema.safeParse(envelope);
+          if (!parsed.success) {
+            // 형태 오류는 재시도 무의미함 - non-retryable drop 반환함
+            ack?.({ ok: false, retryable: false, error: 'invalid_frame' });
+            return;
+          }
+
+          const {
+            group_id: groupId,
+            subject_idx: subjectIndex,
+            payload,
+          } = parsed.data;
+          const channel = `mind-signal:${groupId}:subject:${subjectIndex}`;
+          try {
+            // redisService.client는 publish 전용 - 모든 subscribe는 duplicate() 경유라
+            // 이 공유 client는 PubSub 모드에 진입하지 않음 (measurement.service.ts 정합).
+            // dedup 미수행이라 duplicate 필드 미emit - be-forwarder는 ok:true로 dequeue함.
+            // 소비자가 요구하는 형태({type, waves})로 감싸 publish함
+            await redisService.client.publish(
+              channel,
+              JSON.stringify({ type: 'brain_sync_all', waves: payload })
+            );
+            ack?.({ ok: true });
+          } catch (err) {
+            // Redis 일시 장애는 재시도 허용함 - 소켓은 죽이지 않음
+            console.error(`[/proxy] publish 실패 ${channel}:`, err);
+            ack?.({ ok: false, retryable: true, error: 'publish_failed' });
+          }
         }
       );
 


### PR DESCRIPTION
## 요약

Phase 18.1에서 `proxy:sample` 핸들러가 `{ok:false, retryable:false, error:'not_implemented'}`로 모든 envelope을 drop하던 것을, envelope 검증 후 Redis publish로 교체한다. 이로써 DUAL_2PC에서 노트북 B(원격 Subject 2)의 EEG 샘플이 기존 `subscribeWithAligner` 소비 경로에 합류한다.

데이터 흐름: proxy be-forwarder → BE `/proxy` `proxy:sample` → envelope 검증 → `mind-signal:{group_id}:subject:{subject_idx}` 채널에 `{type:'brain_sync_all', waves}` publish → 기존 구독자가 aligner로 라우팅.

## 변경 (2 commits)

- `feat(socket)`: `proxy-envelope.schema.ts`(Zod 집중 검증) + `socket.ts` 핸들러 교체(검증 실패 시 `invalid_frame`, 성공 시 publish 후 `{ok:true}`) + `/proxy` init 시 공유 redis client 연결 보장 + 회귀 박제 Scenario D를 publish 계약으로 amend, `invalid_frame` Scenario F 추가
- `chore(scripts)`: 하드웨어 없이 경로를 검증하는 합성 E2E 스크립트(`npm run e2e:synthetic`)

## 검증

- verify GREEN: format / typecheck / depcruise / lint / test(38 suites, 346 tests, baseline 345 + Scenario F) / build
- 회귀 시뮬레이션 ABC 실측(세 계약 차원, 전부 예상대로 FAIL 후 복구 PASS): 채널 키(`subject:2` vs `subject:99`), 메시지 형태(`brain_sync_all` vs `x`), ack 계약(2초 타임아웃)
- 레벨 2 합성 E2E 라이브 PASS: `5/5 broadcast on mind-signal:synthetic-grp:subject:2`, 각 ack `{ok:true}`. 이 과정에서 공유 redis client 미연결 런타임 버그를 발견하여 수정
- plan-review-deep 2모델(Claude code-reviewer + codex 5.5) PROCEED-WITH-CONDITIONS, Critical 0, 조건 전부 반영

## 범위 경계

- subjectIndex 1-based 문서 정정은 BE `.agents/`가 gitignore라 로컬에만 적용(추적 파일 중 0-based 오기는 그 파일이 유일)
- 후속 별 PR: SocketService DI(reviewer H-1), session_not_measuring/aligner_not_ready 풍부한 ack, F-5 4-모드 dropdown
- 레벨 3 실기기 E2E(노트북 B + EMOTIV 2대 + FE 그래프)는 하드웨어 준비 후 별 세션

prod 무접촉: dev 대상, main/Heroku 변경 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 합성 DUAL 2PC 브로드캐스트 경로를 확인하는 E2E 테스트 스크립트 추가
  * `/proxy`에서 `proxy:sample`을 Redis 기반 브로드캐스 흐름으로 처리하고 ACK 결과를 반환하도록 개선
* **Bug Fixes**
  * 잘못된 envelope은 `invalid_frame`으로 즉시 거부하고, 유효한 샘플만 전달
  * Redis publish 실패 시 재시도 가능한 오류로 응답하며 연결은 유지
* **Tests**
  * `/proxy` 핸들러 검증 시나리오(정상/비정상) 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->