### PR TITLE
fix(engine): DUAL_2PC 측정 정합 및 experimentMode 저장, dead code 정리

### DIFF
--- a/src/02-processes/engine/services/dual-2pc-trigger.service.ts
+++ b/src/02-processes/engine/services/dual-2pc-trigger.service.ts
@@ -24,21 +24,20 @@ export interface RegistryStatus {
     | 'both_failed'
     | 'invalid_secret'
     | 'not_pending_mode'
-    | 'group_id_conflict'
-    | 'precondition_unmet';
+    | 'group_id_conflict';
   startedAt?: number;
   finishedAt?: number;
 }
 
-/** DE pending 정보 — groupId + url + subjectIndex 묶음 */
-export interface DePendingInfo {
+/** DE pending 정보 — groupId + url + subjectIndex 묶음 (모듈 내부 전용) */
+interface DePendingInfo {
   groupId: string;
   url: string;
   subjectIndex: 1 | 2;
 }
 
-/** dualTriggerService 공개 API */
-export interface DualTriggerService {
+/** dualTriggerService API 형태 — 모듈 내부 타입 가드 전용 (외부 import 없음) */
+interface DualTriggerService {
   /**
    * 양쪽 DE에 /control/assign-group POST 호출함.
    * Promise.allSettled + 3회 retry exponential backoff 적용함.

--- a/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
@@ -68,4 +68,19 @@ describe('engineProxyService.streamStop — DUAL_2PC URL 해석', () => {
       expect.objectContaining({ method: 'POST' })
     );
   });
+
+  it('dual group 존재하나 slot 없으면 503 throw함', async () => {
+    // subject 1만 등록 — subject 2 slot 없음
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+
+    await expect(
+      engineProxyService.streamStop(GROUP_ID, 2)
+    ).rejects.toMatchObject({ statusCode: 503 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });

--- a/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
@@ -1,0 +1,71 @@
+/**
+ * engine-proxy.service.ts — streamStop DUAL_2PC URL 해석 회귀 재현 (감사 fix_needed #3)
+ *
+ * fix 전: streamStop이 getEngineUrl()(legacy 단일 slot)만 사용 →
+ *         DUAL_2PC는 registerDual만 호출되어 registeredEngineUrl=null →
+ *         streamStop 시 503 throw. 본 테스트는 fix 전 RED.
+ * fix 후: groupId+subjectIndex 등록(dualRegistry)이 있으면 그 URL을,
+ *         없으면 legacy URL을 사용함.
+ */
+
+const ENGINE_SECRET = 'correct-engine-secret';
+
+jest.mock('@07-shared/config/config', () => ({
+  config: {
+    dataEngine: {
+      path: '/tmp/engine',
+      baseUrl: 'http://localhost:5002',
+      pythonBin: 'python',
+      secretKey: 'correct-engine-secret',
+    },
+  },
+}));
+
+import { engineProxyService } from './engine-proxy.service';
+import { engineRegistryService } from './engine-registry.service';
+
+const GROUP_ID = 'grp_streamstop_test';
+
+describe('engineProxyService.streamStop — DUAL_2PC URL 해석', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(GROUP_ID);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'stopped' }),
+    }) as unknown as typeof fetch;
+  });
+
+  it('DUAL_2PC 등록 시 subject별 dual URL로 stop 요청함', async () => {
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+
+    await engineProxyService.streamStop(GROUP_ID, 2);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://de2:5002/api/stream/stop',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('dual 등록 없으면 legacy 단일 slot URL로 폴백함', async () => {
+    engineRegistryService.register('http://legacy:5002', ENGINE_SECRET);
+
+    await engineProxyService.streamStop(GROUP_ID, 1);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://legacy:5002/api/stream/stop',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.streamstop.test.ts
@@ -69,7 +69,10 @@ describe('engineProxyService.streamStop — DUAL_2PC URL 해석', () => {
     );
   });
 
-  it('dual group 존재하나 slot 없으면 503 throw함', async () => {
+  it('dual group 존재하나 slot 없으면 503 throw함 (legacy 오인 폴백 방지)', async () => {
+    // legacy 슬롯이 등록돼 있어도, group은 있고 slot만 비면 legacy로 폴백하면 안 됨.
+    // 폴백하면 엉뚱한 엔진에 stop을 보내므로, 이 등록으로 order-독립 재현을 보장함.
+    engineRegistryService.register('http://legacy:5002', ENGINE_SECRET);
     // subject 1만 등록 — subject 2 slot 없음
     engineRegistryService.registerDual(
       GROUP_ID,
@@ -81,6 +84,7 @@ describe('engineProxyService.streamStop — DUAL_2PC URL 해석', () => {
     await expect(
       engineProxyService.streamStop(GROUP_ID, 2)
     ).rejects.toMatchObject({ statusCode: 503 });
+    // legacy로 stop을 보내지 않아야 함
     expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -216,57 +216,17 @@ export const engineProxyService = {
     return toCamelCaseKeys(data) as Record<string, unknown>;
   },
 
-  /**
-   * DUAL_2PC 파이프라인 분석 요청을 파이썬 엔진으로 프록시함 (v8 M-1 반영).
-   * subject 1 담당 DE를 analysis 전담으로 지정함.
-   * getEngineUrl() legacy 단일 slot 방식 금지 — getEngineUrlByGroupSubject(groupId, 1) 사용함.
-   *
-   * @param groupId - 실험 그룹 ID
-   * @param satisfactionScores - 피실험자별 만족도 점수 (선택)
-   * @param includeMarkdown - 마크다운 결과 포함 여부 (기본 false)
-   * @returns 분석 결과 (camelCase 변환됨)
-   * @throws AppError — 엔진 미등록 또는 분석 요청 실패 시
-   */
-  async analyzeDual2pcPipeline(
-    groupId: string,
-    satisfactionScores?: Record<number, number>,
-    includeMarkdown?: boolean
-  ): Promise<Record<string, unknown>> {
-    // v8 M-1: 두 DE 중 subject 1 담당 DE를 analysis 전담으로 지정
-    const engineUrl = engineRegistryService.getEngineUrlByGroupSubject(
-      groupId,
-      1
-    );
-    const response = await fetch(`${engineUrl}/api/analyze/pipeline`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-Engine-Secret': config.dataEngine.secretKey,
-      },
-      body: JSON.stringify({
-        ['group_id']: groupId,
-        ['subject_indices']: [1, 2], // v7 C-1: DUAL_2PC는 1-based 고정
-        ['mode']: 'DUAL_2PC',
-        ['include_markdown']: includeMarkdown ?? false,
-        ['satisfaction_scores']: satisfactionScores,
-      }),
-    });
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new AppError(
-        `DUAL_2PC 파이프라인 분석 실패: ${response.status} ${errorText}`,
-        response.status
-      );
-    }
-    return toCamelCaseKeys(await response.json()) as Record<string, unknown>;
-  },
-
   /** 등록된 파이썬 엔진으로 EEG 스트리밍 종료 요청을 프록시함 */
   async streamStop(
     groupId: string,
     subjectIndex: number
   ): Promise<Record<string, unknown>> {
-    const engineUrl = engineRegistryService.getEngineUrl();
+    // DUAL_2PC는 subject별 dual 등록 URL 우선, 미등록(1PC/SEQUENTIAL)은 legacy slot 폴백함.
+    // getByGroup은 비throw — getEngineUrlByGroupSubject(503 throw) 대신 사용함.
+    const dualUrl = engineRegistryService
+      .getByGroup(groupId)
+      ?.get(subjectIndex)?.url;
+    const engineUrl = dualUrl ?? engineRegistryService.getEngineUrl();
 
     const response = await fetch(`${engineUrl}/api/stream/stop`, {
       method: 'POST',

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -221,12 +221,21 @@ export const engineProxyService = {
     groupId: string,
     subjectIndex: number
   ): Promise<Record<string, unknown>> {
-    // DUAL_2PC는 subject별 dual 등록 URL 우선, 미등록(1PC/SEQUENTIAL)은 legacy slot 폴백함.
-    // getByGroup은 비throw — getEngineUrlByGroupSubject(503 throw) 대신 사용함.
-    const dualUrl = engineRegistryService
-      .getByGroup(groupId)
-      ?.get(subjectIndex)?.url;
-    const engineUrl = dualUrl ?? engineRegistryService.getEngineUrl();
+    // group 없으면 1PC/SEQUENTIAL legacy 폴백, group 있는데 slot 없으면 DUAL_2PC 미등록 — 503
+    const registrations = engineRegistryService.getByGroup(groupId);
+    let engineUrl: string;
+    if (!registrations) {
+      engineUrl = engineRegistryService.getEngineUrl();
+    } else {
+      const registration = registrations.get(subjectIndex);
+      if (!registration) {
+        throw new AppError(
+          `DUAL_2PC 엔진 미등록: groupId=${groupId}, subjectIndex=${subjectIndex}`,
+          503
+        );
+      }
+      engineUrl = registration.url;
+    }
 
     const response = await fetch(`${engineUrl}/api/stream/stop`, {
       method: 'POST',

--- a/src/02-processes/engine/services/engine-registry.service.test.ts
+++ b/src/02-processes/engine/services/engine-registry.service.test.ts
@@ -66,12 +66,6 @@ describe('engineRegistryService — BE-5', () => {
         expect(err.statusCode).toBe(403);
       }
     });
-
-    it('isRegistered — 등록 전 false, 등록 후 true 반환함', () => {
-      expect(engineRegistryService.isRegistered()).toBe(false);
-      engineRegistryService.register('http://engine-1:5002', 'valid-secret');
-      expect(engineRegistryService.isRegistered()).toBe(true);
-    });
   });
 
   // ============================================================

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -16,14 +16,12 @@ const registeredCallbacks = new Map<string, Set<() => void>>();
 interface EngineRegistration {
   url: string;
   subjectIndex: number;
-  registeredAt: number;
 }
 
 // ===== Phase 17.6 — pending registry (LD-10) =====
 /** subjectIndex → pending entry (groupId 미정 상태) */
 interface PendingEntry {
   url: string;
-  registeredAt: number;
 }
 
 const pendingRegistry = new Map<1 | 2, PendingEntry>();
@@ -46,11 +44,6 @@ export const engineRegistryService = {
       throw new AppError('파이썬 데이터 엔진이 아직 등록되지 않았습니다.', 503);
     }
     return registeredEngineUrl;
-  },
-
-  /** 등록 상태 확인함 */
-  isRegistered(): boolean {
-    return registeredEngineUrl !== null;
   },
 
   // ===== 신규 메서드 — DUAL_2PC 전용 =====
@@ -80,7 +73,6 @@ export const engineRegistryService = {
     const registration: EngineRegistration = {
       url: engineUrl,
       subjectIndex,
-      registeredAt: Date.now(),
     };
 
     dualRegistry.get(groupId)!.set(subjectIndex, registration);
@@ -183,7 +175,7 @@ export const engineRegistryService = {
     if (secretKey !== config.dataEngine.secretKey) {
       throw new AppError('유효하지 않은 시크릿 키입니다.', 403);
     }
-    pendingRegistry.set(subjectIndex, { url, registeredAt: Date.now() });
+    pendingRegistry.set(subjectIndex, { url });
     console.log(`pending 등록 완료: subjectIndex=${subjectIndex}, url=${url}`);
   },
 

--- a/src/02-processes/measurements/api/measurement.controller.ts
+++ b/src/02-processes/measurements/api/measurement.controller.ts
@@ -36,6 +36,33 @@ const measurementController = {
       return next(error);
     }
   },
+
+  /**
+   * groupId 기반 DUAL_2PC 측정 시작 핸들러.
+   * 오퍼레이터 대시보드가 sessionId 없이 groupId만 보유할 때 사용함.
+   * 202 Accepted + groupId 반환함.
+   */
+  startStreamingByGroup: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      const { groupId } = req.params;
+
+      // groupId 기반 서비스 호출 — 404/400 검증 포함
+      const result =
+        await measurementService.startDualMeasurementByGroup(groupId);
+
+      return res.status(202).json({
+        status: 'accepted',
+        groupId: result.groupId,
+      });
+    } catch (error) {
+      // 에러 발생 시 전역 핸들러로 전달
+      return next(error);
+    }
+  },
 };
 
 export default measurementController;

--- a/src/02-processes/measurements/api/measurement.routes.test.ts
+++ b/src/02-processes/measurements/api/measurement.routes.test.ts
@@ -218,5 +218,7 @@ describe('POST /groups/:groupId/eeg/stream:start — DUAL_2PC 그룹 기반 측�
       '/groups/invalid-group-id/eeg/stream:start'
     );
     expect(res.status).toBe(400);
+    // validateParams가 short-circuit하여 서비스 미호출 확인
+    expect(mockedStartDualMeasurementByGroup).not.toHaveBeenCalled();
   });
 });

--- a/src/02-processes/measurements/api/measurement.routes.test.ts
+++ b/src/02-processes/measurements/api/measurement.routes.test.ts
@@ -3,21 +3,31 @@
  *
  * 검증 항목:
  *   - measurementStartParamsSchema Zod 런타임 검증
+ *   - measurementGroupStartParamsSchema Zod 런타임 검증
  *   - validateParams가 라우트 미들웨어 체인에 실제로 연결됨 (supertest 기반)
  *   - 유효하지 않은 sessionId(비-ObjectId)는 검증 실패함
+ *   - POST /groups/:groupId/eeg/stream:start 엔드포인트 검증
  */
 
 import express from 'express';
 import request from 'supertest';
-import { measurementStartParamsSchema } from './measurement.schema';
+import {
+  measurementStartParamsSchema,
+  measurementGroupStartParamsSchema,
+} from './measurement.schema';
 import { authenticate, validateParams } from '@07-shared/middlewares';
 import measurementController from './measurement.controller';
+import * as measurementService from '@02-processes/measurements/services/measurement.service';
+import { AppError } from '@07-shared/errors';
 
 // measurementService 모킹 — 외부 인프라(Redis, Python 엔진, MongoDB) 의존 제거
 jest.mock('@02-processes/measurements/services/measurement.service', () => ({
   startMeasurementService: jest
     .fn()
     .mockResolvedValue({ measuredAt: '2026-01-01T00:00:00.000Z' }),
+  startDualMeasurementByGroup: jest
+    .fn()
+    .mockResolvedValue({ groupId: '65c9f0b2a1b2c3d4e5f67890' }),
 }));
 
 // authenticate 모킹 — JWT 검증 없이 req.user 주입
@@ -45,6 +55,29 @@ function buildMeasurementApp() {
     authenticate,
     validateParams(measurementStartParamsSchema),
     measurementController.startStreaming
+  );
+  app.post(
+    '/groups/:groupId/eeg/stream:start',
+    authenticate,
+    validateParams(measurementGroupStartParamsSchema),
+    measurementController.startStreamingByGroup
+  );
+  // 전역 에러 핸들러 — AppError를 JSON으로 변환함
+  app.use(
+    (
+      err: unknown,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      if (err instanceof AppError) {
+        const status = err.statusCode >= 500 ? 'error' : 'fail';
+        return res
+          .status(err.statusCode)
+          .json({ status, message: err.message });
+      }
+      return res.status(500).json({ status: 'error', message: 'unknown' });
+    }
   );
   return app;
 }
@@ -89,6 +122,27 @@ describe('measurementStartParamsSchema Zod 런타임 검증', () => {
   });
 });
 
+describe('measurementGroupStartParamsSchema Zod 런타임 검증', () => {
+  it('유효한 24자리 hex ObjectId는 검증을 통과함', () => {
+    const result = measurementGroupStartParamsSchema.safeParse({
+      groupId: '65c9f0b2a1b2c3d4e5f67890',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('비-hex 문자 포함 시 검증 실패함', () => {
+    const result = measurementGroupStartParamsSchema.safeParse({
+      groupId: 'invalid-group-id',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('groupId 누락 시 검증 실패함', () => {
+    const result = measurementGroupStartParamsSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
 describe('POST /sessions/:sessionId/eeg/stream:start — validateParams 라우트 통합', () => {
   const app = buildMeasurementApp();
 
@@ -102,6 +156,66 @@ describe('POST /sessions/:sessionId/eeg/stream:start — validateParams 라우�
   it('비-ObjectId sessionId로 요청 시 400 반환함 (validateParams 체인 확인)', async () => {
     const res = await request(app).post(
       '/sessions/invalid-id/eeg/stream:start'
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /groups/:groupId/eeg/stream:start — DUAL_2PC 그룹 기반 측정 시작', () => {
+  const VALID_GROUP_ID = '65c9f0b2a1b2c3d4e5f67890';
+  const app = buildMeasurementApp();
+
+  const mockedStartDualMeasurementByGroup =
+    measurementService.startDualMeasurementByGroup as jest.MockedFunction<
+      typeof measurementService.startDualMeasurementByGroup
+    >;
+
+  beforeEach(() => {
+    mockedStartDualMeasurementByGroup.mockResolvedValue({
+      groupId: VALID_GROUP_ID,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('유효한 groupId + DUAL_2PC 세션 존재 시 202 반환함', async () => {
+    const res = await request(app).post(
+      `/groups/${VALID_GROUP_ID}/eeg/stream:start`
+    );
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({
+      status: 'accepted',
+      groupId: VALID_GROUP_ID,
+    });
+  });
+
+  it('groupId에 속한 세션 없을 때 404 반환함', async () => {
+    mockedStartDualMeasurementByGroup.mockRejectedValue(
+      new AppError('해당 groupId에 속한 세션을 찾을 수 없습니다.', 404)
+    );
+    const res = await request(app).post(
+      `/groups/${VALID_GROUP_ID}/eeg/stream:start`
+    );
+    expect(res.status).toBe(404);
+    expect(res.body.status).toBe('fail');
+  });
+
+  it('experimentMode가 DUAL_2PC가 아닐 때 400 반환함', async () => {
+    mockedStartDualMeasurementByGroup.mockRejectedValue(
+      new AppError('groupId 기반 측정 시작은 DUAL_2PC 모드만 지원합니다.', 400)
+    );
+    const res = await request(app).post(
+      `/groups/${VALID_GROUP_ID}/eeg/stream:start`
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe('fail');
+  });
+
+  it('비-ObjectId groupId로 요청 시 400 반환함 (validateParams 체인 확인)', async () => {
+    const res = await request(app).post(
+      '/groups/invalid-group-id/eeg/stream:start'
     );
     expect(res.status).toBe(400);
   });

--- a/src/02-processes/measurements/api/measurement.routes.ts
+++ b/src/02-processes/measurements/api/measurement.routes.ts
@@ -2,7 +2,10 @@
 import { Router } from 'express';
 import measurementController from './measurement.controller';
 import { authenticate, validateParams } from '@07-shared/middlewares';
-import { measurementStartParamsSchema } from './measurement.schema';
+import {
+  measurementStartParamsSchema,
+  measurementGroupStartParamsSchema,
+} from './measurement.schema';
 
 const router = Router();
 
@@ -102,6 +105,92 @@ router.post(
   authenticate,
   validateParams(measurementStartParamsSchema),
   measurementController.startStreaming
+);
+
+/**
+ * @openapi
+ * /api/measurements/groups/{groupId}/eeg/stream:start:
+ *   post:
+ *     summary: DUAL_2PC 그룹 기반 측정 시작
+ *     description: |
+ *       오퍼레이터 대시보드가 sessionId 없이 groupId만 보유한 경우 사용함.
+ *       - groupId로 세션 존재 여부 및 experimentMode=DUAL_2PC 검증함.
+ *       - 검증 통과 시 fire-and-forget으로 DUAL_2PC 측정을 시작하고 202 반환함.
+ *     tags: [Measurements]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: groupId
+ *         required: true
+ *         description: 측정을 시작할 실험 그룹 ID(ObjectId)
+ *         schema:
+ *           type: string
+ *           example: "65c9f0b2a1b2c3d4e5f67890"
+ *     responses:
+ *       202:
+ *         description: 측정 시작 수락됨(fire-and-forget)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "accepted" }
+ *                 groupId:
+ *                   type: string
+ *                   example: "65c9f0b2a1b2c3d4e5f67890"
+ *
+ *       400:
+ *         description: experimentMode가 DUAL_2PC가 아님
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "fail" }
+ *                 message:
+ *                   type: string
+ *                   example: "groupId 기반 측정 시작은 DUAL_2PC 모드만 지원합니다."
+ *
+ *       401:
+ *         description: 인증 실패(토큰 누락/만료/비정상)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "fail" }
+ *                 message: { type: string, example: "유효하지 않은 토큰입니다." }
+ *
+ *       404:
+ *         description: 해당 groupId의 세션을 찾을 수 없음
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "fail" }
+ *                 message:
+ *                   type: string
+ *                   example: "해당 groupId에 속한 세션을 찾을 수 없습니다."
+ *
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status: { type: string, example: "error" }
+ *                 message:
+ *                   type: string
+ *                   example: "서버 내부에 예상치 못한 오류가 발생했습니다."
+ */
+router.post(
+  '/groups/:groupId/eeg/stream:start',
+  authenticate,
+  validateParams(measurementGroupStartParamsSchema),
+  measurementController.startStreamingByGroup
 );
 
 export default router;

--- a/src/02-processes/measurements/api/measurement.schema.ts
+++ b/src/02-processes/measurements/api/measurement.schema.ts
@@ -15,3 +15,15 @@ export const measurementStartParamsSchema = z.object({
     .string()
     .regex(OBJECT_ID_REGEX, 'sessionId는 유효한 MongoDB ObjectId여야 합니다.'),
 });
+
+/**
+ * DUAL_2PC 그룹 기반 측정 시작 경로 파라미터 스키마.
+ *
+ * POST /groups/:groupId/eeg/stream:start 요청의
+ * req.params를 검증함.
+ */
+export const measurementGroupStartParamsSchema = z.object({
+  groupId: z
+    .string()
+    .regex(OBJECT_ID_REGEX, 'groupId는 유효한 MongoDB ObjectId여야 합니다.'),
+});

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
@@ -310,3 +310,103 @@ describe('DUAL_2PC 측정 라이프사이클 회귀 재현', () => {
     );
   });
 });
+
+// ===========================================================================
+// 전체 세션 검증 — sessions.every() 가드 (RC-2 고쳐진 사항)
+// ===========================================================================
+
+describe('startDualMeasurementByGroup 전체 세션 검증', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(GROUP_ID);
+  });
+
+  it('두 세션 중 하나가 transition 불가면 400 throw함', async () => {
+    // Session.find가 두 세션 반환, 두 번째가 canTransitionTo=false
+    (Session.find as jest.Mock).mockResolvedValue([
+      {
+        groupId: GROUP_ID,
+        experimentMode: 'DUAL_2PC',
+        status: 'PAIRED',
+        canTransitionTo: jest.fn().mockReturnValue(true),
+      },
+      {
+        groupId: GROUP_ID,
+        experimentMode: 'DUAL_2PC',
+        status: 'MEASURING',
+        canTransitionTo: jest.fn().mockReturnValue(false),
+      },
+    ]);
+
+    await expect(startDualMeasurementByGroup(GROUP_ID)).rejects.toThrow(
+      /측정을 시작할 수 없습니다/
+    );
+  });
+
+  it('두 세션 중 하나가 비-DUAL_2PC면 400 throw함', async () => {
+    // Session.find가 두 세션 반환, 두 번째가 experimentMode != DUAL_2PC
+    (Session.find as jest.Mock).mockResolvedValue([
+      {
+        groupId: GROUP_ID,
+        experimentMode: 'DUAL_2PC',
+        status: 'PAIRED',
+        canTransitionTo: jest.fn().mockReturnValue(true),
+      },
+      {
+        groupId: GROUP_ID,
+        experimentMode: 'SEQUENTIAL',
+        status: 'PAIRED',
+        canTransitionTo: jest.fn().mockReturnValue(true),
+      },
+    ]);
+
+    await expect(startDualMeasurementByGroup(GROUP_ID)).rejects.toThrow(
+      /DUAL_2PC 모드만 지원합니다/
+    );
+  });
+});
+
+// ===========================================================================
+// 중복 트리거 차단 — dualMeasurementInFlight 가드 (RC-3 고쳐진 사항)
+// ===========================================================================
+
+describe('startDualMeasurement 중복 트리거 차단 (in-flight 가드)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(GROUP_ID);
+    // 두 DE 사전 등록 — waitForBothEngines 즉시 resolve 유도
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+    (Session.find as jest.Mock).mockResolvedValue([
+      makeDualSession(GROUP_ID),
+      makeDualSession(GROUP_ID),
+    ]);
+    (Session.updateMany as jest.Mock).mockResolvedValue({ modifiedCount: 2 });
+  });
+
+  it('같은 groupId로 연속 2회 호출 시 streamStartDual은 정확히 2회만 호출됨', async () => {
+    // Act — 두 호출을 await 없이 동시에 시작해 in-flight 가드 작동 검증
+    const p1 = startDualMeasurementByGroup(GROUP_ID);
+    const p2 = startDualMeasurementByGroup(GROUP_ID);
+    await Promise.all([p1, p2]);
+
+    // fire-and-forget IIFE 완료 대기
+    await new Promise<void>((r) => setTimeout(r, 300));
+
+    // Assert — streamStartDual은 subject 1, 2 각 1회씩 총 2회만 호출됨
+    const { engineProxyService } = jest.requireMock(
+      '@02-processes/engine/services/engine-proxy.service'
+    );
+    expect(engineProxyService.streamStartDual).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
@@ -47,7 +47,6 @@ jest.mock('@02-processes/engine/services/engine-proxy.service', () => ({
     streamStartDual: jest.fn().mockResolvedValue({ status: 'started' }),
     streamStart: jest.fn().mockResolvedValue({ status: 'started' }),
     analyzePipeline: jest.fn(),
-    analyzeDual2pcPipeline: jest.fn(),
   },
 }));
 
@@ -118,6 +117,7 @@ jest.mock(
 jest.mock('@06-entities/sessions', () => ({
   Session: {
     findById: jest.fn(),
+    find: jest.fn(),
     updateMany: jest.fn().mockResolvedValue({ modifiedCount: 0 }),
   },
 }));
@@ -126,7 +126,10 @@ jest.mock('@06-entities/sessions', () => ({
 // imports (mock 선언 후)
 // ---------------------------------------------------------------------------
 import { engineRegistryService } from '@02-processes/engine/services/engine-registry.service';
-import { startMeasurementService } from './measurement.service';
+import {
+  startMeasurementService,
+  startDualMeasurementByGroup,
+} from './measurement.service';
 import { SocketService } from '@07-shared/lib/socket';
 import { Session } from '@06-entities/sessions';
 
@@ -232,6 +235,78 @@ describe('startDualMeasurement 런타임 streamStart 호출 검증', () => {
       expect.objectContaining({
         error: expect.stringContaining('DE 2'),
       })
+    );
+  });
+});
+
+// ===========================================================================
+// 회귀 재현 — DUAL_2PC 측정 라이프사이클 fix (감사 fix_needed #1, #2)
+// ===========================================================================
+
+describe('DUAL_2PC 측정 라이프사이클 회귀 재현', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(GROUP_ID);
+    (Session.updateMany as jest.Mock).mockResolvedValue({ modifiedCount: 2 });
+  });
+
+  // fix #1: startDualMeasurement 성공 시 세션 MEASURING 전이 누락 회귀
+  // fix 전: 성공 경로에 updateMany(MEASURING) 없음 → 세션 PAIRED 잔류 →
+  //         이후 stop이 PAIRED→COMPLETED 불가로 실패. 본 테스트는 fix 전 RED.
+  it('streamStartDual 성공 후 세션을 MEASURING으로 전이함', async () => {
+    (Session.findById as jest.Mock).mockResolvedValue(
+      makeDualSession(GROUP_ID)
+    );
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+
+    await startMeasurementService('session-id-001');
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    // 성공 경로에서 MEASURING 전이가 DB에 반영되어야 함
+    expect(Session.updateMany).toHaveBeenCalledWith(
+      { groupId: GROUP_ID },
+      expect.objectContaining({ status: 'MEASURING' })
+    );
+  });
+
+  // fix #2: startDualMeasurementByGroup canTransitionTo 가드 부재 회귀
+  // fix 전: experimentMode만 보고 상태 전이 가드 없음 → 측정 불가 상태에서도
+  //         start 진행. 본 테스트는 fix 전 RED(throw 기대인데 resolve됨).
+  it('전이 불가 상태에서 startDualMeasurementByGroup이 400 throw함', async () => {
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      GROUP_ID,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+    (Session.find as jest.Mock).mockResolvedValue([
+      {
+        groupId: GROUP_ID,
+        experimentMode: 'DUAL_2PC',
+        status: 'MEASURING',
+        canTransitionTo: jest.fn().mockReturnValue(false),
+      },
+    ]);
+
+    await expect(startDualMeasurementByGroup(GROUP_ID)).rejects.toThrow(
+      /측정을 시작할 수 없습니다/
     );
   });
 });

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.test.ts
@@ -164,9 +164,4 @@ describe('measurement.service.ts — BE-3: engine-proxy 5곳 호출 보존 검�
     // ADR-004: getEngineUrl 시그니처 유지, engine-proxy 5곳 호출 깨짐 방지
     expect(engineProxySource).toContain('getEngineUrl');
   });
-
-  it('engine-proxy.service.ts에 analyzeDual2pcPipeline 신규 메서드가 추가됨', () => {
-    // Wave 2에서 신규 메서드 추가됨
-    expect(engineProxySource).toContain('analyzeDual2pcPipeline');
-  });
 });

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -184,6 +184,13 @@ function startDualMeasurement(groupId: string): void {
       ]);
       // ▲ 신규
 
+      // 두 DE 스트림 시작 성공 → 양쪽 세션 MEASURING 전이함 (상태머신 정합).
+      // 누락 시 세션이 PAIRED 잔류하여 stop이 PAIRED→COMPLETED 불가로 실패함.
+      await Session.updateMany(
+        { groupId },
+        { status: 'MEASURING', measuredAt: new Date() }
+      );
+
       // aligner registry에 인스턴스 생성
       timestampAlignerRegistry.getOrCreate(
         groupId,
@@ -245,6 +252,15 @@ export const startDualMeasurementByGroup = async (
   if (sessions[0].experimentMode !== 'DUAL_2PC') {
     throw new AppError(
       'groupId 기반 측정 시작은 DUAL_2PC 모드만 지원합니다.',
+      400
+    );
+  }
+
+  // 상태 전이 가드 — sessionId 경로(startMeasurementService)와 정합.
+  // MEASURING 잔류 세션 재트리거(중복 start) 차단함.
+  if (!sessions[0].canTransitionTo('MEASURING')) {
+    throw new AppError(
+      `현재 ${sessions[0].status} 상태에서는 측정을 시작할 수 없습니다.`,
       400
     );
   }

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -35,6 +35,9 @@ const groupSubscribers = new Map<string, RedisClientType[]>();
 /** DUAL_2PC groupId별 flush setInterval 핸들러 — unsubscribeGroupChannels에서 clearInterval */
 const groupFlushIntervals = new Map<string, ReturnType<typeof setInterval>>();
 
+/** 진행 중인 DUAL_2PC 측정 groupId — 중복 트리거 차단 */
+const dualMeasurementInFlight = new Set<string>();
+
 // ---------------------------------------------------------------------------
 // 내부 헬퍼 — DUAL_2PC 전용
 // ---------------------------------------------------------------------------
@@ -170,6 +173,11 @@ async function waitForBothEngines(
  * @param groupId - 실험 그룹 ID
  */
 function startDualMeasurement(groupId: string): void {
+  // 동일 groupId 중복 호출 차단 — 원자적 동기 가드
+  if (dualMeasurementInFlight.has(groupId)) {
+    return;
+  }
+  dualMeasurementInFlight.add(groupId);
   (async () => {
     try {
       // 두 DE 등록 대기 (최대 60초) — 클라이언트에게는 이미 응답 반환됨
@@ -222,6 +230,8 @@ function startDualMeasurement(groupId: string): void {
         { groupId },
         { status: 'CANCELLED', stopReason: 'ProcessError' }
       );
+    } finally {
+      dualMeasurementInFlight.delete(groupId);
     }
   })();
 }
@@ -248,19 +258,19 @@ export const startDualMeasurementByGroup = async (
     throw new AppError('해당 groupId에 속한 세션을 찾을 수 없습니다.', 404);
   }
 
-  // experimentMode 검증 — DUAL_2PC만 허용함
-  if (sessions[0].experimentMode !== 'DUAL_2PC') {
+  // experimentMode 검증 — 그룹 내 모든 세션이 DUAL_2PC여야 함
+  if (!sessions.every((s) => s.experimentMode === 'DUAL_2PC')) {
     throw new AppError(
       'groupId 기반 측정 시작은 DUAL_2PC 모드만 지원합니다.',
       400
     );
   }
 
-  // 상태 전이 가드 — sessionId 경로(startMeasurementService)와 정합.
+  // 상태 전이 가드 — 그룹 내 모든 세션이 MEASURING으로 전이 가능해야 함.
   // MEASURING 잔류 세션 재트리거(중복 start) 차단함.
-  if (!sessions[0].canTransitionTo('MEASURING')) {
+  if (!sessions.every((s) => s.canTransitionTo('MEASURING'))) {
     throw new AppError(
-      `현재 ${sessions[0].status} 상태에서는 측정을 시작할 수 없습니다.`,
+      '그룹 내 전이 불가 세션이 존재하여 측정을 시작할 수 없습니다.',
       400
     );
   }

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -224,6 +224,37 @@ function startDualMeasurement(groupId: string): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * groupId 기반 DUAL_2PC 측정 시작 서비스.
+ * 오퍼레이터 대시보드가 sessionId 없이 groupId만 보유한 경우 사용함.
+ *
+ * @param groupId - 실험 그룹 ID
+ * @returns 그룹 ID 반환
+ * @throws AppError 404 — 해당 groupId의 세션 미존재
+ * @throws AppError 400 — experimentMode가 DUAL_2PC가 아님
+ */
+export const startDualMeasurementByGroup = async (
+  groupId: string
+): Promise<{ groupId: string }> => {
+  // groupId로 세션 목록 조회함
+  const sessions = await Session.find({ groupId });
+  if (sessions.length === 0) {
+    throw new AppError('해당 groupId에 속한 세션을 찾을 수 없습니다.', 404);
+  }
+
+  // experimentMode 검증 — DUAL_2PC만 허용함
+  if (sessions[0].experimentMode !== 'DUAL_2PC') {
+    throw new AppError(
+      'groupId 기반 측정 시작은 DUAL_2PC 모드만 지원합니다.',
+      400
+    );
+  }
+
+  // fire-and-forget 실행 (기존 함수 재사용)
+  startDualMeasurement(groupId);
+  return { groupId };
+};
+
+/**
  * 뇌파 측정 시작 서비스 (discriminated union 반환, v5 N-9 반영).
  *
  * DUAL_2PC: fire-and-forget 후 { kind: 'DUAL_2PC', groupId } 반환.

--- a/src/05-features/sessions/api/session.controller.ts
+++ b/src/05-features/sessions/api/session.controller.ts
@@ -30,10 +30,15 @@ export const createSession = async (
   next: NextFunction
 ) => {
   try {
-    const { groupId } = req.body; // 기존 그룹에 추가할 경우 groupId를 본문에서 받음
+    // 기존 그룹 추가 시 groupId, DUAL_2PC 등 모드 지정 시 experimentMode를 본문에서 받음
+    const { groupId, experimentMode } = req.body;
 
     // 비즈니스 프로세스 호출하여 세션 생성 수행함
-    const newSession = await createGroupSessionProcess(groupId, req.user?.id);
+    const newSession = await createGroupSessionProcess(
+      groupId,
+      req.user?.id,
+      experimentMode
+    );
 
     res.status(201).json({
       status: 'success',

--- a/src/05-features/sessions/api/session.repro-dual-mode-qr.test.ts
+++ b/src/05-features/sessions/api/session.repro-dual-mode-qr.test.ts
@@ -66,7 +66,6 @@ jest.mock('@05-features/sessions/services/pairing.service', () => ({
   }),
   addPairingCompleteListener: jest.fn(),
   firePairingCompleteListeners: jest.fn(),
-  removePairingCompleteListener: jest.fn(),
   pairDeviceProcess: jest.fn(),
 }));
 
@@ -233,9 +232,30 @@ describe('Reproduce: DUAL 모드 QR 미생성 버그 회귀 박제', () => {
       expect(res.body.data.groupId).toMatch(/^[0-9a-fA-F]{24}$/);
 
       // service가 groupId 없이 호출되었음을 확인 (신규 그룹 생성 경로)
+      // experimentMode 미전달 시 3번째 인자 undefined 전달됨 (BE default DUAL)
       expect(createGroupSessionProcess).toHaveBeenCalledWith(
         undefined,
-        '507f1f77bcf86cd799439011'
+        '507f1f77bcf86cd799439011',
+        undefined
+      );
+    });
+
+    it('experimentMode=DUAL_2PC 전달 시 service 3번째 인자로 전달됨 (생성부터 DUAL_2PC)', async () => {
+      // Arrange — DUAL_2PC 모드 세션 생성 요청
+      const body = { experimentMode: 'DUAL_2PC' };
+
+      // Act
+      const res = await request(app)
+        .post('/api/sessions')
+        .set('Authorization', TEST_JWT)
+        .send(body);
+
+      // Assert — 201 + experimentMode가 service에 전달됨
+      expect(res.status).toBe(201);
+      expect(createGroupSessionProcess).toHaveBeenCalledWith(
+        undefined,
+        '507f1f77bcf86cd799439011',
+        'DUAL_2PC'
       );
     });
 
@@ -254,7 +274,8 @@ describe('Reproduce: DUAL 모드 QR 미생성 버그 회귀 박제', () => {
       expect(res.status).toBe(201);
       expect(createGroupSessionProcess).toHaveBeenCalledWith(
         validObjectId,
-        '507f1f77bcf86cd799439011'
+        '507f1f77bcf86cd799439011',
+        undefined
       );
     });
 

--- a/src/05-features/sessions/api/session.schema.ts
+++ b/src/05-features/sessions/api/session.schema.ts
@@ -9,6 +9,10 @@ export const createSessionSchema = z
       .string()
       .regex(/^[0-9a-fA-F]{24}$/, 'groupId는 24자리 HEX ObjectId여야 합니다.')
       .optional(),
+    // 실험 모드 — 미제공 시 BE 스키마 default(DUAL) 적용함 (DUAL_2PC 생성 경로 지원)
+    experimentMode: z
+      .enum(['DUAL', 'SEQUENTIAL', 'BTI', 'DUAL_2PC'])
+      .optional(),
   })
   .default({});
 

--- a/src/05-features/sessions/services/join-operator.service.ts
+++ b/src/05-features/sessions/services/join-operator.service.ts
@@ -18,15 +18,6 @@ export function addOperatorJoinListener(cb: OperatorJoinCallback): void {
 }
 
 /**
- * operator join 완료 콜백 등록 해제함.
- *
- * @param cb - 제거할 콜백 함수
- */
-export function removeOperatorJoinListener(cb: OperatorJoinCallback): void {
-  operatorJoinListeners.delete(cb);
-}
-
-/**
  * [Service] operator join 프로세스 수행함.
  *
  * invite JWT 토큰을 검증하여 groupId와 experimentMode를 반환함.

--- a/src/05-features/sessions/services/pairing.service.ts
+++ b/src/05-features/sessions/services/pairing.service.ts
@@ -2,6 +2,7 @@ import { Session } from '@06-entities/sessions';
 import { Types } from 'mongoose';
 import mongoose from 'mongoose';
 import { AppError } from '@07-shared/errors';
+import { ExperimentMode } from '@07-shared/constants/experiment';
 import crypto from 'crypto';
 
 // ===== 페어링 완료 listener registry =====
@@ -22,22 +23,16 @@ export function addPairingCompleteListener(cb: PairingCallback): void {
 }
 
 /**
- * 페어링 완료 콜백 등록 해제함.
- *
- * @param cb - 제거할 콜백 함수
- */
-export function removePairingCompleteListener(cb: PairingCallback): void {
-  pairingListeners.delete(cb);
-}
-
-/**
  * [Service] 운영자용 그룹 세션 생성 프로세스 정의함
  * $inc 원자적 연산으로 동시 요청 시에도 고유한 subjectIndex 보장함
  * @param groupId 기존 그룹에 추가할 경우 제공하며, 없을 경우 신규 생성함
+ * @param creatorId 세션 생성자(운영자) ID — 제공 시 바인딩함
+ * @param experimentMode 실험 모드 — 미제공 시 스키마 default(DUAL) 적용함
  */
 export const createGroupSessionProcess = async (
   groupId?: string,
-  creatorId?: string
+  creatorId?: string,
+  experimentMode?: ExperimentMode
 ) => {
   // 1. 그룹 식별자 결정함 (제공되지 않으면 24자리 ObjectId hex 신규 생성함)
   // session.schema.ts:8-11의 24자리 HEX regex와 정합 보장. 8자리 단축 형식은
@@ -70,6 +65,8 @@ export const createGroupSessionProcess = async (
     status: 'CREATED',
     expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5분 유효함
     ...(creatorId ? { creatorId: new Types.ObjectId(creatorId) } : {}),
+    // experimentMode 제공 시 명시 저장, 미제공 시 스키마 default(DUAL) 적용함
+    ...(experimentMode ? { experimentMode } : {}),
   });
 
   return await newSession.save();


### PR DESCRIPTION
## 변경
- groupId 기반 DUAL_2PC stream:start 엔드포인트(선행 커밋 D4).
- 세션 생성 시 experimentMode 저장(생성부터 DUAL_2PC) — createGroupSessionProcess + controller + zod schema.
- 측정 라이프사이클 정합: startDualMeasurement 성공 시 MEASURING 전이, startDualMeasurementByGroup 전이 가드, streamStop dual URL 해석(legacy 폴백)으로 DUAL_2PC 정지 503 해소.
- 미사용 코드 제거: analyzeDual2pcPipeline, EngineRegistration/PendingEntry.registeredAt, isRegistered, remove*Listener, RegistryStatus precondition_unmet, DualTriggerService/DePendingInfo unexport.

## 검증
npm run verify 전체 GREEN (39 suites / 359 tests, depcruise/lint/build). 측정 라이프사이클 fix는 회귀 재현 테스트 red→green 동반.

## 범위
dev 대상, prod(main/Heroku) 무접촉. 라이브 2-PC E2E는 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 ID만으로 EEG 측정을 시작할 수 있는 엔드포인트가 추가되었습니다(승인 응답 202).
  * 세션 생성 시 실험 모드를 선택할 수 있게 되었습니다.

* **Bug Fixes**
  * DUAL_2PC 환경에서 스트림 중지 요청이 올바른 엔진 대상으로 전달되도록 개선되었습니다.
  * 듀얼 측정 시작 후 세션 상태 전이가 더 안정적으로 처리됩니다.
  * 그룹/슬롯 매칭이 불완전한 경우 적절한 실패 응답이 반환되도록 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->