### PR TITLE
feat(engine): 2-PC subject CSV 집계 + 분석 operator DE 고정

### DIFF
--- a/src/02-processes/engine/api/engine.controller.ts
+++ b/src/02-processes/engine/api/engine.controller.ts
@@ -3,6 +3,7 @@ import { engineRegistryService } from '../services/engine-registry.service';
 import { engineProxyService } from '../services/engine-proxy.service';
 import { dualTriggerService } from '../services/dual-2pc-trigger.service';
 import { stopMeasurementService } from '@02-processes/measurements/services/measurement.service';
+import { saveUploadedCsv } from '../services/csv-upload.service';
 import { AppError } from '@07-shared/errors';
 import { SocketService } from '@07-shared/lib/socket';
 
@@ -117,6 +118,19 @@ export const engineController = {
         message: 'DUAL_2PC 엔진 등록 완료',
         registeredCount: group?.size ?? 0,
       });
+    } catch (error) {
+      next(error);
+    }
+  },
+
+  /** 노트북 B DE가 업로드한 subject CSV를 operator csv 폴더에 저장함 (2-PC 집계) */
+  csvUpload: (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const secretKey = req.header('x-engine-secret') ?? '';
+      const filename = String(req.query.filename ?? '');
+      const content = typeof req.body === 'string' ? req.body : '';
+      saveUploadedCsv({ secretKey, filename, content });
+      res.status(200).json({ status: 'success', message: 'CSV 업로드 완료' });
     } catch (error) {
       next(error);
     }

--- a/src/02-processes/engine/api/engine.routes.csv-upload.test.ts
+++ b/src/02-processes/engine/api/engine.routes.csv-upload.test.ts
@@ -1,0 +1,137 @@
+/**
+ * engine.routes.ts — POST /api/engine/csv-upload supertest 런타임 검증 (2-PC CSV 집계)
+ *
+ * 배경: DUAL_2PC에서 노트북 B DE가 자기 subject_2 CSV를 operator BE로 업로드함.
+ * operator의 csv 폴더(분석이 읽는 위치)에 저장되어야 두 subject 분석이 가능함.
+ *
+ * 검증 항목:
+ *   - 유효 secret + 유효 filename + CSV 본문 → 200 + 파일이 CSV_STORAGE_DIR에 저장됨
+ *   - secret 불일치 → 403
+ *   - filename 패턴 위반(path traversal 등) → 400
+ *   - 같은 filename 재업로드 → 200 (멱등 overwrite)
+ */
+
+import express from 'express';
+import request from 'supertest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// config 모킹 — dataEngine.secretKey 고정값 주입
+jest.mock('@07-shared/config/config', () => ({
+  config: {
+    env: 'test',
+    port: 5000,
+    mongoUri: 'mongodb://localhost:27017/test',
+    jwtSecret: { secret: 'test-secret', expiresIn: '5m' },
+    isProduction: false,
+    redis: { url: 'redis://localhost:6379' },
+    dataEngine: {
+      path: '/tmp/engine',
+      baseUrl: 'http://localhost:5002',
+      pythonBin: 'python',
+      secretKey: 'correct-engine-secret',
+    },
+    dualPc: {
+      timestampToleranceMs: 200,
+      registrationTimeoutMs: 60000,
+    },
+  },
+}));
+
+import engineRouter from './engine.routes';
+
+// 테스트용 CSV 저장 디렉토리 — 실제 Team-project/csv 오염 방지
+const TEST_CSV_DIR = path.join(os.tmpdir(), 'ms-csv-upload-test');
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/engine', engineRouter);
+  app.use(
+    (
+      err: any,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      res.status(err.statusCode || 500).json({
+        status: err.status || 'error',
+        message: err.message,
+      });
+    }
+  );
+  return app;
+}
+
+const VALID_FILENAME = 'subject_2_6a413cef58664859f44ee519_20260629_002612.csv';
+const CSV_BODY =
+  'time,delta,theta,alpha,beta,gamma\n2026-06-29 00:26:12,0.1,0.2,0.3,0.4,0.5\n';
+
+describe('POST /api/engine/csv-upload — 2-PC subject CSV 업로드', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    process.env.CSV_STORAGE_DIR = TEST_CSV_DIR;
+    fs.rmSync(TEST_CSV_DIR, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    fs.rmSync(TEST_CSV_DIR, { recursive: true, force: true });
+    delete process.env.CSV_STORAGE_DIR;
+  });
+
+  it('유효 secret + 유효 filename + CSV 본문 → 200 + 파일 저장됨', async () => {
+    const res = await request(app)
+      .post(`/api/engine/csv-upload?filename=${VALID_FILENAME}`)
+      .set('x-engine-secret', 'correct-engine-secret')
+      .set('Content-Type', 'text/csv')
+      .send(CSV_BODY);
+
+    expect(res.status).toBe(200);
+
+    const saved = path.join(TEST_CSV_DIR, VALID_FILENAME);
+    expect(fs.existsSync(saved)).toBe(true);
+    expect(fs.readFileSync(saved, 'utf-8')).toBe(CSV_BODY);
+  });
+
+  it('secret 불일치 → 403', async () => {
+    const res = await request(app)
+      .post(`/api/engine/csv-upload?filename=${VALID_FILENAME}`)
+      .set('x-engine-secret', 'wrong-secret')
+      .set('Content-Type', 'text/csv')
+      .send(CSV_BODY);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('filename path traversal → 400 (파일 미저장)', async () => {
+    const evil = encodeURIComponent('../../evil.csv');
+    const res = await request(app)
+      .post(`/api/engine/csv-upload?filename=${evil}`)
+      .set('x-engine-secret', 'correct-engine-secret')
+      .set('Content-Type', 'text/csv')
+      .send(CSV_BODY);
+
+    expect(res.status).toBe(400);
+    expect(fs.existsSync(path.join(os.tmpdir(), 'evil.csv'))).toBe(false);
+  });
+
+  it('같은 filename 재업로드 → 200 (멱등 overwrite)', async () => {
+    await request(app)
+      .post(`/api/engine/csv-upload?filename=${VALID_FILENAME}`)
+      .set('x-engine-secret', 'correct-engine-secret')
+      .set('Content-Type', 'text/csv')
+      .send('old\n');
+
+    const res = await request(app)
+      .post(`/api/engine/csv-upload?filename=${VALID_FILENAME}`)
+      .set('x-engine-secret', 'correct-engine-secret')
+      .set('Content-Type', 'text/csv')
+      .send(CSV_BODY);
+
+    expect(res.status).toBe(200);
+    const saved = path.join(TEST_CSV_DIR, VALID_FILENAME);
+    expect(fs.readFileSync(saved, 'utf-8')).toBe(CSV_BODY);
+  });
+});

--- a/src/02-processes/engine/api/engine.routes.ts
+++ b/src/02-processes/engine/api/engine.routes.ts
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import express, { Router } from 'express';
 import { engineController } from './engine.controller';
 import { authenticate } from '@07-shared/middlewares/authenticate.middleware';
 import { validate } from '@07-shared/middlewares/validate.middleware';
@@ -118,6 +118,14 @@ router.post(
   '/register-dual',
   validate(registerDualSchema),
   engineController.registerDual
+);
+
+// DUAL_2PC 2-PC 집계 — 노트북 B DE가 자기 subject CSV를 operator로 업로드함.
+// 인증: x-engine-secret 헤더(엔진 내부 통신). 본문: text/csv 원본, 메타: filename 쿼리.
+router.post(
+  '/csv-upload',
+  express.text({ type: ['text/csv', 'text/plain'], limit: '15mb' }),
+  engineController.csvUpload
 );
 
 // 전체 파이프라인 분석 프록시

--- a/src/02-processes/engine/services/csv-upload.service.ts
+++ b/src/02-processes/engine/services/csv-upload.service.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import { config } from '@07-shared/config/config';
+import { AppError } from '@07-shared/errors';
+
+// 업로드 파일명 화이트리스트 — path traversal 차단 + analysis.py find_csv_files 패턴 정합
+const FILENAME_RE = /^subject_[12]_[A-Za-z0-9]+_\d{8}_\d{6}\.csv$/;
+
+/**
+ * 업로드 CSV 저장 디렉토리 반환함.
+ * 기본값은 BE 루트의 형제 csv 폴더(Team-project/csv) — DE 분석(find_csv_files)이 읽는 위치.
+ * 테스트는 CSV_STORAGE_DIR 환경변수로 override함.
+ *
+ * @returns CSV 저장 디렉토리 절대경로
+ */
+export function resolveCsvDir(): string {
+  return (
+    process.env.CSV_STORAGE_DIR || path.resolve(process.cwd(), '..', 'csv')
+  );
+}
+
+/**
+ * 노트북 B DE가 업로드한 subject CSV를 operator csv 폴더에 저장함 (2-PC 집계).
+ * 원본은 각 노트북에 분산 유지하고 분석용 사본만 operator로 모으는 모델임.
+ *
+ * @param params - secretKey 검증값, filename(화이트리스트), content(CSV 본문)
+ * @returns 저장된 파일 절대경로
+ * @throws AppError 403 — secretKey 불일치
+ * @throws AppError 400 — filename 패턴 위반
+ */
+export function saveUploadedCsv(params: {
+  secretKey: string;
+  filename: string;
+  content: string;
+}): string {
+  if (params.secretKey !== config.dataEngine.secretKey) {
+    throw new AppError('유효하지 않은 시크릿 키입니다.', 403);
+  }
+  if (!FILENAME_RE.test(params.filename)) {
+    throw new AppError('유효하지 않은 파일명입니다.', 400);
+  }
+  const dir = resolveCsvDir();
+  fs.mkdirSync(dir, { recursive: true });
+  const dest = path.join(dir, params.filename);
+  // 멱등 — 같은 파일 재업로드 시 overwrite함
+  fs.writeFileSync(dest, params.content ?? '', 'utf-8');
+  return dest;
+}

--- a/src/02-processes/engine/services/engine-proxy.service.analyze-url.test.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.analyze-url.test.ts
@@ -1,0 +1,69 @@
+/**
+ * engine-proxy.service.ts — analyzePipeline DUAL_2PC URL 고정 (2-PC CSV 집계)
+ *
+ * 배경: 2-PC에서는 양쪽 DE가 legacy /register를 단일 slot에 호출해 getEngineUrl()이
+ * 레이스(마지막 등록 승)임. 분석은 CSV가 집계된 operator 로컬 DE에서 돌아야 하므로
+ * engineUrlOverride로 operator 로컬 DE URL을 강제할 수 있어야 함.
+ *
+ * fix 전 RED: override 파라미터 무시 → legacy URL로 요청.
+ * fix 후 GREEN: override 제공 시 그 URL, 없으면 legacy 폴백.
+ */
+
+const ENGINE_SECRET = 'correct-engine-secret';
+
+jest.mock('@07-shared/config/config', () => ({
+  config: {
+    dataEngine: {
+      path: '/tmp/engine',
+      baseUrl: 'http://localhost:5002',
+      pythonBin: 'python',
+      secretKey: 'correct-engine-secret',
+    },
+  },
+}));
+
+import { engineProxyService } from './engine-proxy.service';
+import { engineRegistryService } from './engine-registry.service';
+
+const GROUP_ID = 'grp_analyze_url_test';
+
+describe('engineProxyService.analyzePipeline — DUAL_2PC operator 로컬 DE 고정', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(GROUP_ID);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+  });
+
+  it('engineUrlOverride 제공 시 그 URL로 분석 요청함', async () => {
+    // legacy 레이스 상황 재현 — 다른 DE가 단일 slot 점유
+    engineRegistryService.register('http://legacy-race:5002', ENGINE_SECRET);
+
+    await engineProxyService.analyzePipeline(
+      GROUP_ID,
+      [1, 2],
+      undefined,
+      undefined,
+      false,
+      'http://localhost:5002'
+    );
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:5002/api/analyze/pipeline',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('override 없으면 legacy getEngineUrl 사용함 (1-PC 호환)', async () => {
+    engineRegistryService.register('http://legacy-race:5002', ENGINE_SECRET);
+
+    await engineProxyService.analyzePipeline(GROUP_ID, [1, 2]);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://legacy-race:5002/api/analyze/pipeline',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+});

--- a/src/02-processes/engine/services/engine-proxy.service.ts
+++ b/src/02-processes/engine/services/engine-proxy.service.ts
@@ -36,9 +36,12 @@ export const engineProxyService = {
       bandCols?: string[];
     },
     satisfactionScores?: Record<number, number>,
-    includeMarkdown?: boolean
+    includeMarkdown?: boolean,
+    engineUrlOverride?: string
   ): Promise<Record<string, unknown>> {
-    const engineUrl = engineRegistryService.getEngineUrl();
+    // 2-PC는 양쪽 DE가 legacy 단일 slot에 등록해 getEngineUrl()이 레이스임.
+    // CSV가 집계된 operator 로컬 DE로 분석을 고정하려면 override를 사용함.
+    const engineUrl = engineUrlOverride ?? engineRegistryService.getEngineUrl();
 
     const response = await fetch(`${engineUrl}/api/analyze/pipeline`, {
       method: 'POST',

--- a/src/02-processes/post-measurement/services/post-measurement.service.ts
+++ b/src/02-processes/post-measurement/services/post-measurement.service.ts
@@ -4,6 +4,7 @@ import { MatchingPool } from '@06-entities/matching-pools';
 import { EegRecord } from '@06-entities/eeg-records';
 import { Consent } from '@06-entities/consents';
 import { engineProxyService } from '@02-processes/engine/services/engine-proxy.service';
+import { config } from '@07-shared/config/config';
 
 /**
  * 포스트-측정 오케스트레이션 파이프라인 수행함
@@ -63,12 +64,19 @@ export const runPostMeasurementPipeline = async (groupId: string) => {
   let matchingScore = 0;
 
   try {
+    // DUAL_2PC는 CSV가 operator로 집계되므로 분석을 operator 로컬 DE로 고정함.
+    // (양쪽 DE가 legacy 단일 slot에 등록해 getEngineUrl()이 레이스이기 때문)
+    const analysisEngineUrl =
+      session1.experimentMode === 'DUAL_2PC'
+        ? config.dataEngine.baseUrl
+        : undefined;
     pipelineResult = await engineProxyService.analyzePipeline(
       groupId,
       [1, 2],
       undefined,
       undefined,
-      true
+      true,
+      analysisEngineUrl
     );
 
     synchronyScore = (pipelineResult.synchronyScore as number) ?? null;


### PR DESCRIPTION
## 변경
- POST /api/engine/csv-upload — 노트북 B DE가 subject CSV를 operator csv 폴더에 저장 (secret 인증, filename 화이트리스트로 traversal 차단, 멱등 overwrite)
- analyzePipeline engineUrlOverride 추가 + post-measurement이 DUAL_2PC 분석을 operator 로컬 DE로 고정 (legacy getEngineUrl 단일 slot 레이스 회피)

## 배경
2-PC에서 각 DE가 자기 subject CSV를 로컬에만 써서 분석이 양쪽 CSV를 못 읽던 문제. 원본은 각 노트북 분산 유지, 분석용 사본만 operator로 집계.

## 테스트
- BE Jest: csv-upload 4 + analyze-url 2 신규, 풀 verify 374 GREEN + build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV 파일 업로드 기능이 추가되어, 지정된 형식의 CSV를 서버에 저장할 수 있습니다.
  * 업로드된 파일은 동일한 이름으로 다시 올리면 최신 내용으로 갱신됩니다.
  * 일부 분석 요청에서 엔진 연결 주소를 더 안정적으로 선택하도록 개선되었습니다.

* **Bug Fixes**
  * 잘못된 인증 정보, 파일명 형식 오류, 경로 접근 시도를 차단해 업로드 동작의 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->