### PR TITLE
fix(engine): CodeRabbit 지적 반영 — dual_2pc cleanup 보강

### DIFF
--- a/src/02-processes/engine/services/engine-registry.service.test.ts
+++ b/src/02-processes/engine/services/engine-registry.service.test.ts
@@ -350,5 +350,35 @@ describe('engineRegistryService — BE-5', () => {
         engineRegistryService.getEngineUrlByGroupSubject('grp-old', 2)
       ).toBe('http://old2:5002');
     });
+
+    it('빈 그룹 삭제 시 registeredCallbacks도 정리해 죽은 콜백 재호출 방지함', () => {
+      // CodeRabbit #68: dualRegistry만 지우면 registeredCallbacks 잔존 →
+      // 같은 groupId 재사용 시 종료된 flow의 onRegistered 콜백이 다시 호출됨.
+      engineRegistryService.registerDual(
+        'grp-stale-cb',
+        1,
+        'http://old:5002',
+        'valid-secret'
+      );
+      const staleCb = jest.fn();
+      engineRegistryService.onRegistered('grp-stale-cb', staleCb);
+
+      // 다른 url로 pending 재등록 → subject 1 evict → 그룹 비어 삭제
+      engineRegistryService.registerPending(
+        1,
+        'http://new:5002',
+        'valid-secret'
+      );
+      staleCb.mockClear();
+
+      // 같은 groupId 재사용 — 죽은 콜백이 호출되면 안 됨
+      engineRegistryService.registerDual(
+        'grp-stale-cb',
+        1,
+        'http://reuse:5002',
+        'valid-secret'
+      );
+      expect(staleCb).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -185,6 +185,8 @@ export const engineRegistryService = {
       if (existing && existing.url !== url) {
         group.delete(subjectIndex);
         if (group.size === 0) {
+          // cleanupGroup과 동일하게 콜백도 정리 — 재사용 groupId의 죽은 콜백 호출 방지함
+          registeredCallbacks.delete(gid);
           dualRegistry.delete(gid);
         }
       }

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
@@ -514,6 +514,11 @@ describe('F1b — startup in-flight 그룹 supersede', () => {
       OLD,
       expect.anything()
     );
+    // superseded OLD 세션은 terminal cleanup(CANCELLED)으로 정리됨 (CodeRabbit #70)
+    expect(Session.updateMany).toHaveBeenCalledWith(
+      { groupId: OLD },
+      expect.objectContaining({ status: 'CANCELLED' })
+    );
   });
 });
 

--- a/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
+++ b/src/02-processes/measurements/services/measurement.service.dual2pc.runtime.test.ts
@@ -440,6 +440,83 @@ describe('F1 — 새 그룹 시작 시 stale 그룹 aligner teardown', () => {
   });
 });
 
+// ===========================================================================
+// F1b 회귀 재현 — startup in-flight 그룹 supersede (CodeRabbit #68)
+// teardownStaleGroups는 구독 완료 그룹만 보므로, OLD가 아직 waitForBothEngines
+// 단계면 정리 대상에서 빠짐. NEW 시작 후 OLD가 뒤늦게 resolve되면 두 번째 aligner를
+// 붙여 "단일 활성" 보장이 깨짐. supersede 가드로 차단되어야 함.
+// ===========================================================================
+
+describe('F1b — startup in-flight 그룹 supersede', () => {
+  const OLD = 'grp_f1b_old';
+  const NEW = 'grp_f1b_new';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    engineRegistryService.cleanupGroup(OLD);
+    engineRegistryService.cleanupGroup(NEW);
+    (Session.updateMany as jest.Mock).mockResolvedValue({ modifiedCount: 2 });
+  });
+
+  it('OLD가 DE 대기 중일 때 NEW 시작 시 OLD는 superseded되어 aligner 미생성', async () => {
+    const { timestampAlignerRegistry } = jest.requireMock(
+      '@02-processes/measurements/services/timestamp-aligner.service'
+    );
+
+    // OLD: DE 미등록 → waitForBothEngines에서 대기 상태로 진입
+    (Session.find as jest.Mock).mockResolvedValue([
+      makeDualSession(OLD),
+      makeDualSession(OLD),
+    ]);
+    await startDualMeasurementByGroup(OLD);
+
+    // NEW: DE 등록 → 정상 완료 (activeDualGroup=NEW)
+    engineRegistryService.registerDual(
+      NEW,
+      1,
+      'http://de3:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      NEW,
+      2,
+      'http://de4:5002',
+      ENGINE_SECRET
+    );
+    (Session.find as jest.Mock).mockResolvedValue([
+      makeDualSession(NEW),
+      makeDualSession(NEW),
+    ]);
+    await startDualMeasurementByGroup(NEW);
+    await new Promise<void>((r) => setTimeout(r, 150));
+
+    // 뒤늦게 OLD DE 등록 → OLD waitForBothEngines resolve → supersede 가드 진입
+    engineRegistryService.registerDual(
+      OLD,
+      1,
+      'http://de1:5002',
+      ENGINE_SECRET
+    );
+    engineRegistryService.registerDual(
+      OLD,
+      2,
+      'http://de2:5002',
+      ENGINE_SECRET
+    );
+    await new Promise<void>((r) => setTimeout(r, 300));
+
+    // NEW만 aligner 생성, OLD는 supersede되어 미생성
+    expect(timestampAlignerRegistry.getOrCreate).toHaveBeenCalledWith(
+      NEW,
+      expect.anything()
+    );
+    expect(timestampAlignerRegistry.getOrCreate).not.toHaveBeenCalledWith(
+      OLD,
+      expect.anything()
+    );
+  });
+});
+
 describe('startDualMeasurement 중복 트리거 차단 (in-flight 가드)', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -38,6 +38,9 @@ const groupFlushIntervals = new Map<string, ReturnType<typeof setInterval>>();
 /** 진행 중인 DUAL_2PC 측정 groupId — 중복 트리거 차단 */
 const dualMeasurementInFlight = new Set<string>();
 
+/** 가장 최근 시작된 DUAL_2PC 그룹 — startup in-flight supersede 판정용 (F1b) */
+let activeDualGroup: string | null = null;
+
 // ---------------------------------------------------------------------------
 // 내부 헬퍼 — DUAL_2PC 전용
 // ---------------------------------------------------------------------------
@@ -204,6 +207,8 @@ function startDualMeasurement(groupId: string): void {
     return;
   }
   dualMeasurementInFlight.add(groupId);
+  // 최신 시작 그룹 기록 — 대기 중 superseded 판정용 (F1b)
+  activeDualGroup = groupId;
   (async () => {
     try {
       // 새 측정 시작 전 stale 그룹 aligner/구독 정리 — 단일 활성 보장 (F1)
@@ -211,6 +216,13 @@ function startDualMeasurement(groupId: string): void {
 
       // 두 DE 등록 대기 (최대 60초) — 클라이언트에게는 이미 응답 반환됨
       await waitForBothEngines(groupId, config.dualPc.registrationTimeoutMs);
+
+      // 대기 중 다른 그룹이 시작되면 이 그룹은 superseded — 재구독 방지 (F1b).
+      // teardownStaleGroups는 구독 완료 그룹만 정리하므로 startup in-flight는 여기서 차단함.
+      if (activeDualGroup !== groupId) {
+        engineRegistryService.cleanupGroup(groupId);
+        return;
+      }
 
       // ▼ 신규 (T17-4): 두 DE에 streamStart 병렬 호출
       const { engineProxyService } =

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -219,9 +219,13 @@ function startDualMeasurement(groupId: string): void {
 
       // 대기 중 다른 그룹이 시작되면 이 그룹은 superseded — 재구독 방지 (F1b).
       // teardownStaleGroups는 구독 완료 그룹만 정리하므로 startup in-flight는 여기서 차단함.
+      // return 대신 throw로 아래 catch의 terminal cleanup(세션 CANCELLED + 실패 emit)을
+      // 경유함 — 선점된 그룹 세션이 PAIRED 잔류해 이후 흐름 꼬이는 것 방지함 (CodeRabbit #70).
       if (activeDualGroup !== groupId) {
-        engineRegistryService.cleanupGroup(groupId);
-        return;
+        throw new AppError(
+          'DUAL_2PC 측정이 다른 그룹 시작으로 선점되었습니다.',
+          409
+        );
       }
 
       // ▼ 신규 (T17-4): 두 DE에 streamStart 병렬 호출


### PR DESCRIPTION
## CodeRabbit #68 반영
- engine-registry: registerPending이 빈 그룹 삭제 시 registeredCallbacks도 정리 (재사용 groupId 죽은 콜백 방지, Major)
- measurement: startDualMeasurement supersede 가드 — startup in-flight 그룹이 새 그룹 시작에 밀리면 재구독 안 함 (단일 활성 aligner 보장, Major)

## 테스트
TDD red→green+회귀, 풀 verify 376 GREEN + build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DUAL_2PC 측정 시작 시 더 최신 groupId가 먼저 시작되면, 이전 그룹의 후속 처리(정렬/진행)가 실행되지 않도록 가드를 추가했습니다. 또한 해당 세션은 실패로 정리하고 관련 이벤트를 발행합니다.
  * groupId 재사용 시 “죽은 콜백”이 다시 호출되지 않도록, 그룹이 비워질 때 등록 콜백도 함께 정리하도록 개선했습니다.
* **Tests**
  * in-flight 그룹이 supersede 되는 회귀 재현 케이스와 콜백 정리 동작 검증 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->