### PR TITLE
feat(measurement): 측정 시작 직전 자동 registry 보정(D) + registry 이벤트 진단

### DIFF
--- a/src/01-app/diag.controller.ts
+++ b/src/01-app/diag.controller.ts
@@ -144,6 +144,7 @@ export const diagStatus: RequestHandler = async (req, res) => {
       dataEngineB: deB,
       pendingSubjects,
       registeredGroups,
+      registryEvents: engineRegistryService.getRegistryEvents(),
       match: {
         matched,
         state,

--- a/src/02-processes/engine/services/engine-registry.service.ts
+++ b/src/02-processes/engine/services/engine-registry.service.ts
@@ -12,6 +12,13 @@ const dualRegistry = new Map<string, Map<number, EngineRegistration>>();
 /** groupId → 등록 콜백 Set */
 const registeredCallbacks = new Map<string, Set<() => void>>();
 
+// dualRegistry 등록/evict 추적 이벤트 링버퍼 — 진단 대시보드용 (subject 누락 원인 추적)
+const registryEvents: string[] = [];
+function pushEvent(msg: string): void {
+  registryEvents.push(msg);
+  if (registryEvents.length > 60) registryEvents.shift();
+}
+
 /** 단일 DE 등록 정보 */
 interface EngineRegistration {
   url: string;
@@ -76,6 +83,9 @@ export const engineRegistryService = {
     };
 
     dualRegistry.get(groupId)!.set(subjectIndex, registration);
+    pushEvent(
+      `registerDual gid=${groupId.slice(-6)} sub=${subjectIndex} url=${engineUrl}`
+    );
     console.log(
       `DUAL_2PC 엔진 등록 완료: groupId=${groupId}, subjectIndex=${subjectIndex}, url=${engineUrl}`
     );
@@ -173,6 +183,11 @@ export const engineRegistryService = {
     return result;
   },
 
+  /** dualRegistry 등록/evict 추적 이벤트 반환함 — subject 누락 원인 진단용 */
+  getRegistryEvents(): string[] {
+    return [...registryEvents];
+  },
+
   /**
    * 모든 DUAL_2PC 등록/pending/콜백 전부 제거함 — 비상 전체해제(대시보드)에서 호출됨.
    *
@@ -213,6 +228,10 @@ export const engineRegistryService = {
     for (const [gid, group] of dualRegistry.entries()) {
       const existing = group.get(subjectIndex);
       if (existing && existing.url !== url) {
+        pushEvent(
+          `F4-EVICT gid=${gid.slice(-6)} sub=${subjectIndex} ` +
+            `stored=${existing.url} incoming=${url}`
+        );
         group.delete(subjectIndex);
         if (group.size === 0) {
           // cleanupGroup과 동일하게 콜백도 정리 — 재사용 groupId의 죽은 콜백 호출 방지함

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -3,6 +3,7 @@ import { redisService } from '@07-shared/lib/redis';
 import { SocketService } from '@07-shared/lib/socket';
 import { AppError } from '@07-shared/errors';
 import { engineRegistryService } from '@02-processes/engine/services/engine-registry.service';
+import { dualTriggerService } from '@02-processes/engine/services/dual-2pc-trigger.service';
 import { timestampAlignerRegistry } from './timestamp-aligner.service';
 import { stimulusBroadcasterService } from './stimulus-broadcaster.service';
 import type { WavePower } from './timestamp-aligner.service';
@@ -221,6 +222,25 @@ function startDualMeasurement(groupId: string): void {
     try {
       // 새 측정 시작 전 stale 그룹 aligner/구독 정리 — 단일 활성 보장 (F1)
       await teardownStaleGroups(groupId);
+
+      // 측정 시작 직전 registry gap 자동복구 (D, codex gpt-5.5 권장) — 자동 페어링
+      // 트리거가 subject 2(원격 Tailscale DE)를 놓친 경우를 여기서 1회 보정함. 폴링 없이
+      // 실패 지점(waitForBothEngines) 바로 앞에서 collectPendingSubjects + triggerAssignGroup
+      // 재사용(수동 dual-trigger와 동일 경로, DE already_registered 멱등). 실패해도 아래
+      // waitForBothEngines timeout이 최종 가드. pending 2개 아니면 skip(DE 준비 미완).
+      try {
+        const subjects =
+          await dualTriggerService.collectPendingSubjects(groupId);
+        if (subjects.length === 2) {
+          await dualTriggerService.triggerAssignGroup(groupId, subjects);
+        }
+      } catch (e) {
+        console.warn(
+          `[측정시작-보정] dual-trigger 보정 실패(무시, wait로 폴백): ${
+            e instanceof Error ? e.message : e
+          }`
+        );
+      }
 
       // 두 DE 등록 대기 (최대 60초) — 클라이언트에게는 이미 응답 반환됨
       await waitForBothEngines(groupId, config.dualPc.registrationTimeoutMs);

--- a/src/02-processes/measurements/services/measurement.service.ts
+++ b/src/02-processes/measurements/services/measurement.service.ts
@@ -228,18 +228,23 @@ function startDualMeasurement(groupId: string): void {
       // 실패 지점(waitForBothEngines) 바로 앞에서 collectPendingSubjects + triggerAssignGroup
       // 재사용(수동 dual-trigger와 동일 경로, DE already_registered 멱등). 실패해도 아래
       // waitForBothEngines timeout이 최종 가드. pending 2개 아니면 skip(DE 준비 미완).
-      try {
-        const subjects =
-          await dualTriggerService.collectPendingSubjects(groupId);
-        if (subjects.length === 2) {
-          await dualTriggerService.triggerAssignGroup(groupId, subjects);
+      // superseded 가드: collectPendingSubjects는 groupId로 필터 안 하고 caller groupId를
+      // attach하므로, 대기 중 다른 그룹에 선점되면 잘못된 그룹에 assign-group 오발행 위험.
+      // await 전후로 activeDualGroup === groupId 재확인함 (CodeRabbit).
+      if (activeDualGroup === groupId) {
+        try {
+          const subjects =
+            await dualTriggerService.collectPendingSubjects(groupId);
+          if (subjects.length === 2 && activeDualGroup === groupId) {
+            await dualTriggerService.triggerAssignGroup(groupId, subjects);
+          }
+        } catch (e) {
+          console.warn(
+            `[측정시작-보정] dual-trigger 보정 실패(무시, wait로 폴백): ${
+              e instanceof Error ? e.message : e
+            }`
+          );
         }
-      } catch (e) {
-        console.warn(
-          `[측정시작-보정] dual-trigger 보정 실패(무시, wait로 폴백): ${
-            e instanceof Error ? e.message : e
-          }`
-        );
       }
 
       // 두 DE 등록 대기 (최대 60초) — 클라이언트에게는 이미 응답 반환됨


### PR DESCRIPTION
## 배경
자동 페어링/합류 트리거(maybeTriggerDualAssignGroup)가 원격 subject 2(노트북B Tailscale)를 타이밍상 놓쳐 dualRegistry가 subject 1만 등록되는 갭. 측정 시작 시 isFullyRegistered(2) 미충족으로 "DE 등록 timeout". 그동안 수동 `POST /dual-trigger`로 때웠음.

## 변경 (codex gpt-5.5 평가 D 채택: 기대효과9/위험8/ponytail9)
- `startDualMeasurement`의 `waitForBothEngines` 직전에 **1회** `collectPendingSubjects + triggerAssignGroup`로 registry gap self-heal. 기존 수동 dual-trigger와 동일 경로 재사용, 폴링 없음, DE already_registered 멱등이라 안전, 실패해도 60초 wait timeout 최종가드. 이제 페어링 → 실험 시작만으로 자동 [1,2].
- `/diag`에 `registryEvents`(registerDual / F4-evict 추적) 노출 — subject 누락 원인 진단용.

## 검증
전체 385 tests 통과, typecheck·depcruise·lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 대시보드 진단 패널에서 레지스트리 이벤트 정보도 함께 확인할 수 있게 되었습니다.
* **버그 수정**
  * 측정 시작 시 누락될 수 있던 대기 대상이 있으면 보정 로직을 통해 1회 추가 페어링/할당을 시도하도록 개선했습니다.
  * 엔진 등록/해제(이벤트) 변경 이력을 더 안정적으로 추적해 진단 확인이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->