### PR TITLE
feat: DUAL_2PC 단일 헤드셋 subject_2 단독 aligned_pair emit

### DIFF
--- a/src/02-processes/engine/services/engine-registry.service.test.ts
+++ b/src/02-processes/engine/services/engine-registry.service.test.ts
@@ -279,4 +279,76 @@ describe('engineRegistryService — BE-5', () => {
       expect(callback).not.toHaveBeenCalled();
     });
   });
+
+  // ============================================================
+  // F4 — registerPending이 stale dualRegistry 배정 제거 검증
+  // (DE 재시작 시 옛 그룹 배정 잔류가 그룹ID 표류를 유발. 단 proxy 모드
+  //  주기 재등록(동일 url)은 라이브 배정을 보존해야 함 — D2 정합.)
+  // ============================================================
+
+  describe('registerPending — stale dualRegistry 제거 (F4)', () => {
+    it('다른 url로 registerPending 시 동일 subjectIndex의 옛 그룹 배정 제거됨', () => {
+      engineRegistryService.registerDual(
+        'grp-old',
+        1,
+        'http://old:5002',
+        'valid-secret'
+      );
+      expect(
+        engineRegistryService.getEngineUrlByGroupSubject('grp-old', 1)
+      ).toBe('http://old:5002');
+
+      // DE 재시작 → 다른 url로 pending 재등록
+      engineRegistryService.registerPending(
+        1,
+        'http://new:5002',
+        'valid-secret'
+      );
+
+      expect(() =>
+        engineRegistryService.getEngineUrlByGroupSubject('grp-old', 1)
+      ).toThrow();
+    });
+
+    it('동일 url로 registerPending(주기 재등록) 시 라이브 배정 유지함', () => {
+      engineRegistryService.registerDual(
+        'grp-live',
+        1,
+        'http://de:5002',
+        'valid-secret'
+      );
+      // proxy 모드 주기 재등록 — 동일 url이면 evict 안 함
+      engineRegistryService.registerPending(
+        1,
+        'http://de:5002',
+        'valid-secret'
+      );
+      expect(
+        engineRegistryService.getEngineUrlByGroupSubject('grp-live', 1)
+      ).toBe('http://de:5002');
+    });
+
+    it('registerPending이 다른 subjectIndex 배정은 유지함', () => {
+      engineRegistryService.registerDual(
+        'grp-old',
+        1,
+        'http://old1:5002',
+        'valid-secret'
+      );
+      engineRegistryService.registerDual(
+        'grp-old',
+        2,
+        'http://old2:5002',
+        'valid-secret'
+      );
+      engineRegistryService.registerPending(
+        1,
+        'http://new1:5002',
+        'valid-secret'
+      );
+      expect(
+        engineRegistryService.getEngineUrlByGroupSubject('grp-old', 2)
+      ).toBe('http://old2:5002');
+    });
+  });
 });

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -176,6 +176,20 @@ export const engineRegistryService = {
       throw new AppError('유효하지 않은 시크릿 키입니다.', 403);
     }
     pendingRegistry.set(subjectIndex, { url });
+
+    // F4: DE 재시작(다른 url) 시 동일 subjectIndex의 옛 그룹 dualRegistry 배정 제거함.
+    // 옛 배정 잔류가 그룹ID 표류를 유발함. proxy 모드 주기 재등록(동일 url)은
+    // 라이브 배정을 보존하기 위해 url이 다를 때만 evict함 (D2 정합).
+    for (const [gid, group] of dualRegistry.entries()) {
+      const existing = group.get(subjectIndex);
+      if (existing && existing.url !== url) {
+        group.delete(subjectIndex);
+        if (group.size === 0) {
+          dualRegistry.delete(gid);
+        }
+      }
+    }
+
     console.log(`pending 등록 완료: subjectIndex=${subjectIndex}, url=${url}`);
   },
 

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
@@ -370,6 +370,76 @@ describe('startDualMeasurementByGroup 전체 세션 검증', () => {
 // 중복 트리거 차단 — dualMeasurementInFlight 가드 (RC-3 고쳐진 사항)
 // ===========================================================================
 
+// ===========================================================================
+// F1 회귀 재현 — 새 그룹 시작 시 stale 그룹 aligner teardown
+// (차트 0건 근본원인: 이전 run의 aligner가 allCompleted stop 없이 잔존하여
+//  옛 room으로 계속 aligned_pair emit. 새 그룹 시작 시 타 그룹 정리되어야 함.)
+// ===========================================================================
+
+describe('F1 — 새 그룹 시작 시 stale 그룹 aligner teardown', () => {
+  const OLD = 'grp_f1_old';
+  const NEW = 'grp_f1_new';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(OLD);
+    engineRegistryService.cleanupGroup(NEW);
+    (Session.updateMany as jest.Mock).mockResolvedValue({ modifiedCount: 2 });
+  });
+
+  it('OLD 그룹 측정 중 NEW 그룹 시작 시 OLD aligner를 cleanup하고 NEW는 보존함', async () => {
+    const { timestampAlignerRegistry } = jest.requireMock(
+      '@02-processes/measurements/services/timestamp-aligner.service'
+    );
+
+    // OLD 측정 시작 — subscribeWithAligner(OLD)까지 진행되어 활성 그룹 등록됨
+    (Session.find as jest.Mock).mockResolvedValue([
+      makeDualSession(OLD),
+      makeDualSession(OLD),
+    ]);
+    engineRegistryService.registerDual(
+      OLD,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      OLD,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+    await startDualMeasurementByGroup(OLD);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    timestampAlignerRegistry.cleanup.mockClear();
+
+    // NEW 측정 시작 — 타 그룹(OLD) teardown 발동 기대
+    (Session.find as jest.Mock).mockResolvedValue([
+      makeDualSession(NEW),
+      makeDualSession(NEW),
+    ]);
+    engineRegistryService.registerDual(
+      NEW,
+      1,
+      'http://de3:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      NEW,
+      2,
+      'http://de4:5002',
+      ENGINE_SECRET
+    );
+    await startDualMeasurementByGroup(NEW);
+    await new Promise<void>((r) => setTimeout(r, 200));
+
+    // OLD aligner는 정리, NEW(현재 그룹)는 정리 대상 아님
+    expect(timestampAlignerRegistry.cleanup).toHaveBeenCalledWith(OLD);
+    expect(timestampAlignerRegistry.cleanup).not.toHaveBeenCalledWith(NEW);
+  });
+});
+
 describe('startDualMeasurement 중복 트리거 차단 (in-flight 가드)', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -119,6 +119,32 @@ async function unsubscribeGroupChannels(groupId: string): Promise<void> {
 }
 
 /**
+ * 현재 그룹 외 다른 활성 DUAL_2PC 그룹의 aligner/구독/레지스트리 전부 정리함 (F1).
+ * 이전 run의 aligner가 allCompleted stop 없이 잔존하면 옛 room으로 계속
+ * aligned_pair를 emit하여 새 그룹 차트가 비는 표류가 발생함. 새 측정 시작 시
+ * 타 그룹을 teardown해 단일 활성 aligner를 보장함.
+ * 현재 그룹에 잔존 구독이 있으면 재구독 전 정리함 (동일 그룹 재시작 누수 방지).
+ *
+ * @param currentGroupId - 이번에 시작하는 그룹 ID (정리 제외 대상)
+ */
+async function teardownStaleGroups(currentGroupId: string): Promise<void> {
+  const activeGroups = new Set<string>([
+    ...groupSubscribers.keys(),
+    ...groupFlushIntervals.keys(),
+  ]);
+  for (const gid of activeGroups) {
+    if (gid === currentGroupId) continue;
+    await unsubscribeGroupChannels(gid);
+    timestampAlignerRegistry.cleanup(gid);
+    engineRegistryService.cleanupGroup(gid);
+  }
+  // 동일 그룹 재시작 — 기존 구독 잔존 시 재구독 전 정리함
+  if (groupSubscribers.has(currentGroupId)) {
+    await unsubscribeGroupChannels(currentGroupId);
+  }
+}
+
+/**
  * 두 DE가 모두 등록될 때까지 기다리거나 timeout 발생함 (v4 N-4 + v4 N-7 반영).
  * EventEmitter 패턴: engineRegistryService.registerDual() 호출 시 emit.
  * Promise settle 시 unsubscribe + clearTimeout 필수 (ghost 콜백/타이머 누수 방지).
@@ -180,6 +206,9 @@ function startDualMeasurement(groupId: string): void {
   dualMeasurementInFlight.add(groupId);
   (async () => {
     try {
+      // 새 측정 시작 전 stale 그룹 aligner/구독 정리 — 단일 활성 보장 (F1)
+      await teardownStaleGroups(groupId);
+
       // 두 DE 등록 대기 (최대 60초) — 클라이언트에게는 이미 응답 반환됨
       await waitForBothEngines(groupId, config.dualPc.registrationTimeoutMs);
 

--- a/src/02-processes/measurements/services/timestamp-aligner.service.test.ts
+++ b/src/02-processes/measurements/services/timestamp-aligner.service.test.ts
@@ -249,6 +249,46 @@ describe('timestampAlignerRegistry — BE-aligner', () => {
   });
 
   // ============================================================
+  // 단일 헤드셋 지원 — subject 2 단독 emit
+  // ============================================================
+
+  describe('단일 헤드셋 — subject 2 단독 emit', () => {
+    it('subject 2만 수신(subject 1 없음) → subject_1:null, subject_2:sample로 emit됨', () => {
+      // Arrange — subject 1 헤드셋 없음, subject 2(노트북 B)만 측정
+      const groupId = 'grp-single2';
+      timestampAlignerRegistry.getOrCreate(groupId, 200);
+      const sample2 = makeSample(2.0);
+
+      // Act
+      timestampAlignerRegistry.ingest(groupId, 2, sample2, Date.now());
+      const result = timestampAlignerRegistry.flush(groupId);
+
+      // Assert
+      expect(result).toHaveLength(1);
+      expect(result[0].subject_1).toBeNull();
+      expect(result[0].subject_2).toEqual(sample2);
+      expect(mockEmitToGroup).toHaveBeenCalledTimes(1);
+      expect(mockEmitToGroup.mock.calls[0][1]).toBe('aligned_pair');
+    });
+
+    it('subject 2 단독 emit 후 버퍼 비워짐 — 다음 flush 재emit 없음', () => {
+      // Arrange
+      const groupId = 'grp-single2-clear';
+      timestampAlignerRegistry.getOrCreate(groupId, 200);
+      timestampAlignerRegistry.ingest(groupId, 2, makeSample(2.0), Date.now());
+
+      // Act — 1차 flush에서 단독 emit
+      timestampAlignerRegistry.flush(groupId);
+      mockEmitToGroup.mockClear();
+      const second = timestampAlignerRegistry.flush(groupId);
+
+      // Assert — 2차 flush는 빈 배열 + emit 없음
+      expect(second).toHaveLength(0);
+      expect(mockEmitToGroup).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================================
   // v8 C-1: brain_sync_all 타입 가드 소스 검증
   // ============================================================
 

--- a/src/02-processes/measurements/services/timestamp-aligner.service.test.ts
+++ b/src/02-processes/measurements/services/timestamp-aligner.service.test.ts
@@ -253,14 +253,15 @@ describe('timestampAlignerRegistry — BE-aligner', () => {
   // ============================================================
 
   describe('단일 헤드셋 — subject 2 단독 emit', () => {
-    it('subject 2만 수신(subject 1 없음) → subject_1:null, subject_2:sample로 emit됨', () => {
-      // Arrange — subject 1 헤드셋 없음, subject 2(노트북 B)만 측정
+    it('subject 2가 tolerance 초과 대기(subject 1 없음) → subject_1:null로 단독 emit됨', () => {
+      // Arrange — subject 1 헤드셋 없음, subject 2(노트북 B) 샘플이 페어링 윈도
+      // (200ms) 를 넘겨 대기함 (250ms 전 ingest, 500ms 만료 전)
       const groupId = 'grp-single2';
       timestampAlignerRegistry.getOrCreate(groupId, 200);
       const sample2 = makeSample(2.0);
 
       // Act
-      timestampAlignerRegistry.ingest(groupId, 2, sample2, Date.now());
+      timestampAlignerRegistry.ingest(groupId, 2, sample2, Date.now() - 250);
       const result = timestampAlignerRegistry.flush(groupId);
 
       // Assert
@@ -275,7 +276,12 @@ describe('timestampAlignerRegistry — BE-aligner', () => {
       // Arrange
       const groupId = 'grp-single2-clear';
       timestampAlignerRegistry.getOrCreate(groupId, 200);
-      timestampAlignerRegistry.ingest(groupId, 2, makeSample(2.0), Date.now());
+      timestampAlignerRegistry.ingest(
+        groupId,
+        2,
+        makeSample(2.0),
+        Date.now() - 250
+      );
 
       // Act — 1차 flush에서 단독 emit
       timestampAlignerRegistry.flush(groupId);
@@ -285,6 +291,32 @@ describe('timestampAlignerRegistry — BE-aligner', () => {
       // Assert — 2차 flush는 빈 배열 + emit 없음
       expect(second).toHaveLength(0);
       expect(mockEmitToGroup).not.toHaveBeenCalled();
+    });
+
+    it('subject 1이 tolerance 내로 늦게 도착하면 조기 단독 emit 없이 pair로 매칭됨 (CodeRabbit #68 회귀)', () => {
+      // Arrange — 2헤드셋 세션, subject 2 먼저 도착(아직 페어링 윈도 내)
+      const groupId = 'grp-late1';
+      timestampAlignerRegistry.getOrCreate(groupId, 200);
+      const now = Date.now();
+      const sample1 = makeSample(1.0);
+      const sample2 = makeSample(2.0);
+
+      // Act 1 — subject 2만 있고 어림 → 단독 emit 안 함, 버퍼 유지
+      timestampAlignerRegistry.ingest(groupId, 2, sample2, now);
+      const first = timestampAlignerRegistry.flush(groupId);
+
+      // Assert 1 — subject 1 지연을 single-headset으로 오판하지 않음
+      expect(first).toHaveLength(0);
+      expect(mockEmitToGroup).not.toHaveBeenCalled();
+
+      // Act 2 — subject 1이 tolerance 내(100ms)로 늦게 도착
+      timestampAlignerRegistry.ingest(groupId, 1, sample1, now + 100);
+      const second = timestampAlignerRegistry.flush(groupId);
+
+      // Assert 2 — 조기 solo가 아니라 pair로 매칭됨
+      expect(second).toHaveLength(1);
+      expect(second[0].subject_1).toEqual(sample1);
+      expect(second[0].subject_2).toEqual(sample2);
     });
   });
 

--- a/src/02-processes/measurements/services/timestamp-aligner.service.ts
+++ b/src/02-processes/measurements/services/timestamp-aligner.service.ts
@@ -111,6 +111,27 @@ class TimestampAligner {
     const usedIdx1 = new Set<number>();
     const usedIdx2 = new Set<number>();
 
+    // 단일 헤드셋 지원 — subject 1 미수신 시 subject 2 단독 emit함
+    // ponytail: subject 2 방향만 처리. 데모는 subject 1=operator(헤드셋 없음) 고정.
+    // 양쪽 다 있으면 아래 그리디 매칭 경로(불변)로 진입함.
+    if (fresh1.length === 0 && fresh2.length > 0) {
+      /* eslint-disable camelcase */
+      for (const entry2 of fresh2) {
+        const sample: AlignedSample = {
+          groupId: this.groupId,
+          timestamp_ms: entry2.ts,
+          subject_1: null,
+          subject_2: entry2.sample,
+        };
+        aligned.push(sample);
+        SocketService.emitToGroup(this.groupId, 'aligned_pair', sample);
+      }
+      /* eslint-enable camelcase */
+      this.buffer.set(1, []);
+      this.buffer.set(2, []);
+      return aligned;
+    }
+
     for (let i1 = 0; i1 < fresh1.length; i1++) {
       const entry1 = fresh1[i1];
       let bestIdx = -1;

--- a/src/02-processes/measurements/services/timestamp-aligner.service.ts
+++ b/src/02-processes/measurements/services/timestamp-aligner.service.ts
@@ -111,27 +111,6 @@ class TimestampAligner {
     const usedIdx1 = new Set<number>();
     const usedIdx2 = new Set<number>();
 
-    // 단일 헤드셋 지원 — subject 1 미수신 시 subject 2 단독 emit함
-    // ponytail: subject 2 방향만 처리. 데모는 subject 1=operator(헤드셋 없음) 고정.
-    // 양쪽 다 있으면 아래 그리디 매칭 경로(불변)로 진입함.
-    if (fresh1.length === 0 && fresh2.length > 0) {
-      /* eslint-disable camelcase */
-      for (const entry2 of fresh2) {
-        const sample: AlignedSample = {
-          groupId: this.groupId,
-          timestamp_ms: entry2.ts,
-          subject_1: null,
-          subject_2: entry2.sample,
-        };
-        aligned.push(sample);
-        SocketService.emitToGroup(this.groupId, 'aligned_pair', sample);
-      }
-      /* eslint-enable camelcase */
-      this.buffer.set(1, []);
-      this.buffer.set(2, []);
-      return aligned;
-    }
-
     for (let i1 = 0; i1 < fresh1.length; i1++) {
       const entry1 = fresh1[i1];
       let bestIdx = -1;
@@ -170,8 +149,30 @@ class TimestampAligner {
     const newBuf1 = fresh1.filter((_, idx) => !usedIdx1.has(idx));
     const newBuf2 = fresh2.filter((_, idx) => !usedIdx2.has(idx));
 
+    // 단일 헤드셋 지원 — subject 1이 버퍼에 없고, subject 2 샘플이 페어링 윈도
+    // (toleranceMs) 를 넘겨 대기한 경우에만 단독 emit함. buffer 비움이 아니라
+    // "tolerance 초과 미매칭"을 신호로 써서 subject 1의 일시적 지연을 single-headset
+    // 으로 오판하지 않음 (CodeRabbit #68). 윈도 내 어린 샘플은 유지해 late pair 허용.
+    const keptBuf2: BufferEntry[] = [];
+    for (const entry2 of newBuf2) {
+      if (newBuf1.length === 0 && now - entry2.ts > this.toleranceMs) {
+        /* eslint-disable camelcase */
+        const sample: AlignedSample = {
+          groupId: this.groupId,
+          timestamp_ms: entry2.ts,
+          subject_1: null,
+          subject_2: entry2.sample,
+        };
+        /* eslint-enable camelcase */
+        aligned.push(sample);
+        SocketService.emitToGroup(this.groupId, 'aligned_pair', sample);
+      } else {
+        keptBuf2.push(entry2);
+      }
+    }
+
     this.buffer.set(1, newBuf1);
-    this.buffer.set(2, newBuf2);
+    this.buffer.set(2, keptBuf2);
 
     return aligned;
   }


### PR DESCRIPTION
## 배경
DUAL_2PC 모드에서 timestamp-aligner는 subject 1·2 둘 다 데이터가 있어야 aligned_pair를 emit한다. 헤드셋이 1대(노트북 B=subject 2)뿐이면 buf1이 영구히 비어 emit이 발생하지 않아 operator 화면에 아무것도 뜨지 않았다.

## 변경
- `timestamp-aligner.service.ts` flush(): fresh1이 비고 fresh2가 있으면 subject_2를 `{subject_1: null, subject_2}`로 단독 emit 후 early return. 양쪽 다 있으면 기존 그리디 매칭 경로로 진입(불변).

## 테스트
- 신규: subject 2 단독 emit, 단독 emit 후 버퍼 비움
- 회귀 유지: pair 매칭, subject 1 단독 시 emit 미발생(비대칭 의도), 200ms 경계, 500ms 만료
- BE verify 통과: 363 tests, build OK

## 비고
FE 차트 렌더(subject_2)는 mind-signal-frontend 동명 브랜치 PR과 짝.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 한쪽만 도착해도 정렬 결과가 올바르게 전송되도록 개선했습니다(단독 케이스에서 tolerance 경과 항목은 전송 후 제거, 이내 항목은 유지).
  * 새 듀얼 2PC 측정 시작 시 이전 그룹의 잔존 리소스를 자동 정리해 충돌을 줄였습니다.
  * 엔진 재시작/대기 등록 시 오래된 배정이 정리되도록 개선했습니다.
* **Tests**
  * 단독/조기 단독 오판 및 stale 정리 관련 회귀 시나리오를 추가로 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->