### PR TITLE
feat(diag): 2PC 진단 대시보드 API + groupId 일치확인 + 비상 그룹 해제

### DIFF
--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -7,9 +7,16 @@
       body {
         font-family: system-ui, sans-serif;
         margin: 2rem;
+        max-width: 900px;
       }
       h1 {
         font-size: 1.2rem;
+      }
+      h2 {
+        font-size: 1rem;
+        margin-top: 1.6rem;
+        border-top: 1px solid #ddd;
+        padding-top: 1rem;
       }
       .row {
         display: flex;
@@ -34,11 +41,83 @@
         color: #666;
         font-size: 0.8rem;
       }
+      .badge {
+        display: inline-block;
+        padding: 0.2rem 0.6rem;
+        border-radius: 0.4rem;
+        font-weight: 600;
+        color: #fff;
+      }
+      .badge.ok {
+        background: #2e7d32;
+      }
+      .badge.bad {
+        background: #c62828;
+      }
+      table {
+        border-collapse: collapse;
+        margin: 0.5rem 0;
+        font-size: 0.9rem;
+      }
+      td,
+      th {
+        border: 1px solid #ddd;
+        padding: 0.3rem 0.6rem;
+        text-align: left;
+      }
+      code {
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+      }
+      button {
+        margin: 0.2rem 0.3rem 0.2rem 0;
+        padding: 0.4rem 0.7rem;
+        font-size: 0.85rem;
+        cursor: pointer;
+        border: 1px solid #bbb;
+        border-radius: 0.4rem;
+        background: #f7f7f7;
+      }
+      button.danger {
+        border-color: #c62828;
+        color: #c62828;
+      }
+      pre#out {
+        background: #1e1e1e;
+        color: #d4d4d4;
+        padding: 0.8rem;
+        border-radius: 0.4rem;
+        max-height: 320px;
+        overflow: auto;
+        font-size: 0.8rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+      .muted {
+        color: #888;
+      }
     </style>
   </head>
   <body>
     <h1>MindSignal 2-PC 상태 <span class="ts" id="ts"></span></h1>
     <div id="list"></div>
+
+    <h2>groupId 일치 확인 <span class="ts" id="diagTs"></span></h2>
+    <div id="diag"><span class="muted">진단 새로고침을 눌러 조회</span></div>
+
+    <h2>진단 · 수정 액션</h2>
+    <div id="actions">
+      <button onclick="loadDiag()">진단 새로고침</button>
+      <button onclick="act('redis-sample')">redis 샘플(2초)</button>
+      <button onclick="act('notebook-b-logs?tail=60')">노트북B 로그</button>
+      <button onclick="act('de-a-logs?tail=60')">DE_A 로그</button>
+      <button onclick="registryStatus()">registry 조회</button>
+      <button class="danger" onclick="act('firewall-allow')">방화벽 허용(5050/5002)</button>
+      <button class="danger" onclick="confirmAct('restart-de-a', 'DE_A를 재시작할까요?')">DE_A 재시작</button>
+      <button class="danger" onclick="confirmAct('release-all', '모든 groupId 연결을 해제할까요? (비상)')">비상: 전체 그룹 해제</button>
+    </div>
+    <pre id="out" class="muted">액션 결과가 여기 표시됩니다.</pre>
+
     <script>
       const ROWS = [
         ['redis', 'Redis(operator)'],
@@ -48,24 +127,21 @@
         ['data-engine-B', '데이터엔진 B(노트북B, Tailscale)'],
       ];
       function render(state) {
-        document.getElementById('list').innerHTML = ROWS.map(
-          ([key, label]) => {
-            const v = state[key];
-            const cls =
-              v === 'ok' || v === 'up' ? 'up' : v === undefined ? '' : 'down';
-            const txt =
-              v === undefined ? '미확인' : cls === 'up' ? '정상' : '다운';
-            return (
-              '<div class="row"><span class="dot ' +
-              cls +
-              '"></span>' +
-              label +
-              ': ' +
-              txt +
-              '</div>'
-            );
-          }
-        ).join('');
+        document.getElementById('list').innerHTML = ROWS.map(([key, label]) => {
+          const v = state[key];
+          const cls =
+            v === 'ok' || v === 'up' ? 'up' : v === undefined ? '' : 'down';
+          const txt = v === undefined ? '미확인' : cls === 'up' ? '정상' : '다운';
+          return (
+            '<div class="row"><span class="dot ' +
+            cls +
+            '"></span>' +
+            label +
+            ': ' +
+            txt +
+            '</div>'
+          );
+        }).join('');
         document.getElementById('ts').textContent =
           new Date().toLocaleTimeString('ko-KR');
       }
@@ -76,11 +152,76 @@
           const d = body.data || {};
           render({ redis: d.redis, ...(d.services || {}) });
         } catch {
-          render({}); // BE 자체가 다운이면 전부 미확인
+          render({});
         }
       }
       setInterval(refresh, 5000);
       refresh();
+
+      // ── groupId 일치확인 패널 ──
+      const short = (g) => (g ? '<code>' + g + '</code>' : '<span class="muted">없음</span>');
+      async function loadDiag() {
+        const el = document.getElementById('diag');
+        el.innerHTML = '<span class="muted">조회 중…</span>';
+        try {
+          const r = await fetch('/diag', { signal: AbortSignal.timeout(8000) });
+          const { data: d } = await r.json();
+          const m = d.match;
+          const badge = m.matched
+            ? '<span class="badge ok">일치 ✓</span>'
+            : '<span class="badge bad">불일치 ⚠️ (' + m.distinct.length + '개 groupId)</span>';
+          const pending = (d.pendingSubjects || [])
+            .map((p) => 'subject' + p.subjectIndex + ' <code>' + p.url + '</code>')
+            .join('<br/>') || '<span class="muted">없음</span>';
+          const groups = (d.registeredGroups || [])
+            .map((g) => short(g.groupId) + ' → subjects [' + g.subjects.join(',') + ']')
+            .join('<br/>') || '<span class="muted">없음</span>';
+          const stream = (v) =>
+            v === true ? '측정중' : v === false ? 'idle' : '<span class="muted">미확인</span>';
+          el.innerHTML =
+            badge +
+            '<table>' +
+            '<tr><th>대상</th><th>registered groupId</th><th>스트림</th></tr>' +
+            '<tr><td>DE_A(operator, subject1)</td><td>' + short(m.deA) + '</td><td>' + stream(d.dataEngineA.streaming) + '</td></tr>' +
+            '<tr><td>DE_B(노트북B, subject2)</td><td>' + short(m.deB) + '</td><td>' + stream(d.dataEngineB ? d.dataEngineB.streaming : null) + '</td></tr>' +
+            '<tr><td>BE active</td><td>' + short(m.beActive) + '</td><td>-</td></tr>' +
+            '</table>' +
+            '<div><b>pending 등록:</b><br/>' + pending + '</div>' +
+            '<div style="margin-top:.5rem"><b>바인딩된 그룹:</b><br/>' + groups + '</div>';
+          document.getElementById('diagTs').textContent =
+            new Date().toLocaleTimeString('ko-KR');
+        } catch (e) {
+          el.innerHTML = '<span class="badge bad">조회 실패</span> ' + e;
+        }
+      }
+
+      // ── 액션 실행 ──
+      const out = document.getElementById('out');
+      function showOut(obj) {
+        out.classList.remove('muted');
+        out.textContent = JSON.stringify(obj, null, 2);
+      }
+      async function act(name) {
+        out.classList.remove('muted');
+        out.textContent = name + ' 실행 중…';
+        try {
+          const r = await fetch('/diag/action/' + name, {
+            method: 'POST',
+            signal: AbortSignal.timeout(95000),
+          });
+          showOut(await r.json());
+          loadDiag();
+        } catch (e) {
+          showOut({ error: String(e) });
+        }
+      }
+      function confirmAct(name, msg) {
+        if (confirm(msg)) act(name);
+      }
+      function registryStatus() {
+        const gid = prompt('groupId 입력');
+        if (gid) act('registry-status?groupId=' + encodeURIComponent(gid));
+      }
     </script>
   </body>
 </html>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -159,7 +159,21 @@
       refresh();
 
       // ── groupId 일치확인 패널 ──
-      const short = (g) => (g ? '<code>' + g + '</code>' : '<span class="muted">없음</span>');
+      // XSS 방어 — DE/로그 응답·예외 문자열을 innerHTML에 넣기 전 escape
+      const esc = (s) =>
+        String(s).replace(
+          /[&<>"']/g,
+          (c) =>
+            ({
+              '&': '&amp;',
+              '<': '&lt;',
+              '>': '&gt;',
+              '"': '&quot;',
+              "'": '&#39;',
+            })[c]
+        );
+      const short = (g) =>
+        g ? '<code>' + esc(g) + '</code>' : '<span class="muted">없음</span>';
       async function loadDiag() {
         const el = document.getElementById('diag');
         el.innerHTML = '<span class="muted">조회 중…</span>';
@@ -171,7 +185,7 @@
             ? '<span class="badge ok">일치 ✓</span>'
             : '<span class="badge bad">불일치 ⚠️ (' + m.distinct.length + '개 groupId)</span>';
           const pending = (d.pendingSubjects || [])
-            .map((p) => 'subject' + p.subjectIndex + ' <code>' + p.url + '</code>')
+            .map((p) => 'subject' + p.subjectIndex + ' <code>' + esc(p.url) + '</code>')
             .join('<br/>') || '<span class="muted">없음</span>';
           const groups = (d.registeredGroups || [])
             .map((g) => short(g.groupId) + ' → subjects [' + g.subjects.join(',') + ']')
@@ -191,7 +205,7 @@
           document.getElementById('diagTs').textContent =
             new Date().toLocaleTimeString('ko-KR');
         } catch (e) {
-          el.innerHTML = '<span class="badge bad">조회 실패</span> ' + e;
+          el.innerHTML = '<span class="badge bad">조회 실패</span> ' + esc(e);
         }
       }
 

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -54,6 +54,9 @@
       .badge.bad {
         background: #c62828;
       }
+      .badge.idle {
+        background: #777;
+      }
       table {
         border-collapse: collapse;
         margin: 0.5rem 0;
@@ -181,11 +184,14 @@
           const r = await fetch('/diag', { signal: AbortSignal.timeout(8000) });
           const { data: d } = await r.json();
           const m = d.match;
-          const badge = m.matched
-            ? '<span class="badge ok">일치 ✓</span>'
-            : '<span class="badge bad">불일치 ⚠️ (' + m.distinct.length + '개 groupId)</span>';
+          const badge =
+            m.state === 'matched'
+              ? '<span class="badge ok">일치 ✓</span>'
+              : m.state === 'idle'
+                ? '<span class="badge idle">대기(idle)</span>'
+                : '<span class="badge bad">불일치 ⚠️ (' + m.distinct.length + '개 groupId)</span>';
           const pending = (d.pendingSubjects || [])
-            .map((p) => 'subject' + p.subjectIndex + ' <code>' + esc(p.url) + '</code>')
+            .map((p) => 'subject' + esc(p.subjectIndex) + ' <code>' + esc(p.url) + '</code>')
             .join('<br/>') || '<span class="muted">없음</span>';
           const groups = (d.registeredGroups || [])
             .map((g) => short(g.groupId) + ' → subjects [' + g.subjects.join(',') + ']')

--- a/src/01-app/app.ts
+++ b/src/01-app/app.ts
@@ -11,6 +11,7 @@ import { SocketService } from '@07-shared/lib/socket';
 import { AuthProviderRegistry } from '@05-features/auth/services/providers/auth-provider.registry';
 import { registerPairingTriggerListener } from '@01-app/startup-listeners';
 import { healthCheck } from '@01-app/health.controller';
+import { diagStatus, diagAction } from '@01-app/diag.controller';
 import { registerStatic } from '@01-app/static';
 
 const app = express();
@@ -25,6 +26,9 @@ registerStatic(app);
 // 운영 정보(redis 상태, 내부 서비스 가용성) 노출 방지를 위해 비-production에서만 등록함.
 if (!config.isProduction) {
   app.get('/health', healthCheck);
+  // 진단 대시보드 API (groupId 일치확인 + 수정 액션) — localhost 전용, dev 전용
+  app.get('/diag', diagStatus);
+  app.post('/diag/action/:name', diagAction);
 }
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));

--- a/src/01-app/diag.controller.test.ts
+++ b/src/01-app/diag.controller.test.ts
@@ -61,4 +61,11 @@ describe('POST /diag/action/:name', () => {
     expect(res.status).toBe(200);
     expect(res.body.data).toHaveProperty('error');
   });
+
+  it('허용되지 않은 Origin(CSRF)은 403 반환함', async () => {
+    const res = await request(buildApp())
+      .post('/diag/action/release-all')
+      .set('Origin', 'https://evil.example');
+    expect(res.status).toBe(403);
+  });
 });

--- a/src/01-app/diag.controller.test.ts
+++ b/src/01-app/diag.controller.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('@07-shared/lib/redis', () => ({
+  redisService: {
+    connect: jest.fn(),
+    client: { ping: jest.fn(), duplicate: jest.fn() },
+  },
+}));
+
+import { diagStatus, diagAction } from './diag.controller';
+
+// 모든 외부 fetch(DE_A/DE_B)는 실패로 모킹함 (서비스 미기동 가정)
+const failFetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+const originalFetch = global.fetch;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.get('/diag', diagStatus);
+  app.post('/diag/action/:name', diagAction);
+  return app;
+}
+
+beforeEach(() => {
+  failFetch.mockReset().mockRejectedValue(new Error('ECONNREFUSED'));
+  global.fetch = failFetch as unknown as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('GET /diag', () => {
+  it('DE 미도달 시에도 200 + match 구조 반환함', async () => {
+    const res = await request(buildApp()).get('/diag');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.data.dataEngineA.reachable).toBe(false);
+    expect(res.body.data.match).toHaveProperty('matched');
+  });
+});
+
+describe('POST /diag/action/:name', () => {
+  it('알 수 없는 액션은 404 반환함', async () => {
+    const res = await request(buildApp()).post('/diag/action/bogus');
+    expect(res.status).toBe(404);
+  });
+
+  it('registry-status는 groupId로 기본 status 반환함', async () => {
+    const res = await request(buildApp()).post(
+      '/diag/action/registry-status?groupId=abc'
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.data.groupId).toBe('abc');
+    expect(res.body.data.status).toHaveProperty('registered', 0);
+  });
+
+  it('registry-status는 groupId 누락 시 error 필드 반환함', async () => {
+    const res = await request(buildApp()).post('/diag/action/registry-status');
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('error');
+  });
+});

--- a/src/01-app/diag.controller.ts
+++ b/src/01-app/diag.controller.ts
@@ -22,6 +22,20 @@ function isLoopback(req: Request): boolean {
   );
 }
 
+// CSRF 방어 — 전역 cors() 하에서 악성 사이트가 브라우저로 localhost 액션을 호출하는 것 차단함.
+// Origin 헤더가 있으면 대시보드 동일 출처만 허용, 없으면(same-origin GET/curl) loopback 게이트로 충분함.
+const ALLOWED_ORIGINS = ['http://localhost:5000', 'http://127.0.0.1:5000'];
+function isSameOrigin(req: Request): boolean {
+  const origin = req.get('origin');
+  if (!origin) return true;
+  return ALLOWED_ORIGINS.includes(origin);
+}
+
+// 진단 API 접근 가드 — loopback + 동일 출처 둘 다 통과해야 함
+function denyUnsafe(req: Request): boolean {
+  return !isLoopback(req) || !isSameOrigin(req);
+}
+
 interface DeHealth {
   reachable: boolean;
   registeredGroupId: string | null;
@@ -91,8 +105,10 @@ async function releaseDe(url: string): Promise<unknown> {
  * 집계 진단 스냅샷 반환함 — groupId 일치확인 + pending + 그룹 목록 (대시보드 진단 패널용).
  */
 export const diagStatus: RequestHandler = async (req, res) => {
-  if (!isLoopback(req)) {
-    return res.status(403).json({ status: 'fail', message: 'loopback only' });
+  if (denyUnsafe(req)) {
+    return res
+      .status(403)
+      .json({ status: 'fail', message: 'loopback + same-origin only' });
   }
 
   const [deA, deB] = await Promise.all([
@@ -227,8 +243,10 @@ async function actionRestartDeA(): Promise<unknown> {
  * 진단/수정 액션 실행함 — 고정 화이트리스트, localhost 전용.
  */
 export const diagAction: RequestHandler = async (req, res) => {
-  if (!isLoopback(req)) {
-    return res.status(403).json({ status: 'fail', message: 'loopback only' });
+  if (denyUnsafe(req)) {
+    return res
+      .status(403)
+      .json({ status: 'fail', message: 'loopback + same-origin only' });
   }
   const name = req.params.name;
   const tail = Math.min(Number(req.query.tail) || 200, 1000);

--- a/src/01-app/diag.controller.ts
+++ b/src/01-app/diag.controller.ts
@@ -1,0 +1,276 @@
+import { exec } from 'child_process';
+import path from 'path';
+import { promisify } from 'util';
+import { RequestHandler, Request } from 'express';
+import { config } from '@07-shared/config/config';
+import { redisService } from '@07-shared/lib/redis';
+import { engineRegistryService } from '@02-processes/engine/services/engine-registry.service';
+import { dualTriggerService } from '@02-processes/engine/services/dual-2pc-trigger.service';
+import { getActiveDualGroup } from '@02-processes/measurements/services/measurement.service';
+
+const execAsync = promisify(exec);
+
+const DE_A_URL = config.dataEngine.baseUrl;
+const DE_B_URL = process.env.NOTEBOOK_B_URL ?? '';
+const SECRET = config.dataEngine.secretKey;
+
+// 진단/수정 API는 localhost(loopback)에서만 허용함 — 원격 노출 차단 (dev 전용 도구)
+function isLoopback(req: Request): boolean {
+  const ip = req.ip || req.socket.remoteAddress || '';
+  return (
+    ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1' || ip === ''
+  );
+}
+
+interface DeHealth {
+  reachable: boolean;
+  registeredGroupId: string | null;
+  streaming: boolean | null;
+  subjectIndex: number | null;
+}
+
+// DE /health 조회해 registered_group_id + streaming 노출 형태로 정규화함
+async function fetchDeHealth(url: string): Promise<DeHealth> {
+  try {
+    const res = await fetch(`${url}/health`, {
+      signal: AbortSignal.timeout(2500),
+    });
+    if (!res.ok) {
+      return {
+        reachable: false,
+        registeredGroupId: null,
+        streaming: null,
+        subjectIndex: null,
+      };
+    }
+    const body = (await res.json()) as Record<string, unknown>;
+    return {
+      reachable: true,
+      registeredGroupId: (body.registered_group_id as string) ?? null,
+      streaming: (body.streaming as boolean) ?? null,
+      subjectIndex: (body.subject_index as number) ?? null,
+    };
+  } catch {
+    return {
+      reachable: false,
+      registeredGroupId: null,
+      streaming: null,
+      subjectIndex: null,
+    };
+  }
+}
+
+// DE /logs 조회함 (secret 헤더 첨부)
+async function fetchDeLogs(url: string, tail: number): Promise<unknown> {
+  const res = await fetch(`${url}/logs?tail=${tail}`, {
+    headers: { 'X-Engine-Secret': SECRET },
+    signal: AbortSignal.timeout(3000),
+  });
+  return res.json();
+}
+
+// DE /control/release 호출함 (비상 해제)
+async function releaseDe(url: string): Promise<unknown> {
+  try {
+    const res = await fetch(`${url}/control/release`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Engine-Secret': SECRET,
+      },
+      body: JSON.stringify({}),
+      signal: AbortSignal.timeout(4000),
+    });
+    return { url, ok: res.ok, body: await res.json() };
+  } catch (e) {
+    return { url, ok: false, error: (e as Error).message };
+  }
+}
+
+/**
+ * 집계 진단 스냅샷 반환함 — groupId 일치확인 + pending + 그룹 목록 (대시보드 진단 패널용).
+ */
+export const diagStatus: RequestHandler = async (req, res) => {
+  if (!isLoopback(req)) {
+    return res.status(403).json({ status: 'fail', message: 'loopback only' });
+  }
+
+  const [deA, deB] = await Promise.all([
+    fetchDeHealth(DE_A_URL),
+    DE_B_URL ? fetchDeHealth(DE_B_URL) : Promise.resolve(null),
+  ]);
+
+  const beActive = getActiveDualGroup();
+  const pendingSubjects = engineRegistryService.getPendingSubjects();
+  const registeredGroups = engineRegistryService.getRegisteredGroups();
+
+  // groupId 일치 판정 — DE_A / DE_B / BE active 세 값이 모두 같고 non-null 이면 matched
+  const gids = [deA.registeredGroupId, deB?.registeredGroupId, beActive].filter(
+    (g): g is string => Boolean(g)
+  );
+  const distinct = [...new Set(gids)];
+  const matched = distinct.length <= 1;
+
+  return res.status(200).json({
+    status: 'success',
+    data: {
+      beActiveGroup: beActive,
+      dataEngineA: deA,
+      dataEngineB: deB,
+      pendingSubjects,
+      registeredGroups,
+      match: {
+        matched,
+        distinct,
+        deA: deA.registeredGroupId,
+        deB: deB?.registeredGroupId ?? null,
+        beActive,
+      },
+    },
+  });
+};
+
+// ── 액션 핸들러들 (화이트리스트) ──
+
+async function actionReleaseAll(): Promise<unknown> {
+  const deResults = await Promise.all([
+    releaseDe(DE_A_URL),
+    ...(DE_B_URL ? [releaseDe(DE_B_URL)] : []),
+  ]);
+  const cleared = engineRegistryService.clearAll();
+  return { deResults, cleared };
+}
+
+async function actionRegistryStatus(groupId: string): Promise<unknown> {
+  if (!groupId) {
+    return { error: 'groupId query required' };
+  }
+  const status = dualTriggerService.getRegistryStatus(groupId);
+  const group = engineRegistryService.getByGroup(groupId);
+  return {
+    groupId,
+    status,
+    registeredSubjects: group ? [...group.keys()].sort() : [],
+  };
+}
+
+// redis 에 실제 EEG 메시지가 흐르는지 ~2초 psubscribe 샘플링함
+async function actionRedisSample(): Promise<unknown> {
+  const sub = redisService.client.duplicate();
+  await sub.connect();
+  const messages: Array<{ channel: string; preview: string }> = [];
+  try {
+    await sub.pSubscribe('mind-signal:*', (msg: string, channel: string) => {
+      if (messages.length < 20) {
+        messages.push({ channel, preview: msg.slice(0, 160) });
+      }
+    });
+    await new Promise((r) => setTimeout(r, 2000));
+    await sub.pUnsubscribe('mind-signal:*');
+  } finally {
+    await sub.quit();
+  }
+  return { sampled: messages.length, messages };
+}
+
+// 방화벽 인바운드 허용 규칙 추가함 (Tailscale 대역 한정) — 관리자 권한 없으면 실패 보고
+async function actionFirewallAllow(): Promise<unknown> {
+  const ps =
+    "New-NetFirewallRule -DisplayName 'MindSignal-5050-in' -Direction Inbound " +
+    '-LocalPort 5050 -Protocol TCP -Action Allow -RemoteAddress 100.64.0.0/10 ' +
+    '-ErrorAction Stop; ' +
+    "New-NetFirewallRule -DisplayName 'MindSignal-5002-in' -Direction Inbound " +
+    '-LocalPort 5002 -Protocol TCP -Action Allow -RemoteAddress 100.64.0.0/10 ' +
+    '-ErrorAction Stop; Write-Output OK';
+  try {
+    const { stdout, stderr } = await execAsync(
+      `powershell -NoProfile -Command "${ps}"`,
+      { timeout: 15000 }
+    );
+    return { ok: true, stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch (e) {
+    // 관리자 권한 필요 시 여기서 실패 — 대시보드에 원인 표기함
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+// operator DE_A 종료 후 런처로 재기동함 (idle-rebind로 대부분 불필요하나 수동 복구용)
+async function actionRestartDeA(): Promise<unknown> {
+  const launcher = path.join(
+    process.cwd(),
+    '..',
+    'mind-signal-data-engine',
+    'scripts',
+    'realdevice',
+    'start-realdevice-dual-2pc.ps1'
+  );
+  const kill =
+    'Get-CimInstance Win32_Process -Filter \\"Name=\'python.exe\'\\" | ' +
+    "Where-Object { $_.CommandLine -like '*run_server.py*' } | " +
+    'ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }; ' +
+    'Start-Sleep -Seconds 2';
+  try {
+    await execAsync(`powershell -NoProfile -Command "${kill}"`, {
+      timeout: 15000,
+    });
+    const { stdout } = await execAsync(
+      `powershell -NoProfile -File "${launcher}"`,
+      { timeout: 90000 }
+    );
+    return { ok: true, tail: stdout.split('\n').slice(-8).join('\n') };
+  } catch (e) {
+    return { ok: false, error: (e as Error).message };
+  }
+}
+
+/**
+ * 진단/수정 액션 실행함 — 고정 화이트리스트, localhost 전용.
+ */
+export const diagAction: RequestHandler = async (req, res) => {
+  if (!isLoopback(req)) {
+    return res.status(403).json({ status: 'fail', message: 'loopback only' });
+  }
+  const name = req.params.name;
+  const tail = Math.min(Number(req.query.tail) || 200, 1000);
+  const groupId = (req.query.groupId as string) ?? '';
+
+  try {
+    let result: unknown;
+    switch (name) {
+      case 'release-all':
+        result = await actionReleaseAll();
+        break;
+      case 'registry-status':
+        result = await actionRegistryStatus(groupId);
+        break;
+      case 'redis-sample':
+        result = await actionRedisSample();
+        break;
+      case 'notebook-b-logs':
+        result = DE_B_URL
+          ? await fetchDeLogs(DE_B_URL, tail)
+          : { error: 'NOTEBOOK_B_URL 미설정' };
+        break;
+      case 'de-a-logs':
+        result = await fetchDeLogs(DE_A_URL, tail);
+        break;
+      case 'firewall-allow':
+        result = await actionFirewallAllow();
+        break;
+      case 'restart-de-a':
+        result = await actionRestartDeA();
+        break;
+      default:
+        return res
+          .status(404)
+          .json({ status: 'fail', message: `unknown action: ${name}` });
+    }
+    return res
+      .status(200)
+      .json({ status: 'success', action: name, data: result });
+  } catch (e) {
+    return res
+      .status(500)
+      .json({ status: 'error', action: name, message: (e as Error).message });
+  }
+};

--- a/src/01-app/diag.controller.ts
+++ b/src/01-app/diag.controller.ts
@@ -6,7 +6,10 @@ import { config } from '@07-shared/config/config';
 import { redisService } from '@07-shared/lib/redis';
 import { engineRegistryService } from '@02-processes/engine/services/engine-registry.service';
 import { dualTriggerService } from '@02-processes/engine/services/dual-2pc-trigger.service';
-import { getActiveDualGroup } from '@02-processes/measurements/services/measurement.service';
+import {
+  getActiveDualGroup,
+  resetActiveDualGroup,
+} from '@02-processes/measurements/services/measurement.service';
 
 const execAsync = promisify(exec);
 
@@ -16,10 +19,9 @@ const SECRET = config.dataEngine.secretKey;
 
 // 진단/수정 API는 localhost(loopback)에서만 허용함 — 원격 노출 차단 (dev 전용 도구)
 function isLoopback(req: Request): boolean {
+  // 빈 IP는 fail-open 방지를 위해 허용하지 않음 (명시적 loopback 주소만 통과)
   const ip = req.ip || req.socket.remoteAddress || '';
-  return (
-    ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1' || ip === ''
-  );
+  return ip === '127.0.0.1' || ip === '::1' || ip === '::ffff:127.0.0.1';
 }
 
 // CSRF 방어 — 전역 cors() 하에서 악성 사이트가 브라우저로 localhost 액션을 호출하는 것 차단함.
@@ -120,12 +122,19 @@ export const diagStatus: RequestHandler = async (req, res) => {
   const pendingSubjects = engineRegistryService.getPendingSubjects();
   const registeredGroups = engineRegistryService.getRegisteredGroups();
 
-  // groupId 일치 판정 — DE_A / DE_B / BE active 세 값이 모두 같고 non-null 이면 matched
-  const gids = [deA.registeredGroupId, deB?.registeredGroupId, beActive].filter(
-    (g): g is string => Boolean(g)
-  );
-  const distinct = [...new Set(gids)];
-  const matched = distinct.length <= 1;
+  // groupId 일치 판정 — 해당 참가자(deA, deB(URL 설정 시), BE active)가
+  // 모두 non-null 이고 같은 groupId 일 때만 matched. 누락 참가자는 미일치로 처리(fail-open 방지).
+  const applicable = [
+    deA.registeredGroupId,
+    ...(DE_B_URL ? [deB?.registeredGroupId ?? null] : []),
+    beActive,
+  ];
+  const nonNull = applicable.filter((g): g is string => Boolean(g));
+  const distinct = [...new Set(nonNull)];
+  const allIdle = nonNull.length === 0;
+  const matched =
+    !allIdle && nonNull.length === applicable.length && distinct.length === 1;
+  const state = allIdle ? 'idle' : matched ? 'matched' : 'mismatch';
 
   return res.status(200).json({
     status: 'success',
@@ -137,6 +146,7 @@ export const diagStatus: RequestHandler = async (req, res) => {
       registeredGroups,
       match: {
         matched,
+        state,
         distinct,
         deA: deA.registeredGroupId,
         deB: deB?.registeredGroupId ?? null,
@@ -154,6 +164,8 @@ async function actionReleaseAll(): Promise<unknown> {
     ...(DE_B_URL ? [releaseDe(DE_B_URL)] : []),
   ]);
   const cleared = engineRegistryService.clearAll();
+  // BE 활성 그룹도 초기화 — release-all 후 stale activeDualGroup 방지
+  resetActiveDualGroup();
   return { deResults, cleared };
 }
 

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -160,6 +160,36 @@ export const engineRegistryService = {
     console.log(`DUAL_2PC 엔진 레지스트리 정리 완료: groupId=${groupId}`);
   },
 
+  /**
+   * 현재 dualRegistry에 등록된 모든 groupId + subjectIndex 스냅샷 반환함 (진단 대시보드용).
+   *
+   * @returns groupId별 등록된 subjectIndex 배열
+   */
+  getRegisteredGroups(): Array<{ groupId: string; subjects: number[] }> {
+    const result: Array<{ groupId: string; subjects: number[] }> = [];
+    for (const [gid, group] of dualRegistry.entries()) {
+      result.push({ groupId: gid, subjects: [...group.keys()].sort() });
+    }
+    return result;
+  },
+
+  /**
+   * 모든 DUAL_2PC 등록/pending/콜백 전부 제거함 — 비상 전체해제(대시보드)에서 호출됨.
+   *
+   * @returns 제거된 groupId 개수 + pending 개수
+   */
+  clearAll(): { clearedGroups: number; clearedPending: number } {
+    const clearedGroups = dualRegistry.size;
+    const clearedPending = pendingRegistry.size;
+    dualRegistry.clear();
+    registeredCallbacks.clear();
+    pendingRegistry.clear();
+    console.log(
+      `DUAL_2PC 레지스트리 전체 클리어 완료: groups=${clearedGroups}, pending=${clearedPending}`
+    );
+    return { clearedGroups, clearedPending };
+  },
+
   // ===== Phase 17.6 — pending registry 메서드 (LD-10, LD-16, LD-26) =====
 
   /**

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -41,6 +41,9 @@ const dualMeasurementInFlight = new Set<string>();
 /** 가장 최근 시작된 DUAL_2PC 그룹 — startup in-flight supersede 판정용 (F1b) */
 let activeDualGroup: string | null = null;
 
+/** 현재 활성 DUAL_2PC 그룹 반환함 — 진단 대시보드 groupId 일치확인용 */
+export const getActiveDualGroup = (): string | null => activeDualGroup;
+
 // ---------------------------------------------------------------------------
 // 내부 헬퍼 — DUAL_2PC 전용
 // ---------------------------------------------------------------------------

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -44,6 +44,11 @@ let activeDualGroup: string | null = null;
 /** 현재 활성 DUAL_2PC 그룹 반환함 — 진단 대시보드 groupId 일치확인용 */
 export const getActiveDualGroup = (): string | null => activeDualGroup;
 
+/** 활성 DUAL_2PC 그룹 초기화함 — 비상 전체해제(release-all)에서 stale 방지용 */
+export const resetActiveDualGroup = (): void => {
+  activeDualGroup = null;
+};
+
 // ---------------------------------------------------------------------------
 // 내부 헬퍼 — DUAL_2PC 전용
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경
- **GET /diag**: DE_A/DE_B/BE의 registered groupId 일치판정 + pendingSubjects + 바인딩된 그룹 목록 집계 (오늘 라이브에서 안 보였던 정보 노출).
- **POST /diag/action/:name**: 화이트리스트 액션 — `release-all`(비상 전체 그룹 해제), `registry-status`, `redis-sample`, `notebook-b-logs`/`de-a-logs`(원격 로그), `firewall-allow`, `restart-de-a`. localhost 전용 게이트, dev 전용.
- **engineRegistryService**: `clearAll`·`getRegisteredGroups` 추가. **measurement**: `getActiveDualGroup` getter.
- **dashboard.html**: 기존 5행 상태 + groupId 일치 배지 + pending + 액션 버튼 + 결과창.

## 검증
- 전체 384 tests passed, typecheck·depcruise·lint·build clean.
- diag 컨트롤러 테스트 4건(집계 200·unknown 404·registry-status) 통과.

DE PR과 짝(대시보드가 BE→DE 프록시). 상대 PR: mind-signal-data-engine#30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 대시보드에 상태 배지와 “진단·수정 액션” 패널을 추가해 그룹 일치 여부 및 등록/대기 정보를 바로 확인할 수 있습니다.
  * 로컬 전용 진단 API(`/diag`, `diag-action`)와 관리 액션(릴리즈 전체, 레지스트리 조회, 로그/샘플링, 재시작, 방화벽 허용 등)을 연동했습니다.
* **Bug Fixes**
  * 헬스 폴링 실패 시 화면 상태를 안전하게 초기화하고, 진단 결과/에러 문구를 이스케이프 처리했습니다.
* **Tests**
  * `/diag` 및 액션 엔드포인트 동작, 응답 필드, 액세스 제어를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->