### PR TITLE
feat(health): 2-PC 상태 대시보드 (집계 /health + static 서빙)

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,0 +1,1 @@
+<!doctype html><title>dashboard</title>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -1,1 +1,86 @@
-<!doctype html><title>dashboard</title>
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <title>MindSignal 2-PC 상태</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        margin: 2rem;
+      }
+      h1 {
+        font-size: 1.2rem;
+      }
+      .row {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        padding: 0.4rem 0;
+        font-size: 1rem;
+      }
+      .dot {
+        width: 0.9rem;
+        height: 0.9rem;
+        border-radius: 50%;
+        background: #999;
+      }
+      .up {
+        background: #2e7d32;
+      }
+      .down {
+        background: #c62828;
+      }
+      .ts {
+        color: #666;
+        font-size: 0.8rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>MindSignal 2-PC 상태 <span class="ts" id="ts"></span></h1>
+    <div id="list"></div>
+    <script>
+      const ROWS = [
+        ['redis', 'Redis(operator)'],
+        ['data-engine-A', '데이터엔진 A(operator)'],
+        ['proxy', 'Proxy(operator)'],
+        ['frontend', 'Frontend'],
+        ['data-engine-B', '데이터엔진 B(노트북B, Tailscale)'],
+      ];
+      function render(state) {
+        document.getElementById('list').innerHTML = ROWS.map(
+          ([key, label]) => {
+            const v = state[key];
+            const cls =
+              v === 'ok' || v === 'up' ? 'up' : v === undefined ? '' : 'down';
+            const txt =
+              v === undefined ? '미확인' : cls === 'up' ? '정상' : '다운';
+            return (
+              '<div class="row"><span class="dot ' +
+              cls +
+              '"></span>' +
+              label +
+              ': ' +
+              txt +
+              '</div>'
+            );
+          }
+        ).join('');
+        document.getElementById('ts').textContent =
+          new Date().toLocaleTimeString('ko-KR');
+      }
+      async function refresh() {
+        try {
+          const r = await fetch('/health', { signal: AbortSignal.timeout(3000) });
+          const body = await r.json();
+          const d = body.data || {};
+          render({ redis: d.redis, ...(d.services || {}) });
+        } catch {
+          render({}); // BE 자체가 다운이면 전부 미확인
+        }
+      }
+      setInterval(refresh, 5000);
+      refresh();
+    </script>
+  </body>
+</html>

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -21,8 +21,11 @@ app.use(bodyParser.json());
 // 대시보드 정적 파일 서빙함 (public/dashboard.html)
 registerStatic(app);
 
-// 대시보드용 집계 헬스체크 (root 레벨, CORS 불필요)
-app.get('/health', healthCheck);
+// 대시보드용 집계 헬스체크 (root 레벨, CORS 불필요).
+// 운영 정보(redis 상태, 내부 서비스 가용성) 노출 방지를 위해 비-production에서만 등록함.
+if (!config.isProduction) {
+  app.get('/health', healthCheck);
+}
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
 app.use('/api', indexRouter);

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -10,11 +10,15 @@ import { config } from '@07-shared/config/config';
 import { SocketService } from '@07-shared/lib/socket';
 import { AuthProviderRegistry } from '@05-features/auth/services/providers/auth-provider.registry';
 import { registerPairingTriggerListener } from '@01-app/startup-listeners';
+import { healthCheck } from '@01-app/health.controller';
 
 const app = express();
 app.use(cors());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
+
+// 대시보드용 집계 헬스체크 (root 레벨, CORS 불필요)
+app.get('/health', healthCheck);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
 app.use('/api', indexRouter);

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -11,11 +11,15 @@ import { SocketService } from '@07-shared/lib/socket';
 import { AuthProviderRegistry } from '@05-features/auth/services/providers/auth-provider.registry';
 import { registerPairingTriggerListener } from '@01-app/startup-listeners';
 import { healthCheck } from '@01-app/health.controller';
+import { registerStatic } from '@01-app/static';
 
 const app = express();
 app.use(cors());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
+
+// 대시보드 정적 파일 서빙함 (public/dashboard.html)
+registerStatic(app);
 
 // 대시보드용 집계 헬스체크 (root 레벨, CORS 불필요)
 app.get('/health', healthCheck);

--- a/src/01-app/health.controller.test.ts
+++ b/src/01-app/health.controller.test.ts
@@ -3,22 +3,35 @@ import request from 'supertest';
 
 jest.mock('@07-shared/lib/redis', () => ({
   redisService: {
-    connect: jest.fn().mockResolvedValue(undefined),
-    client: { ping: jest.fn().mockResolvedValue('PONG') },
+    connect: jest.fn(),
+    client: { ping: jest.fn() },
   },
 }));
 
-// 모든 peer fetch는 실패로 모킹(서비스 미기동 가정), services 전부 down 처리함
-const failFetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
-global.fetch = failFetch as unknown as typeof fetch;
-
 import { healthCheck } from './health.controller';
+
+// 모든 peer fetch는 실패로 모킹함 (서비스 미기동 가정, services 전부 down 처리함)
+const failFetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+const originalFetch = global.fetch;
 
 function buildApp() {
   const app = express();
   app.get('/health', healthCheck);
   return app;
 }
+
+beforeEach(() => {
+  const { redisService } = jest.requireMock('@07-shared/lib/redis');
+  jest.clearAllMocks();
+  redisService.connect.mockResolvedValue(undefined);
+  redisService.client.ping.mockResolvedValue('PONG');
+  failFetch.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+  global.fetch = failFetch as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
 
 describe('GET /health', () => {
   it('redis가 살아있으면 200과 redis:ok를 반환함', async () => {
@@ -30,7 +43,7 @@ describe('GET /health', () => {
   });
 
   it('redis ping이 실패해도 200으로 redis:down을 표시함', async () => {
-    const { redisService } = require('@07-shared/lib/redis');
+    const { redisService } = jest.requireMock('@07-shared/lib/redis');
     redisService.client.ping.mockRejectedValueOnce(new Error('down'));
     const res = await request(buildApp()).get('/health');
     expect(res.status).toBe(200);

--- a/src/01-app/health.controller.test.ts
+++ b/src/01-app/health.controller.test.ts
@@ -1,0 +1,40 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('@07-shared/lib/redis', () => ({
+  redisService: {
+    connect: jest.fn().mockResolvedValue(undefined),
+    client: { ping: jest.fn().mockResolvedValue('PONG') },
+  },
+}));
+
+// 모든 peer fetch는 실패로 모킹(서비스 미기동 가정), services 전부 down 처리함
+const failFetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+global.fetch = failFetch as unknown as typeof fetch;
+
+import { healthCheck } from './health.controller';
+
+function buildApp() {
+  const app = express();
+  app.get('/health', healthCheck);
+  return app;
+}
+
+describe('GET /health', () => {
+  it('redis가 살아있으면 200과 redis:ok를 반환함', async () => {
+    const res = await request(buildApp()).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.redis).toBe('ok');
+    expect(res.body.data.services).toHaveProperty('data-engine-A', 'down');
+  });
+
+  it('redis ping이 실패해도 200으로 redis:down을 표시함', async () => {
+    const { redisService } = require('@07-shared/lib/redis');
+    redisService.client.ping.mockRejectedValueOnce(new Error('down'));
+    const res = await request(buildApp()).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.data.redis).toBe('down');
+    expect(res.body.data.services).toHaveProperty('proxy');
+  });
+});

--- a/src/01-app/health.controller.ts
+++ b/src/01-app/health.controller.ts
@@ -1,0 +1,43 @@
+import { RequestHandler } from 'express';
+import { redisService } from '@07-shared/lib/redis';
+
+const PEERS: { name: string; url: string }[] = [
+  { name: 'data-engine-A', url: 'http://localhost:5002/health' },
+  { name: 'proxy', url: 'http://localhost:5050/health' },
+  { name: 'frontend', url: 'http://localhost:3000' },
+  ...(process.env.NOTEBOOK_B_URL
+    ? [{ name: 'data-engine-B', url: `${process.env.NOTEBOOK_B_URL}/health` }]
+    : []),
+];
+
+async function ping(url: string): Promise<'up' | 'down'> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    return res.ok ? 'up' : 'down';
+  } catch {
+    return 'down';
+  }
+}
+
+async function checkRedis(): Promise<'ok' | 'down'> {
+  try {
+    await redisService.connect();
+    await redisService.client.ping();
+    return 'ok';
+  } catch {
+    return 'down';
+  }
+}
+
+// 대시보드용 집계 헬스체크. redis ping + 각 서비스 reachability를 서버사이드로 모아
+// 단일 응답으로 반환함 (대시보드는 BE 한 곳만 폴링 -> CORS 불필요).
+export const healthCheck: RequestHandler = async (_req, res) => {
+  const [redis, entries] = await Promise.all([
+    checkRedis(),
+    Promise.all(PEERS.map(async (p) => [p.name, await ping(p.url)] as const)),
+  ]);
+  res.status(200).json({
+    status: 'success',
+    data: { redis, services: Object.fromEntries(entries) },
+  });
+};

--- a/src/01-app/static.test.ts
+++ b/src/01-app/static.test.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import request from 'supertest';
+import { registerStatic } from './static';
+
+it('registerStatic 적용 후 GET /dashboard.html은 200 html을 반환함', async () => {
+  const app = express();
+  registerStatic(app);
+  const res = await request(app).get('/dashboard.html');
+  expect(res.status).toBe(200);
+  expect(res.type).toMatch(/html/);
+});

--- a/src/01-app/static.test.ts
+++ b/src/01-app/static.test.ts
@@ -9,3 +9,10 @@ it('registerStatic 적용 후 GET /dashboard.html은 200 html을 반환함', asy
   expect(res.status).toBe(200);
   expect(res.type).toMatch(/html/);
 });
+
+it('없는 정적 파일 요청은 404를 반환함', async () => {
+  const app = express();
+  registerStatic(app);
+  const res = await request(app).get('/__missing__.html');
+  expect(res.status).toBe(404);
+});

--- a/src/01-app/static.ts
+++ b/src/01-app/static.ts
@@ -1,0 +1,8 @@
+import express, { Express } from 'express';
+import path from 'path';
+
+// public/ 는 BE 프로젝트 루트 기준임 (npm run dev / npm start 모두 cwd=mind-signal-backend).
+// 대시보드 HTML을 같은 출처로 서빙해 /health 폴링 시 CORS를 회피함.
+export function registerStatic(app: Express): void {
+  app.use(express.static(path.join(process.cwd(), 'public')));
+}


### PR DESCRIPTION
## 목적
2-PC(operator + 노트북 B) 셋업 상태를 한 화면에서 보는 상태 대시보드. 각 서비스를 직접 폴링하면 CORS가 여러 곳 필요하므로, BE가 서버사이드로 집계해 대시보드는 BE 한 곳만 폴링한다.

## 변경 (3 커밋)
- `feat(health): aggregating /health` — redis ping + DE_A/proxy/FE/DE_B reachability를 모아 `{status, data:{redis, services}}`로 반환. redis down에도 200(전체 미확인 방지).
- `feat(health): static registerStatic` — public/ 정적 서빙을 공유 함수로 분리, app.ts와 테스트가 같은 코드 검증.
- `feat(health): dashboard.html` — 5초 폴링, 색 표시. NOTEBOOK_B_URL env로 DE_B 행 표시(Tailscale 연결 표시기 겸용).

## 검증
`npm run verify` 전체 통과 (format/typecheck/depcruise/lint + test 379 green + build).

## 비고
- prod 무접촉. 신규 라우트는 root `/health`(대시보드 폴링용), 기존 `/api/*` 무변경.
- 설계/계획: .plans/19-2pc-autoconnect-ops/ (DESIGN/PLAN, codex gpt-5.5 교차검토 PROCEED).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 시스템 상태를 표시하는 정적 대시보드(대시보드 페이지)가 추가되었습니다.
  * 대시보드가 서버의 헬스정보를 바탕으로 Redis 및 주요 서비스 상태를 카드로 렌더링하고, up/down/미확인 상태를 색상으로 구분합니다.
  * 5초마다 자동 갱신되며 마지막 갱신 시간도 함께 표시됩니다.
* **Bug Fixes**
  * 상태 조회 중 오류가 발생해도 화면은 안전하게 “미확인”으로 표시되도록 개선되었습니다.
* **Tests**
  * 대시보드 정적 서빙 및 헬스체크 응답을 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->